### PR TITLE
feat(config): migrate to file-based layered configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -90,6 +90,12 @@ public/resume/**
 .env.development.local
 .env.test.local
 .env.production.local
+# A local `config.toml` (the loader's default path) or secrets directory would be
+# read by the build-time `update-repos` run and baked into a cached layer. The
+# build supplies its token as a mounted BuildKit secret instead.
+config.toml
+config.d
+secrets
 *.pem
 *.key
 *.crt

--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,16 @@ yarn-error.log*
 .serena/
 
 # ---------------------------------------------------------------------------
-# IDE / editor
+# Local layered configuration
 # ---------------------------------------------------------------------------
+# `./config.toml` is the loader's default path, so a developer copying
+# config.example.toml lands here — and may put a GitHub token in it. The example
+# itself is tracked; a real one never is.
+/config.toml
+/config.d/
+/secrets/
+
+
 .vscode/
 .idea/
 *.iml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,6 +1748,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2735,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3377,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "peniko"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,6 +3545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
+name = "portfolio-config"
+version = "2.2.3"
+dependencies = [
+ "figment",
+ "secrecy",
+ "serde",
+ "terrace-config",
+]
+
+[[package]]
 name = "portfolio-data"
 version = "2.2.3"
 dependencies = [
@@ -3573,6 +3637,7 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -4152,6 +4217,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4641,6 +4716,29 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terrace-config"
+version = "0.2.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.2.0#46d924c25af6a0e67f657686f996539482e8abe3"
+dependencies = [
+ "figment",
+ "serde",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5491,6 +5589,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5631,7 +5738,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "update-repos"
 version = "2.2.3"
 dependencies = [
+ "portfolio-config",
  "portfolio-data",
+ "secrecy",
  "serde",
  "serde_json",
  "time",
@@ -5979,6 +6088,7 @@ dependencies = [
  "http",
  "i18nrs",
  "js-sys",
+ "portfolio-config",
  "portfolio-data",
  "schemars",
  "serde",
@@ -6329,6 +6439,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/config",
     "crates/data",
     "apps/web",
     "apps/resume-generator",
@@ -19,7 +20,31 @@ publish = false
 edition = "2024"
 
 [workspace.dependencies]
+portfolio-config = { path = "crates/config" }
 portfolio-data = { path = "crates/data" }
+
+# The layered configuration loader: struct defaults, then TOML, then
+# `PORTFOLIO_`-prefixed environment variables, then a secrets directory, then
+# `_FILE` indirection — with a key supplied by two of the last three refused
+# rather than silently resolved by precedence. Pinned by tag, not branch, so an
+# update to the loader is a deliberate commit here rather than whatever `main`
+# happened to be at build time.
+#
+# `loader` only, and `default-features = false` to say so: the crate's other
+# half is a supervisor that rebuilds a running service when its files change,
+# which would link tokio, notify and tracing into every consumer. Nothing here
+# needs it — see `crates/config/src/lib.rs` for why.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.2.0", default-features = false, features = [
+    "loader",
+] }
+# Keeps the GitHub token out of `Debug` output and off every accidental log
+# line: a `SecretString` has no `Display`, and reading it is the explicit
+# `expose_secret()` call at the one place it is put on the wire.
+secrecy = { version = "0.10", features = ["serde"] }
+# `figment::Jail` sets and restores process-wide environment state, which is how
+# the config tests avoid `env::set_var` in a threaded test binary. Same figment
+# `terrace-config` resolves, plus its `test` feature.
+figment = { version = "0.10", features = ["test"] }
 
 # Dioxus 0.7 fullstack. `fullstack` enables server functions + hydration
 # serialization on both targets; `router` re-exports dioxus-router. The

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,18 @@ COPY . .
 # repos.json from the GitHub API (build.rs embeds it into the web binary). CI=1
 # selects the long cache TTL so a fresh committed/cached file is reused; an
 # optional `gh_token` build secret lifts the API rate limit.
-RUN --mount=type=secret,id=gh_token,env=GH_TOKEN \
+#
+# The secret is handed over as a *path*, not as an environment variable: the
+# builder resolves `PORTFOLIO_GITHUB__TOKEN_FILE` through the layered config, so
+# the token is never in the process environment where a crash dump, `ps e` or a
+# child process would carry it. BuildKit omits the mount entirely when the
+# secret was not supplied (a fork's pull request has none), so the path is only
+# exported when it actually exists — pointing the indirection at a missing file
+# is an error, and correctly so.
+RUN --mount=type=secret,id=gh_token \
+    if [ -s /run/secrets/gh_token ]; then \
+      export PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token; \
+    fi; \
     CI=1 cargo run --release --locked -p update-repos -- apps/web/repos.json
 # Resume PDFs + resume-fingerprint.json, both embedded into the web binary by
 # build.rs (the PDFs are served at /resume/ from memory; the fingerprint is shown
@@ -167,28 +178,36 @@ COPY --from=web-builder /app/target/dx/web/release/web /app
 COPY --from=web-builder --chown=${USER_ID}:${GROUP_ID} /isr-cache /tmp/isr
 WORKDIR /app
 
-# Incremental static regeneration (ISR) is ON by default: ISR_CACHE_DIR points at
-# /tmp/isr, which the deployment (Helm chart) already mounts as a writable volume
-# (so it works under `readOnlyRootFilesystem: true` with no extra setup); a plain
-# `docker run` falls back to the baked-in copy above. The server is locale-aware
-# — it tags each render with the negotiated language, so the cache keeps a
-# separate entry per locale — and the site has only a handful of pages built
-# entirely from compile-time data, so caching every rendered page is safe and
-# cheap. If /tmp/isr is ever not writable, the server fails safe and renders
-# every request fresh.
+# The server reads its own settings through the layered `PORTFOLIO_` config
+# (struct defaults < TOML at $PORTFOLIO_CONFIG < PORTFOLIO_* environment <
+# $PORTFOLIO_SECRETS_DIR < PORTFOLIO_<KEY>_FILE), so every key below can equally
+# be supplied as a mounted ConfigMap fragment or Secret file. See README.md and
+# config.example.toml. PORT, IP and RUST_LOG are *not* in that namespace: they
+# belong to the Dioxus toolchain, which reads them itself.
+#
+# Incremental static regeneration (ISR) is ON by default: the cache directory
+# points at /tmp/isr, which the deployment (Helm chart) already mounts as a
+# writable volume (so it works under `readOnlyRootFilesystem: true` with no extra
+# setup); a plain `docker run` falls back to the baked-in copy above. The server
+# is locale-aware — it tags each render with the negotiated language, so the
+# cache keeps a separate entry per locale — and the site has only a handful of
+# pages built entirely from compile-time data, so caching every rendered page is
+# safe and cheap. If /tmp/isr is ever not writable, the server fails safe and
+# renders every request fresh.
 #
 # The cache is permanent by default (no time-based TTL): the only thing that
-# changes a page is a new build, which starts from an empty cache. Set
-# ISR_TTL_SECS to a positive number of seconds only when you share a *persistent*
-# cache volume across deploys and want time-based revalidation; set ISR_CACHE_DIR
-# empty to turn ISR off entirely. Keep the path outside /app/public so the
-# immutable, content-hashed assets stay read-only.
-#   ISR_CACHE_DIR=/tmp/isr   # empty disables ISR
-#   ISR_TTL_SECS=0           # 0/unset = permanent; positive = finite TTL
+# changes a page is a new build, which starts from an empty cache. Set the TTL to
+# a positive number of seconds only when you share a *persistent* cache volume
+# across deploys and want time-based revalidation; set the cache directory empty
+# to turn ISR off entirely. Keep the path outside /app/public so the immutable,
+# content-hashed assets stay read-only.
+#   PORTFOLIO_ISR__CACHE_DIR=/tmp/isr  # empty disables ISR
+#   PORTFOLIO_ISR__TTL_SECS=0          # 0/unset = permanent; positive = finite TTL
+#   PORTFOLIO_ASSETS__DIST_DIR=public  # what the readiness probe checks
 ENV PORT=8080 \
     IP=0.0.0.0 \
     RUST_LOG=info \
-    ISR_CACHE_DIR=/tmp/isr
+    PORTFOLIO_ISR__CACHE_DIR=/tmp/isr
 
 EXPOSE 8080
 USER ${USER_ID}:${GROUP_ID}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ a distroless container.
   - [Development](#development)
   - [Production Build](#production-build)
   - [Container](#container)
+- [Configuration](#configuration)
 - [Deployment](#deployment)
   - [Probe Endpoints](#probe-endpoints)
   - [Read-only and Security Posture](#read-only-and-security-posture)
@@ -32,6 +33,7 @@ applications.
 
 | Crate | Purpose |
 | --- | --- |
+| `crates/config` | The typed configuration blocks every binary reads, plus the Portfolio dialect of the [terrace-config](https://github.com/TimSchoenle/terrace-config) layered loader (see [Configuration](#configuration)) |
 | `crates/data` | Shared, language-neutral data (config, skills, experience, repos schema) plus embedded `i18n/{en,de}.json` translations |
 | `apps/web` | Dioxus 0.7 fullstack app: a single crate that compiles to both the WASM client (`web` feature) and the native Axum SSR server (`server` feature), with the JSON API, SEO documents, security headers, and probe endpoints |
 | `apps/resume-generator` | Generates `resume/{en,de}.pdf` and `resume-fingerprint.json` (Typst, embedded subset of Liberation Sans) |
@@ -116,6 +118,67 @@ The container performs all of the above and serves the result on port 8080:
 docker build -t portfolio .
 ```
 
+## Configuration
+
+Configuration is **layered and file-first**, via
+[terrace-config](https://github.com/TimSchoenle/terrace-config). `crates/config`
+owns the typed blocks and the `PORTFOLIO_` dialect; each binary declares the
+aggregate it actually reads. Sources are merged in this order, lowest precedence
+first:
+
+1. **Struct defaults** — the `serde` defaults in `crates/config`.
+2. **TOML** at `$PORTFOLIO_CONFIG` — a file, or every `*.toml` inside it when it
+   names a directory (so a `ConfigMap` can be split into fragments).
+3. **Environment** — `PORTFOLIO_`-prefixed variables, `__` for nesting.
+4. **Secrets directory** at `$PORTFOLIO_SECRETS_DIR` — one file per key, named
+   after it (`github__token`); this is what a Kubernetes `Secret` volume mounts.
+5. **File indirection** — `PORTFOLIO_<KEY>_FILE=/path` names a file holding the
+   value.
+
+The last three are **mutually exclusive per key**: a key supplied by two of them
+fails the boot instead of one silently winning, because a stale environment
+variable shadowing a rotated mounted secret keeps the process running on the old
+credential.
+
+Every key, its TOML path and its environment spelling:
+
+| TOML | Environment | Default | Purpose |
+| --- | --- | --- | --- |
+| `assets.dist_dir` | `PORTFOLIO_ASSETS__DIST_DIR` | `public` | Bundle directory the readiness probe checks |
+| `isr.cache_dir` | `PORTFOLIO_ISR__CACHE_DIR` | unset (ISR off; the image sets `/tmp/isr`) | Writable directory rendered pages are cached into |
+| `isr.ttl_secs` | `PORTFOLIO_ISR__TTL_SECS` | `0` (permanent) | Revalidation interval in seconds |
+| `github.username` | `PORTFOLIO_GITHUB__USERNAME` | `CONFIG.github_username` | User whose repositories `update-repos` lists |
+| `github.repos` | `PORTFOLIO_GITHUB__REPOS` | all active repos | Explicit repository set, e.g. `[Portfolio,actions]` |
+| `github.token` | `PORTFOLIO_GITHUB__TOKEN` | unset | Bearer token lifting the GitHub API rate limit |
+
+An empty value counts as unset everywhere, because container platforms routinely
+inject `KEY=` for a declared-but-unset variable. See
+[`config.example.toml`](./config.example.toml) for a commented starting point.
+
+`IP`, `PORT` and `RUST_LOG` are deliberately **outside** this namespace: they are
+the Dioxus toolchain's contract with the binary (`dx serve` sets them to tell a
+development build which port it is proxied on), so the framework keeps reading
+them itself. `CI` likewise belongs to the CI provider.
+
+### Secrets
+
+`github.token` is the only secret in the workspace, and it should arrive as a
+**file**, never as an environment variable — `/proc/<pid>/environ`, a crash dump
+and `docker inspect` all carry the environment, and child processes inherit it:
+
+```bash
+PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token cargo run --release -p update-repos
+```
+
+The Docker build already does this: the `gh_token` BuildKit secret is mounted as
+a file and handed to `update-repos` by path. In the process it is a
+`secrecy::SecretString`, so it has no `Debug` or `Display` and the one place it
+becomes a `&str` is the `Authorization` header.
+
+Only the loader half of `terrace-config` is used; its hot-reload supervisor is
+not. The reasoning — the server holds no secrets, and `dioxus::serve` owns an
+accept loop with no shutdown handle — is recorded in `crates/config/src/lib.rs`.
+
 ## Deployment
 
 The image is built on a `distroless/cc` base holding the dynamically linked
@@ -130,15 +193,16 @@ hardened pod spec out of the box.
 | --- | --- | --- |
 | `GET /api/health` | — | General health report with the current UTC time |
 | `GET /api/health/live` | `GET /livez` | **Liveness** — process is running; failure restarts the container |
-| `GET /api/health/ready` | `GET /readyz` | **Readiness** — the client bundle (`$DIST_DIR/index.html`, default `public/index.html`) is present and servable; failure removes the pod from the Service endpoints |
+| `GET /api/health/ready` | `GET /readyz` | **Readiness** — the client bundle (`index.html` under `assets.dist_dir`, default `public/`) is present and servable; failure removes the pod from the Service endpoints |
 
 All probe responses are `no-store` (never cached). Readiness returns `503` until
 the assets are present.
 
 ### Read-only and Security Posture
 
-The server only reads from `$DIST_DIR` (its sibling `public/` dir) and writes
-logs to stdout, so it runs unchanged with a fully read-only root filesystem (no
+The server only reads from its bundle directory (the sibling `public/` dir) and
+writes logs to stdout, so it runs unchanged with a fully read-only root
+filesystem (no
 writable volume, not even `/tmp`). It is built to satisfy the restricted Pod
 Security Standard:
 
@@ -149,9 +213,10 @@ Security Standard:
   `Referrer-Policy`, `Permissions-Policy`) set on every response
 - listens on `:$PORT` (default `8080`); graceful shutdown on `SIGTERM`
 
-Configuration is provided via environment variables: `DIST_DIR` (default
-`public`), `IP` (default `0.0.0.0`), `PORT` (default `8080`), and `RUST_LOG`
-(default `info`).
+Everything else the server reads comes from the layered configuration described
+under [Configuration](#configuration), so a `ConfigMap` fragment or a `Secret`
+volume is a first-class source rather than something a chart has to flatten into
+environment variables.
 
 ### Reproducible Builds
 
@@ -195,17 +260,19 @@ blacklisted in `CONFIG.blacklisted_repos`, and any repository with no update in
 the last 365 days. It deserializes the rest directly into the shared
 `portfolio_data::Repo`/`ReposFile` models and writes the pretty-printed JSON,
 surfacing failures through a dedicated `UpdateReposError` model. An explicit
-repository set can be requested at runtime via `GITHUB_REPOS` (comma-separated), in
-which case each named repository is fetched directly (without filtering):
+repository set can be requested via `github.repos`, in which case each named
+repository is fetched directly (without filtering):
 
 ```bash
 # Defaults: user = CONFIG.github_username, repos = all active repos
 #           (archived/blacklisted/>1y-stale excluded),
 #           output = apps/web/repos.json
-GH_TOKEN=<token> cargo run --release -p update-repos -- apps/web/repos.json
+PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token \
+  cargo run --release -p update-repos -- apps/web/repos.json
 
-# Override the repo set for a one-off run
-GITHUB_REPOS=Portfolio,actions cargo run --release -p update-repos
+# Override the repo set for a one-off run (figment's bracketed array syntax,
+# so the environment and the TOML spelling stay the same shape)
+PORTFOLIO_GITHUB__REPOS='[Portfolio,actions]' cargo run --release -p update-repos
 ```
 
 ## Contributing

--- a/apps/update-repos/Cargo.toml
+++ b/apps/update-repos/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 publish.workspace = true
 
 [dependencies]
+portfolio-config.workspace = true
 portfolio-data.workspace = true
+# The GitHub token stays wrapped from the loader to the `Authorization` header,
+# so it cannot reach a log line or a `Debug` dump on the way.
+secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true

--- a/apps/update-repos/src/builder.rs
+++ b/apps/update-repos/src/builder.rs
@@ -4,8 +4,8 @@
 //! By default it lists every repository the user owns (paginated) and keeps
 //! only the active ones: not archived, not blacklisted and updated within the
 //! last [`MAX_AGE_DAYS`] days. An explicit set of repository names may also be
-//! supplied (e.g. via `GITHUB_REPOS`), in which case each is fetched by name
-//! without filtering.
+//! supplied (via `github.repos`), in which case each is fetched by name without
+//! filtering.
 //!
 //! [`ReposBuilder::fetch`] performs the network calls; [`ReposBuilder::assemble`]
 //! is a pure step (timestamp + user + repos) so it can be unit-tested without
@@ -14,6 +14,7 @@
 use std::time::Duration;
 
 use portfolio_data::{Repo, ReposFile};
+use secrecy::{ExposeSecret as _, SecretString};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
@@ -33,7 +34,7 @@ const MAX_AGE_DAYS: i64 = 365;
 /// [`ReposFile`] ready to be serialized to `repos.json`.
 pub struct ReposBuilder {
     user: String,
-    token: Option<String>,
+    token: Option<SecretString>,
     repos: Vec<String>,
     blacklist: Vec<String>,
     api_base: String,
@@ -58,10 +59,14 @@ impl ReposBuilder {
     }
 
     /// Sets the bearer token used to authenticate API requests (lifts the rate
-    /// limit and is required for the workflow's `GITHUB_TOKEN`). A `None` or
-    /// empty token leaves requests unauthenticated.
-    pub fn token(mut self, token: Option<String>) -> Self {
-        self.token = token.filter(|t| !t.is_empty());
+    /// limit). A `None` or empty token leaves requests unauthenticated, which
+    /// is the normal case on a fork's pull request.
+    ///
+    /// Kept wrapped rather than taken as a `String`: the token arrives from a
+    /// mounted file and is never printed, so the only place it becomes a `&str`
+    /// is [`Self::get`], where it goes onto the wire.
+    pub fn token(mut self, token: Option<SecretString>) -> Self {
+        self.token = token.filter(|token| !token.expose_secret().is_empty());
         self
     }
 
@@ -193,7 +198,7 @@ impl ReposBuilder {
             .header("X-GitHub-Api-Version", "2022-11-28")
             .header("User-Agent", USER_AGENT);
         if let Some(token) = &self.token {
-            request = request.header("Authorization", format!("Bearer {token}"));
+            request = request.header("Authorization", format!("Bearer {}", token.expose_secret()));
         }
         request
     }

--- a/apps/update-repos/src/error.rs
+++ b/apps/update-repos/src/error.rs
@@ -11,6 +11,9 @@ use std::fmt;
 /// Everything that can go wrong while building `repos.json`.
 #[derive(Debug)]
 pub enum UpdateReposError {
+    /// The layered configuration could not be loaded: a value failed to parse,
+    /// a mounted file could not be read, or one key was supplied twice.
+    Config(portfolio_config::ConfigError),
     /// The GitHub username to query was empty.
     MissingUser,
     /// No repositories were found to write (the user has no non-archived
@@ -30,11 +33,12 @@ pub enum UpdateReposError {
 impl fmt::Display for UpdateReposError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            UpdateReposError::MissingUser => {
-                f.write_str("no GitHub username configured (set GITHUB_USERNAME)")
-            }
+            UpdateReposError::Config(e) => write!(f, "configuration is not usable: {e}"),
+            UpdateReposError::MissingUser => f.write_str(
+                "no GitHub username configured (set PORTFOLIO_GITHUB__USERNAME, or `github.username`)",
+            ),
             UpdateReposError::NoRepos => f.write_str(
-                "no repositories found to write (none non-archived, or GITHUB_REPOS was empty)",
+                "no repositories found to write (none active, or `github.repos` named none)",
             ),
             UpdateReposError::Http(e) => write!(f, "GitHub API request failed: {e}"),
             UpdateReposError::Io(e) => write!(f, "file I/O failed: {e}"),
@@ -47,6 +51,7 @@ impl fmt::Display for UpdateReposError {
 impl Error for UpdateReposError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            UpdateReposError::Config(e) => Some(e),
             UpdateReposError::MissingUser => None,
             UpdateReposError::NoRepos => None,
             UpdateReposError::Http(e) => Some(e),
@@ -54,6 +59,12 @@ impl Error for UpdateReposError {
             UpdateReposError::Serialize(e) => Some(e),
             UpdateReposError::Timestamp(e) => Some(e),
         }
+    }
+}
+
+impl From<portfolio_config::ConfigError> for UpdateReposError {
+    fn from(e: portfolio_config::ConfigError) -> Self {
+        UpdateReposError::Config(e)
     }
 }
 
@@ -86,10 +97,14 @@ mod tests {
     use super::*;
     use std::io::{self, ErrorKind};
 
+    /// The message has to name the key an operator would actually set, in the
+    /// dialect the loader speaks — the whole point of the migration is that
+    /// there is one spelling, so an error naming a retired variable would send
+    /// them to a variable nothing reads.
     #[test]
     fn missing_user_has_actionable_message() {
         let msg = UpdateReposError::MissingUser.to_string();
-        assert!(msg.contains("GITHUB_USERNAME"), "{msg}");
+        assert!(msg.contains("PORTFOLIO_GITHUB__USERNAME"), "{msg}");
         assert!(UpdateReposError::MissingUser.source().is_none());
     }
 

--- a/apps/update-repos/src/main.rs
+++ b/apps/update-repos/src/main.rs
@@ -7,7 +7,7 @@
 //! [`portfolio_data::Repo`]/[`portfolio_data::ReposFile`] models (the very same
 //! types the web client embeds and the server's schema describes) and writes the
 //! pretty-printed JSON to disk. A specific set of repositories can still be
-//! requested explicitly via `GITHUB_REPOS`.
+//! requested explicitly via `github.repos`.
 //!
 //! To avoid hitting the GitHub API on every rebuild (and its rate limits), the
 //! existing output is reused while it is still fresh: the network fetch is
@@ -20,12 +20,23 @@
 //! update-repos [OUTPUT_PATH]      # default: apps/web/repos.json
 //! ```
 //!
-//! Environment:
-//!   GITHUB_USERNAME  user whose repos to fetch (default: CONFIG.github_username)
-//!   GITHUB_REPOS  comma-separated repo names to fetch (default: all
-//!                 non-archived repositories of the user)
-//!   GH_TOKEN / GITHUB_TOKEN  bearer token to authenticate (optional)
-//!   CI  when set, uses the longer (10h) cache TTL instead of 60 minutes
+//! Configuration is layered (see `portfolio_config`); the keys this binary reads
+//! are the [`GithubConfig`] block:
+//!
+//! ```text
+//! PORTFOLIO_GITHUB__USERNAME    user whose repos to fetch
+//!                               (default: CONFIG.github_username)
+//! PORTFOLIO_GITHUB__REPOS       repo names to fetch, e.g. [Portfolio,actions]
+//!                               (default: all active repositories of the user)
+//! PORTFOLIO_GITHUB__TOKEN       bearer token lifting the API rate limit
+//!                               (optional; prefer ..._TOKEN_FILE)
+//! PORTFOLIO_GITHUB__TOKEN_FILE  path to a file holding the token, so it never
+//!                               enters the process environment
+//! ```
+//!
+//! `CI` is read separately and deliberately stays outside that namespace: it is
+//! the CI provider's variable, not ours, and it selects the cache TTL rather
+//! than configuring the fetch.
 
 mod builder;
 mod cache;
@@ -35,7 +46,9 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use portfolio_config::GithubConfig;
 use portfolio_data::CONFIG;
+use serde::Deserialize;
 use time::OffsetDateTime;
 
 use crate::builder::ReposBuilder;
@@ -43,6 +56,17 @@ use crate::error::UpdateReposError;
 
 /// Where `repos.json` is committed, relative to the workspace root.
 const DEFAULT_OUTPUT: &str = "apps/web/repos.json";
+
+/// Everything this builder reads from its configuration.
+///
+/// One block, so the aggregate looks redundant — it is not: it is what fixes the
+/// key path to `github.*`, which is the half of the environment spelling
+/// `portfolio_config` cannot decide on this binary's behalf.
+#[derive(Debug, Deserialize)]
+struct Config {
+    #[serde(default)]
+    github: GithubConfig,
+}
 
 fn main() -> ExitCode {
     match run() {
@@ -71,23 +95,21 @@ fn run() -> Result<(), UpdateReposError> {
         return Ok(());
     }
 
-    let user =
-        env_non_empty("GITHUB_USERNAME").unwrap_or_else(|| CONFIG.github_username.to_string());
-    let token = env_non_empty("GH_TOKEN").or_else(|| env_non_empty("GITHUB_TOKEN"));
+    let github = config()?.github;
+    // The site's own identity is the only sensible default, and it lives in the
+    // compile-time data rather than in the config schema — a deployment that has
+    // to name the user it is a portfolio *for* has bigger problems.
+    let user = github
+        .username()
+        .unwrap_or(CONFIG.github_username)
+        .to_owned();
 
-    // An explicit, comma-separated override; when unset the builder lists every
-    // non-archived repository the user owns.
-    let names: Vec<String> = match env_non_empty("GITHUB_REPOS") {
-        Some(list) => list
-            .split(',')
-            .map(|name| name.trim().to_string())
-            .filter(|name| !name.is_empty())
-            .collect(),
-        None => Vec::new(),
-    };
+    // An explicit override; when empty the builder lists every active repository
+    // the user owns. Collected before the token moves out of `github`.
+    let names: Vec<String> = github.repos().map(str::to_owned).collect();
 
     let builder = ReposBuilder::new(user)
-        .token(token)
+        .token(github.into_token())
         .repos(names)
         .blacklist(CONFIG.blacklisted_repos.iter().map(|name| name.to_string()));
 
@@ -110,7 +132,12 @@ fn run() -> Result<(), UpdateReposError> {
     Ok(())
 }
 
-/// Returns the value of `var` only when it is set and non-empty.
-fn env_non_empty(var: &str) -> Option<String> {
-    std::env::var(var).ok().filter(|v| !v.is_empty())
+/// Reads the layered configuration.
+///
+/// A configuration error aborts the build rather than falling back to an
+/// unauthenticated fetch: silently dropping the token would turn a typo in a
+/// secret's path into an intermittent rate-limit failure much later, in a job
+/// that has nothing to do with the mistake.
+fn config() -> Result<Config, UpdateReposError> {
+    portfolio_config::load().map_err(UpdateReposError::from)
 }

--- a/apps/web/Cargo.toml
+++ b/apps/web/Cargo.toml
@@ -32,6 +32,9 @@ time = { workspace = true, features = ["macros"], optional = true }
 # Pinned to the version dioxus-fullstack re-exports.
 dioxus-fullstack-core = { version = "=0.7.10", optional = true }
 http = { version = "1", optional = true }
+# The layered configuration the SSR server boots through. Server-only: the wasm
+# client has no filesystem to read a config file or a mounted secret from.
+portfolio-config = { workspace = true, optional = true }
 
 [build-dependencies]
 # Read at build time so `build.rs` embeds the resume PDFs under their canonical
@@ -75,4 +78,5 @@ server = [
     "dep:time",
     "dep:dioxus-fullstack-core",
     "dep:http",
+    "dep:portfolio-config",
 ]

--- a/apps/web/src/server/api.rs
+++ b/apps/web/src/server/api.rs
@@ -7,9 +7,11 @@ use std::sync::LazyLock;
 
 use axum::{
     Json,
+    extract::State,
     http::{StatusCode, header},
     response::IntoResponse,
 };
+use portfolio_config::AssetsConfig;
 use portfolio_data::profile::{Profile, ProfileWithSchema};
 use serde::Serialize;
 use time::{OffsetDateTime, macros::format_description};
@@ -81,12 +83,11 @@ fn assets_ready(dist: &Path) -> bool {
     dist.join("index.html").is_file()
 }
 
-/// Readiness probe. Confirms the built client assets are present under
-/// `DIST_DIR` before Kubernetes routes traffic to this instance.
-pub async fn ready() -> impl IntoResponse {
-    let dist = std::env::var("DIST_DIR").unwrap_or_else(|_| "public".into());
-
-    let (status, payload) = if assets_ready(Path::new(&dist)) {
+/// Readiness probe. Confirms the built client assets are present under the
+/// configured bundle directory before Kubernetes routes traffic to this
+/// instance.
+pub async fn ready(State(assets): State<AssetsConfig>) -> impl IntoResponse {
+    let (status, payload) = if assets_ready(assets.dist_dir()) {
         (StatusCode::OK, "ready")
     } else {
         (StatusCode::SERVICE_UNAVAILABLE, "unavailable")

--- a/apps/web/src/server/mod.rs
+++ b/apps/web/src/server/mod.rs
@@ -12,8 +12,7 @@ mod seo;
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
 
 use axum::{
     Router,
@@ -24,7 +23,9 @@ use axum::{
     routing::get,
 };
 use dioxus::server::{DioxusRouterExt, IncrementalRendererConfig, ServeConfig};
+use portfolio_config::{AssetsConfig, IsrConfig};
 use portfolio_data::LANGUAGES;
+use serde::Deserialize;
 use tower_http::{
     compression::{
         CompressionLayer,
@@ -56,23 +57,66 @@ const CSP: &str = "default-src 'self'; \
      frame-ancestors 'none'; \
      upgrade-insecure-requests";
 
+/// Everything this server reads from its configuration.
+///
+/// The blocks belong to `portfolio-config`, which owns the layering; the
+/// aggregate belongs here, so a field exists exactly when this binary consumes
+/// it. See that crate's docs for the layers and their precedence.
+///
+/// Notably absent: the listen address. `IP`, `PORT` and `RUST_LOG` are the
+/// Dioxus toolchain's contract with the binary — `dx serve` sets them to tell a
+/// development build which port it is being proxied on — so folding them into
+/// the `PORTFOLIO_` namespace would take a name the framework still reads and
+/// leave two sources of truth for one socket.
+#[derive(Debug, Deserialize)]
+struct ServerConfig {
+    #[serde(default)]
+    assets: AssetsConfig,
+    #[serde(default)]
+    isr: IsrConfig,
+}
+
+/// Exit code for a configuration the process cannot start with (`EX_CONFIG`
+/// from `sysexits.h`), so an operator can tell a bad config apart from a crash
+/// without reading the logs.
+const EX_CONFIG: i32 = 78;
+
 /// Runs the Axum SSR server. `dioxus::serve` sets up the async runtime and the
 /// default logger, then binds to `IP`/`PORT` (default `127.0.0.1:8080`) and
-/// serves the router below with graceful shutdown.
+/// serves the router below.
+///
+/// Configuration is read once, before the runtime exists: a value that cannot
+/// be loaded is a start-up failure, not a per-request one, and failing here
+/// means the container never reports ready rather than serving a degraded site.
 pub fn serve() {
-    dioxus::serve(|| async move { Ok(router()) });
+    let config = match portfolio_config::load::<ServerConfig>() {
+        Ok(config) => Arc::new(config),
+        Err(err) => {
+            // Before `dioxus::serve` installs the logger, so `tracing` would
+            // discard this.
+            eprintln!("portfolio: cannot start, the configuration is not usable: {err}");
+            std::process::exit(EX_CONFIG);
+        }
+    };
+
+    dioxus::serve(move || {
+        let config = Arc::clone(&config);
+        async move { Ok(router(&config)) }
+    });
 }
 
 /// The full application router: the Dioxus SSR/asset router with our routes and
 /// layers mounted on top. Custom routes take precedence over the SSR fallback;
 /// layers apply to every response (SSR HTML, static assets, API, SEO).
-fn router() -> Router {
+fn router(config: &ServerConfig) -> Router {
     let static_header = |name: HeaderName, value: &'static str| {
         SetResponseHeaderLayer::overriding(name, HeaderValue::from_static(value))
     };
 
-    let (dioxus_app, isr_enabled) = dioxus_app_router();
-    let app = dioxus_app.merge(api_router()).merge(assets::router());
+    let (dioxus_app, isr_enabled) = dioxus_app_router(&config.isr);
+    let app = dioxus_app
+        .merge(api_router(config.assets.clone()))
+        .merge(assets::router());
     // Locale handling for page navigations, innermost so it sees the request
     // before the router and the response before compression: it stamps the
     // negotiated language onto `<html lang>`, declares the `Vary` axes the
@@ -111,22 +155,6 @@ fn compression_predicate() -> impl Predicate {
         .and(NotForContentType::const_new("font/woff2"))
         .and(NotForContentType::const_new("application/pdf"))
 }
-
-/// Environment variable naming the writable directory Dioxus's incremental
-/// renderer (ISR) caches rendered HTML into. Set empty to disable ISR (the
-/// server then renders every request fresh). The image defaults it to a
-/// sub-directory of `/tmp`, which the deployment (Helm chart) already provides
-/// as a writable mount even under a read-only root filesystem. Keep it *outside*
-/// the bundled `public/` asset tree so those assets remain immutable.
-const ISR_CACHE_DIR_ENV: &str = "ISR_CACHE_DIR";
-
-/// Environment variable overriding the ISR revalidation interval, in seconds.
-/// Unset, empty, `0`, or an unparseable value all mean "never revalidate" (a
-/// permanent cache): every page renders from compile-time data, so the only
-/// thing that changes the output is a new build/deploy — which starts from an
-/// empty cache anyway. A positive value opts into a finite, time-based TTL,
-/// useful only when a *persistent* cache volume is shared across deploys.
-const ISR_TTL_SECS_ENV: &str = "ISR_TTL_SECS";
 
 /// Query-string marker [`localize_page`] appends to page requests so the
 /// otherwise language-blind, path-keyed incremental cache stores one entry per
@@ -173,7 +201,7 @@ fn is_cacheable_path(path: &str) -> bool {
 const ISR_UNCACHEABLE_SENTINEL: &str = ".uncacheable";
 
 /// The Dioxus SSR/asset router, with incremental static regeneration enabled
-/// when [`ISR_CACHE_DIR_ENV`] names a writable directory.
+/// when the configuration names a writable cache directory.
 ///
 /// Dioxus's incremental renderer keys its cache by request path (and query)
 /// only. This site negotiates locale per request (cookie / `Accept-Language`,
@@ -184,8 +212,8 @@ const ISR_UNCACHEABLE_SENTINEL: &str = ".uncacheable";
 /// entry per language per path.
 /// Returns the Dioxus router and whether ISR is enabled (so the caller can add
 /// the locale-tagging middleware only when the cache is active).
-fn dioxus_app_router() -> (Router, bool) {
-    match incremental_config() {
+fn dioxus_app_router(isr: &IsrConfig) -> (Router, bool) {
+    match incremental_config(isr) {
         Some(cfg) => (
             Router::new()
                 .serve_dioxus_application(ServeConfig::builder().incremental(cfg), crate::app::App),
@@ -196,18 +224,11 @@ fn dioxus_app_router() -> (Router, bool) {
     }
 }
 
-/// Builds the incremental-render configuration from the environment, or `None`
-/// when ISR is disabled ([`ISR_CACHE_DIR_ENV`] unset) or the cache directory
-/// is not usable (cannot be created, or exists but is not writable).
-fn incremental_config() -> Option<IncrementalRendererConfig> {
-    let dir = std::env::var_os(ISR_CACHE_DIR_ENV)?;
-    // Treat an empty value the same as unset: container platforms routinely
-    // inject `KEY=` for a declared-but-unset variable, and that must mean "ISR
-    // off", not "cache into the current directory".
-    if dir.is_empty() {
-        return None;
-    }
-    let dir = PathBuf::from(dir);
+/// Builds the incremental-render configuration, or `None` when ISR is disabled
+/// (no cache directory configured) or the cache directory is not usable (cannot
+/// be created, or exists but is not writable).
+fn incremental_config(isr: &IsrConfig) -> Option<IncrementalRendererConfig> {
+    let dir = isr.cache_dir()?.to_path_buf();
     // Verify the directory can actually be written to, not merely that it
     // exists: a mounted volume (e.g. a root-owned Kubernetes `emptyDir`) can be
     // present yet unwritable to our non-root user, in which case `create_dir_all`
@@ -229,7 +250,7 @@ fn incremental_config() -> Option<IncrementalRendererConfig> {
         return None;
     }
 
-    let invalidate_after = parse_isr_ttl(std::env::var(ISR_TTL_SECS_ENV).ok().as_deref());
+    let invalidate_after = isr.invalidate_after();
     match invalidate_after {
         Some(ttl) => tracing::info!(
             "ISR enabled: caching rendered pages per locale in {} (revalidate after {}s)",
@@ -268,23 +289,6 @@ fn incremental_config() -> Option<IncrementalRendererConfig> {
         config = config.invalidate_after(ttl);
     }
     Some(config)
-}
-
-/// Parses the configured ISR revalidation interval ([`ISR_TTL_SECS_ENV`]) into an
-/// optional invalidation duration. `None` means a permanent cache (no time-based
-/// invalidation): unset, empty, a literal `0`, or an unparseable value all fail
-/// safe to permanent, since every page renders from compile-time data and the
-/// real invalidation boundary is a redeploy (which starts from an empty cache).
-/// A positive integer opts back into a finite TTL for setups that share a
-/// persistent cache volume across deploys and want time-based churn.
-fn parse_isr_ttl(raw: Option<&str>) -> Option<Duration> {
-    match raw.map(str::trim) {
-        None | Some("") => None,
-        Some(secs) => match secs.parse::<u64>() {
-            Ok(0) | Err(_) => None,
-            Ok(secs) => Some(Duration::from_secs(secs)),
-        },
-    }
 }
 
 /// Ensures `dir` exists and is actually writable by our process. Creates the
@@ -623,7 +627,13 @@ fn log_cache_entry_created(route: &str, mapped: &Path) {
 /// The public HTTP API + SEO documents, as a standalone sub-router so it can be
 /// exercised in isolation by the integration tests below (without the SSR
 /// render machinery).
-fn api_router() -> Router {
+///
+/// `assets` is the router's state purely for the readiness probe, which is the
+/// one handler whose answer depends on configuration rather than on
+/// compile-time data. Holding it as state rather than re-reading it per request
+/// means the probe cannot start disagreeing with the rest of the process about
+/// where the bundle is.
+fn api_router(assets: AssetsConfig) -> Router {
     Router::new()
         .route("/api/health", get(api::health))
         .route("/api/health/live", get(api::live))
@@ -636,6 +646,7 @@ fn api_router() -> Router {
         .route("/robots.txt", get(seo::robots))
         .route("/sitemap.xml", get(seo::sitemap))
         .route("/site.webmanifest", get(seo::webmanifest))
+        .with_state(assets)
 }
 
 #[cfg(test)]
@@ -651,7 +662,7 @@ mod tests {
 
     /// Dispatches a `GET` through the real API router and returns the response.
     async fn get_(path: &str) -> axum::response::Response {
-        api_router()
+        api_router(AssetsConfig::default())
             .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
             .await
             .unwrap()
@@ -759,7 +770,7 @@ mod tests {
 
     #[tokio::test]
     async fn profile_rejects_non_get_methods() {
-        let response = api_router()
+        let response = api_router(AssetsConfig::default())
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -976,19 +987,53 @@ mod tests {
         assert_ne!(imprint_de, de);
     }
 
+    /// ISR is off unless the configuration names a cache directory. That answer
+    /// is what [`dioxus_app_router`] turns into the flag gating locale tagging,
+    /// so getting it wrong would leave every language sharing one cache entry.
+    ///
+    /// The TTL and empty-value semantics themselves belong to
+    /// `portfolio_config::IsrConfig` and are tested there; what this pins is
+    /// that the server asks it rather than reading the environment behind its
+    /// back.
     #[test]
-    fn ttl_defaults_to_permanent_and_honours_a_finite_override() {
-        // Unset, blank, whitespace, and an explicit zero all mean "never
-        // revalidate": the cache is refreshed by a redeploy, not by elapsed time.
-        assert_eq!(parse_isr_ttl(None), None);
-        assert_eq!(parse_isr_ttl(Some("")), None);
-        assert_eq!(parse_isr_ttl(Some("  ")), None);
-        assert_eq!(parse_isr_ttl(Some("0")), None);
-        // Garbage fails safe to permanent rather than a surprise interval.
-        assert_eq!(parse_isr_ttl(Some("later")), None);
-        // A positive value opts back into a finite, time-based TTL.
-        assert_eq!(parse_isr_ttl(Some("3600")), Some(Duration::from_secs(3600)));
-        assert_eq!(parse_isr_ttl(Some(" 90 ")), Some(Duration::from_secs(90)));
+    fn isr_is_off_without_a_configured_cache_directory() {
+        assert!(incremental_config(&IsrConfig::default()).is_none());
+    }
+
+    #[test]
+    fn a_writable_cache_directory_turns_isr_on() {
+        let dir = scratch_path("isr-config");
+        let on = IsrConfig {
+            cache_dir: Some(dir.clone()),
+            ttl_secs: 0,
+        };
+
+        assert!(incremental_config(&on).is_some());
+        // The sentinel is what keeps non-cacheable routes from minting entries;
+        // enabling ISR must have created it as a regular file.
+        assert!(dir.join(ISR_UNCACHEABLE_SENTINEL).is_file());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A cache directory the process cannot write to fails safe: the server
+    /// renders every request fresh rather than refusing to start or persisting
+    /// nothing while believing it caches.
+    #[test]
+    fn an_unusable_cache_directory_disables_isr_instead_of_failing() {
+        // A path *under a regular file* can never be created, which is the one
+        // "unwritable" shape that reproduces identically on every platform
+        // (a mode-0555 directory does not, since root ignores it).
+        let blocker = scratch_path("isr-blocker");
+        std::fs::write(&blocker, b"not a directory").unwrap();
+
+        let unusable = IsrConfig {
+            cache_dir: Some(blocker.join("cache")),
+            ttl_secs: 0,
+        };
+        assert!(incremental_config(&unusable).is_none());
+
+        let _ = std::fs::remove_file(&blocker);
     }
 
     #[test]
@@ -1061,7 +1106,7 @@ mod tests {
     async fn non_page_responses_are_left_alone() {
         // A request may accept HTML and still be answered with JSON; those do
         // not vary by language and have no tag to stamp.
-        let response = api_router()
+        let response = api_router(AssetsConfig::default())
             .layer(middleware::from_fn_with_state(false, localize_page))
             .oneshot(
                 Request::builder()

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,70 @@
+# Example configuration for the portfolio workspace.
+#
+# Point $PORTFOLIO_CONFIG at a copy of this file, or at a directory holding
+# several `*.toml` fragments (merged in sorted order — one file per concern is
+# what lets a Kubernetes ConfigMap and a Secret land side by side).
+#
+#   PORTFOLIO_CONFIG=./config.toml cargo run -p web --features server
+#
+# Every key here can equally be supplied as a `PORTFOLIO_`-prefixed environment
+# variable with `__` for nesting (`assets.dist_dir` → PORTFOLIO_ASSETS__DIST_DIR),
+# as a file in $PORTFOLIO_SECRETS_DIR named after the key (`assets__dist_dir`),
+# or as `PORTFOLIO_<KEY>_FILE=/path`. The last three are mutually exclusive per
+# key: supplying one key from two of them fails the boot rather than letting a
+# stale environment variable shadow a rotated secret.
+#
+# Every value below is the default, so an empty file behaves identically —
+# except `isr.cache_dir`, which has no default and which the container image
+# sets to /tmp/isr.
+#
+# NOT configured here: IP, PORT and RUST_LOG belong to the Dioxus toolchain,
+# which reads them itself, and CI belongs to the CI provider.
+
+# ── the SSR server ───────────────────────────────────────────────────────────
+
+[assets]
+# Directory holding the `dx bundle` output, relative to the working directory.
+# Only the readiness probe consults it: the bundle itself is served by the Dioxus
+# asset router, which resolves `public/` relative to the binary.
+dist_dir = "public"
+
+[isr]
+# Writable directory rendered HTML is cached into. Unset — as it is here —
+# disables incremental static regeneration and renders every request fresh.
+# Keep it outside the bundled `public/` tree so those content-hashed assets stay
+# immutable. The image sets this to /tmp/isr, which the deployment mounts as a
+# writable volume even under a read-only root filesystem.
+#
+# cache_dir = "/tmp/isr"
+
+# Revalidation interval in seconds. `0` means a permanent cache, which is right
+# for this site: every page renders from compile-time data, so the only thing
+# that changes the output is a redeploy — and that starts from an empty cache.
+# Set a positive value only when a *persistent* cache volume is shared across
+# deploys. Unlike the environment variable this replaced, an unparseable value
+# now fails the boot instead of silently meaning "permanent".
+ttl_secs = 0
+
+# ── the update-repos builder (build time only) ───────────────────────────────
+
+[github]
+# User whose repositories to list. Unset falls back to the site's own identity
+# from `crates/data`.
+#
+# username = "TimSchoenle"
+
+# An explicit repository set, bypassing the "every active repository" listing and
+# its archived/blacklisted/stale filtering. Empty lists them all.
+repos = []
+
+# Bearer token lifting the GitHub API rate limit. DO NOT put it here.
+#
+# Supply it as a file so it never enters the process environment, where
+# /proc/<pid>/environ, a crash dump, `docker inspect` and every child process
+# would carry it:
+#
+#   PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token
+#
+# or as `github__token` inside $PORTFOLIO_SECRETS_DIR, which is what a Kubernetes
+# Secret volume mounts. In the process it is a `secrecy::SecretString`: no Debug,
+# no Display, and the one place it becomes a `&str` is the Authorization header.

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "portfolio-config"
+version = "2.2.3"
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde.workspace = true
+# The loader itself. This crate owns the *schema* and the Portfolio dialect
+# (`src/loader.rs`) and none of the layering, the secrets-directory provider or
+# the shadow-key rejection.
+terrace-config.workspace = true
+# Config is where the GitHub token enters the process, so it is where the
+# wrapper has to start: a `SecretString` field cannot be unwrapped by the
+# struct that nests it, so the token stays wrapped until the one line that
+# builds the `Authorization` header.
+secrecy.workspace = true
+
+[dev-dependencies]
+figment.workspace = true

--- a/crates/config/src/assets.rs
+++ b/crates/config/src/assets.rs
@@ -1,0 +1,75 @@
+//! Where the SSR server finds the built client bundle.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// The built client assets the server reads.
+///
+/// Only the readiness probe consults this: the bundle is served by the Dioxus asset router,
+/// which resolves `public/` relative to the binary on its own. What the probe answers is
+/// whether that bundle is actually there, so a pod missing it is removed from the Service
+/// endpoints instead of serving a page with no wasm.
+// No `deny_unknown_fields` on any block in this crate, and it is not an oversight: the
+// `PORTFOLIO_<KEY>_FILE` indirection variables sit inside the same prefixed namespace, so
+// figment's environment layer surfaces `assets.dist_dir_file` alongside the `assets.dist_dir`
+// the file layer supplies. Denying unknown fields would reject exactly the mechanism this
+// migration exists to enable.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AssetsConfig {
+    /// Directory holding the `dx bundle` output, relative to the working directory (the image
+    /// runs from `/app`, next to `public/`).
+    #[serde(default = "AssetsConfig::default_dist_dir")]
+    pub dist_dir: PathBuf,
+}
+
+impl AssetsConfig {
+    /// The sibling `public/` directory a `dx bundle` produces.
+    fn default_dist_dir() -> PathBuf {
+        PathBuf::from("public")
+    }
+
+    /// The configured bundle directory, falling back to the default when the value supplied was
+    /// empty.
+    ///
+    /// Container platforms routinely inject `KEY=` for a declared-but-unset variable, and an
+    /// empty path here would resolve the readiness probe against the working directory — which
+    /// answers "ready" for a deploy that shipped no assets at all.
+    #[must_use]
+    pub fn dist_dir(&self) -> &Path {
+        if self.dist_dir.as_os_str().is_empty() {
+            Path::new("public")
+        } else {
+            &self.dist_dir
+        }
+    }
+}
+
+impl Default for AssetsConfig {
+    fn default() -> Self {
+        Self {
+            dist_dir: Self::default_dist_dir(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AssetsConfig;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn an_unset_bundle_directory_falls_back_to_public() {
+        assert_eq!(AssetsConfig::default().dist_dir(), Path::new("public"));
+    }
+
+    /// `PORTFOLIO_ASSETS__DIST_DIR=` is how a container platform spells "declared but unset",
+    /// and it must not resolve the probe against the working directory.
+    #[test]
+    fn an_empty_bundle_directory_is_treated_as_unset() {
+        let config = AssetsConfig {
+            dist_dir: PathBuf::new(),
+        };
+        assert_eq!(config.dist_dir(), Path::new("public"));
+    }
+}

--- a/crates/config/src/github.rs
+++ b/crates/config/src/github.rs
@@ -1,0 +1,113 @@
+//! What the `update-repos` builder needs to talk to the GitHub REST API.
+
+use secrecy::SecretString;
+use serde::Deserialize;
+
+/// Credentials and scope for the build-time repository listing.
+///
+/// Every field is optional because every field has a defensible zero: an unset user means "the
+/// one in the compile-time site config", an unset token means an unauthenticated request
+/// against the lower rate limit, and an empty repository list means "every active repository
+/// this user owns".
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct GithubConfig {
+    /// User whose repositories to list. Unset falls back to `portfolio_data::CONFIG`, which is
+    /// the site's own identity and therefore the only sensible default — resolved by the
+    /// builder rather than here, so this crate stays a schema and does not depend on the site
+    /// data.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// Bearer token lifting the GitHub API rate limit. Optional: the listing is public, so an
+    /// unauthenticated build still works, just against the anonymous quota.
+    ///
+    /// This is the one secret in the workspace, and the reason the loader is `terrace-config`:
+    /// supply it as `PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token` (or from a secrets
+    /// directory) so it never enters the process environment, where `/proc/<pid>/environ`, a
+    /// crash dump or a `docker inspect` would carry it.
+    #[serde(default)]
+    pub token: Option<SecretString>,
+    /// An explicit repository set, bypassing the "every active repository" listing and its
+    /// archived/blacklisted/stale filtering. Empty means list them all.
+    ///
+    /// Spelled as an array: `repos = ["Portfolio", "actions"]` in TOML, and
+    /// `PORTFOLIO_GITHUB__REPOS=[Portfolio,actions]` in the environment — figment parses the
+    /// bracketed form, and a bare comma-separated string is *not* accepted, so the two
+    /// spellings cannot drift apart.
+    #[serde(default)]
+    pub repos: Vec<String>,
+}
+
+impl GithubConfig {
+    /// The configured user, or `None` when unset or blank.
+    ///
+    /// Blank counts as unset throughout this crate: container platforms routinely inject `KEY=`
+    /// for a declared-but-unset variable, and here that would request the repositories of a
+    /// user with no name.
+    #[must_use]
+    pub fn username(&self) -> Option<&str> {
+        self.username.as_deref().map(str::trim).filter(is_present)
+    }
+
+    /// The bearer token, or `None` when unset or blank.
+    ///
+    /// Blank has to mean unset rather than "authenticate as nobody": CI passes the token
+    /// through unconditionally, and on a fork's pull request there is no secret to pass, so an
+    /// empty value is the *normal* case rather than a misconfiguration.
+    ///
+    /// Consuming rather than borrowing because [`SecretString`] is deliberately not [`Clone`]
+    /// — handing the secret on is a move, which is what makes "who holds this" answerable.
+    #[must_use]
+    pub fn into_token(self) -> Option<SecretString> {
+        use secrecy::ExposeSecret as _;
+        self.token
+            .filter(|token| is_present(&token.expose_secret().trim()))
+    }
+
+    /// The explicit repository set, with blank entries dropped.
+    pub fn repos(&self) -> impl Iterator<Item = &str> {
+        self.repos.iter().map(|name| name.trim()).filter(is_present)
+    }
+}
+
+/// Whether a supplied value carries anything. See [`GithubConfig::username`].
+fn is_present(value: &&str) -> bool {
+    !value.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GithubConfig;
+    use secrecy::SecretString;
+
+    #[test]
+    fn an_unset_github_block_asks_for_nothing() {
+        let config = GithubConfig::default();
+        assert_eq!(config.username(), None);
+        assert_eq!(config.repos().count(), 0);
+        assert!(config.into_token().is_none());
+    }
+
+    /// CI passes the token through unconditionally, so a fork's pull request supplies an empty
+    /// one. That has to read as "unauthenticated", not as a token of length zero.
+    #[test]
+    fn a_blank_token_is_unauthenticated_rather_than_a_bad_credential() {
+        let config = GithubConfig {
+            token: Some(SecretString::from("   ")),
+            ..GithubConfig::default()
+        };
+        assert!(config.into_token().is_none());
+    }
+
+    #[test]
+    fn blank_repository_names_are_dropped() {
+        let config = GithubConfig {
+            repos: vec![
+                " Portfolio ".to_owned(),
+                String::new(),
+                "actions".to_owned(),
+            ],
+            ..GithubConfig::default()
+        };
+        assert_eq!(config.repos().collect::<Vec<_>>(), ["Portfolio", "actions"]);
+    }
+}

--- a/crates/config/src/isr.rs
+++ b/crates/config/src/isr.rs
@@ -1,0 +1,102 @@
+//! Incremental static regeneration: where rendered pages are cached, and for how long.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// The SSR server's incremental render cache.
+///
+/// Off unless [`cache_dir`](Self::cache_dir) names a directory, and off again at runtime if
+/// that directory turns out not to be writable — the server then renders every request fresh
+/// rather than failing to start.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct IsrConfig {
+    /// Writable directory rendered HTML is cached into. Unset (or empty) disables ISR.
+    ///
+    /// Keep it *outside* the bundled `public/` asset tree so those content-hashed assets stay
+    /// immutable. The image points it at a sub-directory of `/tmp`, which the deployment
+    /// already provides as a writable mount even under a read-only root filesystem.
+    #[serde(default)]
+    pub cache_dir: Option<PathBuf>,
+    /// Revalidation interval in seconds. `0` — the default — means a permanent cache.
+    ///
+    /// Every page renders from compile-time data, so the only thing that changes the output is
+    /// a new build, which starts from an empty cache anyway. A positive value opts into a
+    /// finite, time-based TTL, which is useful only when a *persistent* cache volume is shared
+    /// across deploys.
+    #[serde(default)]
+    pub ttl_secs: u64,
+}
+
+impl IsrConfig {
+    /// The cache directory, or `None` when ISR is off.
+    ///
+    /// An empty value counts as unset: container platforms routinely inject `KEY=` for a
+    /// declared-but-unset variable, and that has to mean "ISR off", not "cache into the current
+    /// working directory".
+    #[must_use]
+    pub fn cache_dir(&self) -> Option<&Path> {
+        self.cache_dir
+            .as_deref()
+            .filter(|dir| !dir.as_os_str().is_empty())
+    }
+
+    /// The revalidation interval, or `None` for a permanent cache.
+    ///
+    /// Unlike the environment-variable reader this replaces, an *unparseable* value no longer
+    /// falls back to "permanent" — it fails the boot, because figment rejects it before this is
+    /// ever called. That is the intended trade: a typo used to silently disable revalidation on
+    /// the one deployment shape that needs it, and a container that refuses to start is the
+    /// louder half of the failure.
+    #[must_use]
+    pub fn invalidate_after(&self) -> Option<Duration> {
+        (self.ttl_secs > 0).then(|| Duration::from_secs(self.ttl_secs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IsrConfig;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    #[test]
+    fn isr_is_off_until_a_cache_directory_is_named() {
+        assert_eq!(IsrConfig::default().cache_dir(), None);
+    }
+
+    /// `PORTFOLIO_ISR__CACHE_DIR=` is how a container platform spells "declared but unset"; it
+    /// must disable ISR rather than cache into the working directory.
+    #[test]
+    fn an_empty_cache_directory_disables_isr() {
+        let config = IsrConfig {
+            cache_dir: Some(PathBuf::new()),
+            ..IsrConfig::default()
+        };
+        assert_eq!(config.cache_dir(), None);
+    }
+
+    #[test]
+    fn a_named_cache_directory_enables_isr() {
+        let config = IsrConfig {
+            cache_dir: Some(PathBuf::from("/tmp/isr")),
+            ..IsrConfig::default()
+        };
+        assert_eq!(config.cache_dir(), Some(Path::new("/tmp/isr")));
+    }
+
+    #[test]
+    fn a_zero_ttl_means_a_permanent_cache() {
+        assert_eq!(IsrConfig::default().invalidate_after(), None);
+    }
+
+    #[test]
+    fn a_positive_ttl_opts_into_time_based_revalidation() {
+        let config = IsrConfig {
+            ttl_secs: 3600,
+            ..IsrConfig::default()
+        };
+        assert_eq!(config.invalidate_after(), Some(Duration::from_secs(3600)));
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,0 +1,55 @@
+//! The typed configuration surface every binary in this workspace reads, plus the Portfolio
+//! dialect of the layered loader.
+//!
+//! The layering is [`terrace_config`]'s. Lowest precedence first: struct defaults, TOML at
+//! `$PORTFOLIO_CONFIG` (a file, or every `*.toml` in it when it names a directory),
+//! `PORTFOLIO_`-prefixed `__`-nested environment variables, `$PORTFOLIO_SECRETS_DIR`, and
+//! `PORTFOLIO_<KEY>_FILE` indirection. The last three are mutually exclusive per key: a key
+//! supplied by two of them is refused at boot rather than resolved by precedence, because a
+//! stale environment variable shadowing a rotated mounted secret keeps the process running on
+//! the old credential.
+//!
+//! Call [`load`], which is the only entry point.
+//!
+//! # What each binary composes
+//!
+//! This crate owns the *blocks* and the dialect; each binary declares the aggregate it actually
+//! reads, so a struct field is evidence that something consumes it:
+//!
+//! - the SSR server ([`AssetsConfig`], [`IsrConfig`]),
+//! - the `update-repos` builder ([`GithubConfig`]).
+//!
+//! # Why the loader half only
+//!
+//! `terrace-config` also ships a supervisor that rebuilds a running service when the files its
+//! configuration came from change. This workspace deliberately does not take it, for two
+//! reasons that both have to hold before it would be worth the tokio/notify/`inotify` weight:
+//!
+//! 1. **The server holds no secrets.** Rotation is what the supervisor exists to survive, and
+//!    the only secret in the workspace ([`GithubConfig::token`]) belongs to a one-shot build
+//!    tool that exits in seconds. Every value the *server* reads changes only on a redeploy.
+//! 2. **The serve loop is not ours to cancel.** `dioxus::serve` owns the listener and the accept
+//!    loop, and offers no shutdown handle, so a rebuild could not stop the previous generation
+//!    before the replacement binds the same address. Taking the supervisor would mean
+//!    reimplementing the framework's serve loop — including the devtools hot-patch path that
+//!    `dx serve` depends on in development — to gain a reload for configuration that a
+//!    redeploy already replaces.
+//!
+//! Both halves of that reasoning are recorded here rather than in a commit message because the
+//! second one changes the moment Dioxus grows a cancellable `serve`.
+//!
+//! # Blank means unset
+//!
+//! Every accessor in this crate treats an empty or whitespace-only value as though the key had
+//! not been supplied. Container platforms routinely inject `KEY=` for a declared-but-unset
+//! variable, and each block documents what the alternative reading would have cost.
+
+mod assets;
+mod github;
+mod isr;
+mod loader;
+
+pub use assets::AssetsConfig;
+pub use github::GithubConfig;
+pub use isr::IsrConfig;
+pub use loader::{ConfigError, load, terrace};

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -1,0 +1,154 @@
+//! The Portfolio dialect of [`terrace_config`].
+//!
+//! The layering itself — the TOML fragments, the `PORTFOLIO_` environment layer, the
+//! secrets-directory provider, the `_FILE` indirection and the shadow-key rejection — belongs
+//! to `terrace-config`. What stays here is the one thing that is ours: which environment names
+//! this deployment spells.
+
+use serde::de::DeserializeOwned;
+use terrace_config::Terrace;
+
+pub use terrace_config::Error as ConfigError;
+
+/// The prefix every configuration variable carries.
+const PREFIX: &str = "PORTFOLIO_";
+
+/// The loader every binary in this workspace boots through.
+///
+/// Layers, lowest precedence first: struct defaults, TOML at `$PORTFOLIO_CONFIG` (a file, or
+/// every `*.toml` in it if it names a directory), `PORTFOLIO_`-prefixed `__`-nested environment
+/// variables, `$PORTFOLIO_SECRETS_DIR`, and `PORTFOLIO_<KEY>_FILE` indirection. The last three
+/// are mutually exclusive per key: a key supplied by two of them is refused at boot rather than
+/// resolved by precedence, because a stale environment variable shadowing a rotated mounted
+/// secret keeps the process running on the old credential.
+///
+/// Nothing is [`reserved`](Terrace::reserve) beyond the two names `terrace-config` reserves
+/// itself (`PORTFOLIO_CONFIG` and `PORTFOLIO_SECRETS_DIR`, both read to decide what the layers
+/// *are*). Reserving exists for keys read straight from the environment outside the layered
+/// config, and this workspace has none: every remaining variable it reads —  `IP`, `PORT` and
+/// `RUST_LOG`, which belong to the Dioxus toolchain, and `CI`, which belongs to the CI provider
+/// — is outside the `PORTFOLIO_` namespace entirely, so no file layer could name one.
+///
+/// Both variable names are stated as literals rather than left to the derivation
+/// `Terrace::new(PREFIX)` performs, so the documented surface in `README.md` can be checked
+/// against this file instead of against a dependency's internals.
+#[must_use]
+pub fn terrace() -> Terrace {
+    Terrace::new(PREFIX)
+        .config_var("PORTFOLIO_CONFIG")
+        .secrets_dir_var("PORTFOLIO_SECRETS_DIR")
+}
+
+/// Load a typed config through the layers above.
+///
+/// # Errors
+/// Returns [`ConfigError`] if a required value is missing, a value fails to parse, a
+/// file-backed source cannot be read, or one key is supplied by more than one of the last three
+/// layers.
+pub fn load<T: DeserializeOwned>() -> Result<T, ConfigError> {
+    terrace().load()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{GithubConfig, IsrConfig, load};
+    use secrecy::ExposeSecret as _;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    struct Sample {
+        #[serde(default)]
+        github: GithubConfig,
+        #[serde(default)]
+        isr: IsrConfig,
+    }
+
+    /// The dialect end to end: the prefix, the `__` nesting, and the defaults that fill in
+    /// around what the environment supplied. `terrace-config` owns the layering and tests it;
+    /// what this pins is that this crate wires it to the names an operator actually sets.
+    #[test]
+    // `figment::Jail::expect_with` fixes the closure's error type to the large `figment::Error`.
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn the_environment_layer_speaks_the_documented_names() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.set_env("PORTFOLIO_GITHUB__USERNAME", "TimSchoenle");
+            jail.set_env("PORTFOLIO_ISR__TTL_SECS", "3600");
+
+            let config: Sample = load().map_err(|e| e.to_string()).unwrap();
+            assert_eq!(config.github.username(), Some("TimSchoenle"));
+            assert_eq!(
+                config.isr.invalidate_after(),
+                Some(std::time::Duration::from_secs(3600))
+            );
+            // A field the environment did not touch still materialises with its default.
+            assert_eq!(config.isr.cache_dir(), None);
+            Ok(())
+        });
+    }
+
+    /// A mounted secret outranks the TOML layer, so a `ConfigMap` carrying a placeholder cannot
+    /// win over the `Secret` that carries the real token — through the variable names *this*
+    /// crate configures, which is the half a dependency cannot pin.
+    #[test]
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn a_secrets_directory_outranks_the_toml_layer() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.create_file("config.toml", "[github]\ntoken = \"placeholder\"\n")?;
+            jail.create_dir("secrets")?;
+            jail.create_file("secrets/github__token", "ghp_real\n")?;
+            jail.set_env(
+                "PORTFOLIO_CONFIG",
+                jail.directory().join("config.toml").display(),
+            );
+            jail.set_env(
+                "PORTFOLIO_SECRETS_DIR",
+                jail.directory().join("secrets").display(),
+            );
+
+            let config: Sample = load().map_err(|e| e.to_string()).unwrap();
+            let token = config
+                .github
+                .into_token()
+                .expect("the secret supplies a token");
+            assert_eq!(token.expose_secret(), "ghp_real");
+            Ok(())
+        });
+    }
+
+    /// A key supplied by both the environment and a mounted file fails the boot instead of one
+    /// silently winning. This is the whole reason the loader is `terrace-config` and not a bare
+    /// figment: a `GITHUB_TOKEN` left behind by a half-finished migration must not keep the
+    /// build running on a credential the operator believes they rotated.
+    #[test]
+    #[expect(
+        clippy::result_large_err,
+        reason = "figment::Jail::expect_with fixes the closure's error type"
+    )]
+    fn one_key_supplied_twice_is_refused() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+            jail.create_dir("secrets")?;
+            jail.create_file("secrets/github__token", "ghp_from_file")?;
+            jail.set_env(
+                "PORTFOLIO_SECRETS_DIR",
+                jail.directory().join("secrets").display(),
+            );
+            jail.set_env("PORTFOLIO_GITHUB__TOKEN", "ghp_from_env");
+
+            let error = load::<Sample>().expect_err("two sources for one key must not load");
+            assert!(
+                error.to_string().contains("github.token"),
+                "the error must name the key: {error}"
+            );
+            Ok(())
+        });
+    }
+}

--- a/cst.yaml
+++ b/cst.yaml
@@ -11,6 +11,11 @@ metadataTest:
       value: 0.0.0.0
     - key: RUST_LOG
       value: info
+    # ISR is on by default, cached into the writable /tmp mount. The image's
+    # only `PORTFOLIO_` default, and a deployment-visible contract: a chart that
+    # mounts a volume elsewhere has to override precisely this key.
+    - key: PORTFOLIO_ISR__CACHE_DIR
+      value: /tmp/isr
 
 fileExistenceTests:
   # ── fullstack SSR server binary (the whole `dx bundle` output copied to /app) ─


### PR DESCRIPTION
Migrates the env-based configuration to the file-first layered approach from [terrace-config](https://github.com/TimSchoenle/terrace-config), mirroring how TankoVault does it.

## What changed

A new `crates/config` (`portfolio-config`) owns the typed blocks and the Portfolio dialect of the loader — the same split TankoVault uses, where the crate holds the *schema* and none of the layering. Each binary declares the aggregate it actually reads, so a field exists exactly when something consumes it.

Sources merge lowest-precedence first:

1. struct defaults
2. TOML at `$PORTFOLIO_CONFIG` (a file, or every `*.toml` in it when it names a directory)
3. `PORTFOLIO_`-prefixed, `__`-nested environment variables
4. every key-named file in `$PORTFOLIO_SECRETS_DIR`
5. `PORTFOLIO_<KEY>_FILE=/path` indirection

The last three are **mutually exclusive per key** — a key supplied by two of them fails the boot rather than resolving by precedence, so a stale environment variable cannot keep the process running on a credential the operator believes they rotated.

### Secrets

`github.token` is now a `secrecy::SecretString` and arrives as a **file**. The Docker build mounts the `gh_token` BuildKit secret at `/run/secrets/gh_token` and hands it over as `PORTFOLIO_GITHUB__TOKEN_FILE` instead of exporting `GH_TOKEN`, so the token never enters the process environment (`/proc/<pid>/environ`, crash dumps, `docker inspect`, child processes). No workflow change was needed — CI already passed it as a build secret.

## Key mapping

| Was | Now |
| --- | --- |
| `ISR_CACHE_DIR` | `PORTFOLIO_ISR__CACHE_DIR` / `isr.cache_dir` |
| `ISR_TTL_SECS` | `PORTFOLIO_ISR__TTL_SECS` / `isr.ttl_secs` |
| `DIST_DIR` | `PORTFOLIO_ASSETS__DIST_DIR` / `assets.dist_dir` |
| `GITHUB_USERNAME` | `PORTFOLIO_GITHUB__USERNAME` / `github.username` |
| `GITHUB_REPOS` | `PORTFOLIO_GITHUB__REPOS` / `github.repos` |
| `GH_TOKEN`, `GITHUB_TOKEN` | `PORTFOLIO_GITHUB__TOKEN_FILE` / `github.token` |

`IP`, `PORT` and `RUST_LOG` are deliberately left alone: they are the Dioxus toolchain's contract with the binary (`dx serve` sets them to tell a development build which port it is proxied on), so taking those names would leave two sources of truth for one socket. `CI` likewise belongs to the CI provider.

## Two decisions worth reviewing

**Loader only, no reload supervisor.** `terrace-config` also ships a supervisor that rebuilds a running service when its files change. Not taken here, for two reasons that both had to hold: the server holds **no secrets** (the only one belongs to a build tool that exits in seconds, and everything the server reads changes only on redeploy), and `dioxus::serve` owns the accept loop with no shutdown handle — a rebuild could not stop the previous generation before the replacement binds the same address. Taking it would mean reimplementing the framework's serve loop, including the devtools hot-patch path `dx serve` depends on. The reasoning is recorded in `crates/config/src/lib.rs` rather than only here, because the second half stops holding the moment Dioxus grows a cancellable `serve`.

**No `deny_unknown_fields`.** The `PORTFOLIO_<KEY>_FILE` variables sit inside the same prefixed namespace, so figment's environment layer surfaces `assets.dist_dir_file` alongside the `assets.dist_dir` the file layer supplies. Denying unknown fields would reject exactly the mechanism this migration enables.

## Behaviour changes

- `PORTFOLIO_GITHUB__REPOS` is a bracketed array (`[Portfolio,actions]`), not a bare comma-separated string — one spelling shared with the TOML form.
- An unparseable ISR TTL now **fails the boot** instead of silently falling back to "permanent". A typo used to quietly disable revalidation on the one deployment shape that needs it.
- A config that cannot be loaded exits `78` (`EX_CONFIG`) rather than starting degraded.
- Empty values still count as unset everywhere, since container platforms inject `KEY=` for declared-but-unset variables.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (plus `-p web --features server` and the wasm target separately)
- `cargo test` — 13 new tests in `portfolio-config` (including the shadow-key rejection and a secrets directory outranking TOML), 47 in `web --features server`, workspace green
- `cargo metadata --locked` in sync, so the `--locked` builds in CI and Docker resolve

Docs: new **Configuration** section in `README.md` with the full key table, plus a commented `config.example.toml`. A local `config.toml` / `secrets/` is now gitignored and dockerignored so a developer copy carrying a token cannot be committed or baked into a layer.
