### PR TITLE
feat(csp): build the policy from the served document with csp-shell

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -290,6 +290,70 @@ jobs:
           expect_header / x-frame-options DENY
           expect_header / referrer-policy no-referrer
 
+          # ── The Content-Security-Policy is derived from the page it protects ──
+          # This is the only place the real bundle is served, and the failure it
+          # catches is silent everywhere else: `'unsafe-inline'` is gone from
+          # script-src, so an inline script the scanner never saw is refused by
+          # the browser and the page renders blank with a console message nobody
+          # is watching.
+          csp_of() {
+            curl -fsS -D - -o /dev/null "$base$1" 2>/dev/null \
+              | tr -d '\r' \
+              | awk -F': ' 'tolower($1)=="content-security-policy"{print $2; exit}'
+          }
+
+          page_csp=$(csp_of /)
+          page_html=$(curl -fsS "$base/" || true)
+          # Bare `<script>`: the renderer's own inline scripts. The wasm bootstrap
+          # is `<script type="module" src=…>` and needs no hash — `'self'` covers it.
+          inline_scripts=$(grep -oF '<script>' <<<"$page_html" | wc -l | tr -d ' ')
+          page_hashes=$(grep -oF "'sha256-" <<<"$page_csp" | wc -l | tr -d ' ')
+          if [ "$inline_scripts" -gt 0 ] && [ "$page_hashes" = "$inline_scripts" ]; then
+            echo "ok: all $inline_scripts inline scripts on / are covered by a hash"
+          else
+            echo "::error::/ carries $inline_scripts inline scripts but $page_hashes hashes; a browser will refuse the difference"
+            fail=1
+          fi
+
+          # `'unsafe-inline'` must be gone from script-src. style-src keeps it,
+          # so the check is on that directive alone rather than on the header.
+          script_src=$(tr ';' '\n' <<<"$page_csp" | grep -F 'script-src' || true)
+          case "$script_src" in
+            *"'unsafe-inline'"*)
+              echo "::error::script-src still admits all inline script:$script_src"
+              fail=1
+              ;;
+            *) echo "ok: script-src admits no blanket inline script" ;;
+          esac
+
+          # Cloudflare copies this nonce onto the script it injects at the edge.
+          # Minted per response, and never cached — one served twice is pinned
+          # across every reader, which is `'unsafe-inline'` with extra steps.
+          first_nonce=$(grep -o "'nonce-[^']*'" <<<"$page_csp" || true)
+          second_nonce=$(grep -o "'nonce-[^']*'" <<<"$(csp_of /)" || true)
+          if [ -n "$first_nonce" ] && [ "$first_nonce" != "$second_nonce" ]; then
+            echo "ok: script-src carries a nonce, freshly minted per response"
+          else
+            echo "::error::expected a per-response nonce, got '$first_nonce' then '$second_nonce'"
+            fail=1
+          fi
+          expect_header / cache-control no-cache
+
+          # Anything that is not a document has no inline script to admit, and
+          # gets the policy that admits none.
+          asset_csp=$(csp_of /favicon.svg)
+          case "$asset_csp" in
+            "")
+              echo "::error::/favicon.svg carried no Content-Security-Policy"
+              fail=1
+              ;;
+            *"sha256-"* | *"nonce-"*)
+              echo "::error::a subresource carried a document policy: $asset_csp"
+              fail=1
+              ;;
+            *) echo "ok: subresources carry the policy with no inline-script allowance" ;;
+          esac
+
           if [ "$fail" != "0" ]; then
             echo "::error::container functional smoke tests failed"
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "csp-policy"
+version = "0.2.0"
+source = "git+https://github.com/TimSchoenle/csp-shell?tag=csp-shell-v0.2.0#8e0d90cd955c6e366932bc56d93d4aedd72e1e05"
+
+[[package]]
+name = "csp-shell"
+version = "0.2.0"
+source = "git+https://github.com/TimSchoenle/csp-shell?tag=csp-shell-v0.2.0#8e0d90cd955c6e366932bc56d93d4aedd72e1e05"
+dependencies = [
+ "csp-policy",
+ "getrandom 0.4.3",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6088,6 +6103,7 @@ name = "web"
 version = "2.3.0"
 dependencies = [
  "axum",
+ "csp-shell",
  "dioxus",
  "dioxus-fullstack-core",
  "gloo-timers 0.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,24 @@ tower-http = { version = "0.7", features = [
 ] }
 tracing = "0.1"
 
+# The Content-Security-Policy the SSR server sends, built from the document it is
+# about to serve rather than from a hand-maintained list of hashes that drifts the
+# moment anyone edits the shell. `cloudflare` is the crate's `presets` + `nonce`
+# pair: the origins Cloudflare's products load from *and* the directives they have
+# to appear in, plus the per-response nonce its edge-injected bot script needs.
+#
+# Pinned by tag rather than branch, for the same reason as `terrace-config`: the
+# policy this site serves changes on a deliberate commit here, not on whatever
+# `main` happened to be at build time. Not on crates.io, hence the git source.
+#
+# Server-only — `apps/web` takes it through `dep:` under its `server` feature. The
+# `nonce` feature pulls `getrandom`, which has no default backend on
+# `wasm32-unknown-unknown`, and a response header is not something the wasm client
+# builds anyway.
+csp-shell = { git = "https://github.com/TimSchoenle/csp-shell", tag = "csp-shell-v0.2.0", features = [
+    "cloudflare",
+] }
+
 # Typst is the resume PDF engine, embedded as a library so the generator stays
 # a self-contained `cargo run` (no external binary in CI/Docker). It emits a
 # tagged, standard PDF 1.7 with subsetted fonts and live links.

--- a/Dockerfile
+++ b/Dockerfile
@@ -204,6 +204,16 @@ WORKDIR /app
 #   PORTFOLIO_ISR__CACHE_DIR=/tmp/isr  # empty disables ISR
 #   PORTFOLIO_ISR__TTL_SECS=0          # 0/unset = permanent; positive = finite TTL
 #   PORTFOLIO_ASSETS__DIST_DIR=public  # what the readiness probe checks
+#
+# The Content-Security-Policy is built per document from the inline scripts that
+# document carries, with a per-response nonce for the script Cloudflare's bot
+# products inject at the edge. The ISR cache above is unaffected: it stores the
+# body, and the nonce lives only in the response header, minted after the cached
+# render is read. Both keys default to on and move together — see README.md.
+#   PORTFOLIO_CSP__HASH_INLINE_SCRIPTS=true       # false restores 'unsafe-inline'
+#   PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE=true  # false drops the edge nonce
+#   PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE=false    # admit the Turnstile widget
+#   PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS=false
 ENV PORT=8080 \
     IP=0.0.0.0 \
     RUST_LOG=info \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ a distroless container.
 - [Deployment](#deployment)
   - [Probe Endpoints](#probe-endpoints)
   - [Read-only and Security Posture](#read-only-and-security-posture)
+  - [Content-Security-Policy](#content-security-policy)
   - [Reproducible Builds](#reproducible-builds)
 - [Project Data (`repos.json`)](#project-data-reposjson)
 - [Contributing](#contributing)
@@ -72,7 +73,9 @@ applications.
 - Server-side rendering with WASM hydration; per-route `<head>` metadata, JSON-LD,
   and server-negotiated locale for the first paint
 - SEO: meta/OG tags, JSON-LD, `robots.txt`, `sitemap.xml`, and a web manifest
-- Security headers (CSP, HSTS, and others) set by the server
+- Security headers set by the server: HSTS, `Referrer-Policy`, `Permissions-Policy`,
+  and a Content-Security-Policy built per document from the inline scripts it
+  actually carries, with a per-response nonce for Cloudflare's edge injection
 - WASM client tuned for size: `opt-level = "z"`, LTO, and a single codegen unit
 
 ## Getting Started
@@ -145,6 +148,10 @@ Every key, its TOML path and its environment spelling:
 | TOML | Environment | Default | Purpose |
 | --- | --- | --- | --- |
 | `assets.dist_dir` | `PORTFOLIO_ASSETS__DIST_DIR` | `public` | Bundle directory the readiness probe checks |
+| `csp.hash_inline_scripts` | `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS` | `true` | Hash the document's inline scripts instead of allowing `'unsafe-inline'` |
+| `csp.cloudflare.script_nonce` | `PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE` | `true` | Per-response nonce for the script Cloudflare injects at the edge |
+| `csp.cloudflare.turnstile` | `PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE` | `false` | Admit the Turnstile widget (`script-src` **and** `frame-src`) |
+| `csp.cloudflare.web_analytics` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS` | `false` | Admit the Cloudflare Web Analytics beacon and its endpoint |
 | `isr.cache_dir` | `PORTFOLIO_ISR__CACHE_DIR` | unset (ISR off; the image sets `/tmp/isr`) | Writable directory rendered pages are cached into |
 | `isr.ttl_secs` | `PORTFOLIO_ISR__TTL_SECS` | `0` (permanent) | Revalidation interval in seconds |
 | `github.username` | `PORTFOLIO_GITHUB__USERNAME` | `CONFIG.github_username` | User whose repositories `update-repos` lists |
@@ -210,13 +217,60 @@ Security Standard:
 - `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`
 - all Linux capabilities dropped, `seccompProfile: RuntimeDefault`
 - HTTP security headers (CSP, HSTS, `X-Content-Type-Options`, `X-Frame-Options`,
-  `Referrer-Policy`, `Permissions-Policy`) set on every response
+  `Referrer-Policy`, `Permissions-Policy`) set on every response — see
+  [Content-Security-Policy](#content-security-policy)
 - listens on `:$PORT` (default `8080`); graceful shutdown on `SIGTERM`
 
 Everything else the server reads comes from the layered configuration described
 under [Configuration](#configuration), so a `ConfigMap` fragment or a `Secret`
 volume is a first-class source rather than something a chart has to flatten into
 environment variables.
+
+### Content-Security-Policy
+
+Built with [csp-shell](https://github.com/TimSchoenle/csp-shell) rather than
+written out as a string, in `apps/web/src/server/csp.rs`. Two policies leave the
+server:
+
+- **Documents** get one derived from the bytes they carry. Dioxus renders its
+  hydration data inline (`window.initial_dioxus_hydration_data="…"`), so its text
+  is only known per response — the body is buffered anyway to stamp `<html lang>`,
+  and each inline script is hashed out of that same string. `'unsafe-inline'` is
+  therefore gone from `script-src`: an injected `<script>` no longer runs just
+  because the hydration bootstrap has to.
+- **Everything else** — assets, the JSON API, the SEO documents — gets a policy
+  that admits no inline script at all, because none of them has any.
+
+`'unsafe-eval'` remains, and only for the one reason it has ever been here:
+`dioxus-web`'s document provider applies `document::Title`, `document::Stylesheet`
+and friends through `new Function(…)`, which throws an uncaught `EvalError`
+without it and freezes client-side navigation.
+
+**Cloudflare.** The bot products in front of this origin (Bot Fight Mode,
+JavaScript Detections, the challenge platform — the `_cf_bm`, `cf_clearance` and
+`cf_chl_rc_*` cookies the privacy page lists) inject an inline `<script>` at the
+edge, after this server has hashed what it rendered. No hash can cover it; a
+nonce can, because Cloudflare parses the `Content-Security-Policy` response
+header and copies the nonce onto what it injects. That is
+`csp.cloudflare.script_nonce`, on by default, and it brings one obligation the
+server discharges — every document is `Cache-Control: no-cache`, so a nonce is
+never shared between readers — and one it cannot:
+
+> **Deployment checklist:** no Cloudflare Cache Rule may cache the shell. A
+> "Cache Everything" rule overrides the origin's `Cache-Control`, pinning one
+> nonce across every reader for the lifetime of the cache entry, and nothing
+> inside this process can see that happening.
+
+Turnstile and Web Analytics are off; switching either on admits its origins in
+the directives that product actually needs them in (Turnstile in `script-src`
+**and** `frame-src` — admitting only the first renders an empty box).
+
+**If a page ever renders blank**, that is the failure mode this design has:
+`PORTFOLIO_CSP__HASH_INLINE_SCRIPTS=false` together with
+`PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE=false` restores `'unsafe-inline'` on a
+restart rather than a redeploy. The two must move together — a browser ignores
+`'unsafe-inline'` as soon as the policy carries a nonce — and supplying one
+without the other fails the boot with a message saying so.
 
 ### Reproducible Builds
 

--- a/apps/web/Cargo.toml
+++ b/apps/web/Cargo.toml
@@ -25,6 +25,9 @@ gloo-timers = { workspace = true, optional = true }
 # re-exports, so layers apply to the router `dioxus::server::router` returns.
 axum = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
+# Builds the `Content-Security-Policy` from the document being served. Native SSR
+# only: it hashes the response body, and its nonce feature needs an OS CSPRNG.
+csp-shell = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 time = { workspace = true, features = ["macros"], optional = true }
@@ -73,6 +76,7 @@ server = [
     "portfolio-data/schema",
     "dep:axum",
     "dep:tower-http",
+    "dep:csp-shell",
     "dep:tracing",
     "dep:schemars",
     "dep:time",

--- a/apps/web/src/server/csp.rs
+++ b/apps/web/src/server/csp.rs
@@ -1,0 +1,438 @@
+//! The `Content-Security-Policy` this server sends, built with `csp-shell`.
+//!
+//! Two policies, because a stylesheet and a document do not need the same one:
+//!
+//! * every response that is **not** a document carries [`SitePolicy::subresource`], which admits
+//!   no inline script at all — a `.css`, a `.woff2`, a PDF or a JSON body has none to admit, and
+//!   an allowance nothing uses is an allowance an HTML-sniffing browser bug could use;
+//! * a document carries [`SitePolicy::apply_to_document`], derived from the HTML about to be sent.
+//!
+//! # Why the document policy is per response
+//!
+//! Dioxus renders inline script into every page: the streaming bootstrap, and
+//! `window.initial_dioxus_hydration_data="…"`, whose text is the serialised state of *that*
+//! render. There is no shell on disk carrying it, so nothing about it is knowable at start-up —
+//! `csp-shell`'s file scanner is the wrong half of the crate here, and [`csp_shell::scan_shell`],
+//! which takes the document's text, is the right one. The body is already buffered for the
+//! `<html lang>` rewrite, so scanning it costs a SHA-256 per inline script and no extra read.
+//!
+//! The alternative — `'unsafe-inline'`, which is what this server sent before — admits an
+//! injected `<script>` exactly as readily as the hydration bootstrap. It remains reachable
+//! through `csp.hash_inline_scripts = false`, because the failure mode of getting hashing wrong
+//! is a blank page rather than a loud one.
+//!
+//! # What Cloudflare adds
+//!
+//! Cloudflare's bot products inject their own inline `<script>` at the edge, *after* this process
+//! has hashed what it renders, so no hash here can cover it. A nonce can: Cloudflare parses the
+//! `Content-Security-Policy` response header and copies the nonce onto what it injects, which is
+//! why nothing is stamped into the document. The other two presets are plain origin allowances,
+//! off unless the deployment turns them on. See `portfolio_config::CloudflareConfig`.
+//!
+//! # Where it differs from the string constant this replaced
+//!
+//! `Csp::spa_wasm` is a tighter starting point than the hand-written header was, so two
+//! directives moved and one had to be put back:
+//!
+//! * `base-uri` is `'none'` rather than `'self'` — this site renders no `<base>` element (Dioxus
+//!   applies a base path by nesting the router, not by emitting a tag), so nothing may set one;
+//! * `img-src` and `font-src` drop the `https:` and `data:` sources the preset adds, since every
+//!   image and every font on this site is served from its own origin;
+//! * `upgrade-insecure-requests` is restored, which the preset does not carry.
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use axum::http::{HeaderMap, HeaderValue, header};
+use csp_shell::{
+    Csp, Directive, ScanWarning, Scheme, Source, SourceDirective, presets::cloudflare,
+};
+use portfolio_config::CspConfig;
+
+/// The policies this server serves, rendered as far ahead of the response as each one can be.
+#[derive(Debug)]
+pub(super) struct SitePolicy {
+    /// For responses that are not documents. Constant, so it is rendered once.
+    subresource: HeaderValue,
+    /// For documents.
+    document: DocumentPolicy,
+    /// Scanner limits already reported, so a steady-state one is logged once rather than on
+    /// every response.
+    ///
+    /// A warning is a property of what the renderer emits, not of a single request, so the
+    /// second occurrence carries no information the first did not — and at any real request rate
+    /// an unconditional `error!` would bury the line it was meant to make visible. Taken only
+    /// when a scan actually warns, which is never in the normal case.
+    reported: Mutex<HashSet<ScanWarning>>,
+}
+
+/// How a document response gets its policy.
+#[derive(Debug, Clone)]
+enum DocumentPolicy {
+    /// `'unsafe-inline'`: nothing depends on the response, so the header is rendered once.
+    Constant(HeaderValue),
+    /// The builder the served document's hashes — and, when Cloudflare's nonce is reserved, a
+    /// freshly minted nonce — are folded into per response.
+    PerResponse(Csp),
+}
+
+impl SitePolicy {
+    /// Build both policies from the configuration.
+    ///
+    /// The configuration is validated before this is reached
+    /// (`portfolio_config::CspConfig::validate`), so the one combination that cannot be served —
+    /// a nonce beside `'unsafe-inline'`, which a browser resolves by ignoring the latter — has
+    /// already failed the boot.
+    pub(super) fn new(config: &CspConfig) -> Self {
+        let base = base_policy(config);
+
+        let subresource = header_value(base.clone().build().headers().content_security_policy);
+        let document = if config.hash_inline_scripts {
+            DocumentPolicy::PerResponse(if config.cloudflare.script_nonce {
+                cloudflare::script_nonce(base)
+            } else {
+                base
+            })
+        } else {
+            DocumentPolicy::Constant(header_value(
+                base.allow_unsafe_inline_script()
+                    .build()
+                    .headers()
+                    .content_security_policy,
+            ))
+        };
+
+        Self {
+            subresource,
+            document,
+            reported: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// The policy for every response that is not a document.
+    ///
+    /// Applied as a layer *outside* the document rewrite and only when the header is absent, so a
+    /// document that has already been given its own policy keeps it.
+    pub(super) fn subresource(&self) -> HeaderValue {
+        self.subresource.clone()
+    }
+
+    /// Give a document response the policy for the HTML it is about to carry.
+    ///
+    /// `html` must be the body as it will be sent: the hashes are computed from it, and a policy
+    /// derived from anything else refuses the scripts it was meant to permit.
+    pub(super) fn apply_to_document(&self, headers: &mut HeaderMap, html: &str) {
+        let (policy, cache_control) = match &self.document {
+            DocumentPolicy::Constant(value) => (value.clone(), None),
+            DocumentPolicy::PerResponse(builder) => {
+                let scan = csp_shell::scan_shell(html);
+                self.report(&scan.warnings);
+
+                // The builder is cloned because rendering consumes it, and the hashes have to go
+                // in before the nonce is spliced. A dozen small allocations against a response
+                // that has already allocated the whole page as a `String`.
+                let rendered = builder.clone().with_scan(&scan).build().headers();
+                (
+                    header_value(rendered.content_security_policy),
+                    rendered.cache_control,
+                )
+            }
+        };
+
+        headers.insert(header::CONTENT_SECURITY_POLICY, policy);
+        // An obligation of the nonce, not a caching preference: a nonce served from a cache is
+        // pinned across every reader for the lifetime of that entry, which is `'unsafe-inline'`
+        // with extra steps. It overrides rather than defers to `cache::set_cache_control` — that
+        // middleware happens to answer `no-cache` for documents already, and this must not
+        // depend on it continuing to.
+        if let Some(value) = cache_control {
+            headers.insert(header::CACHE_CONTROL, HeaderValue::from_static(value));
+        }
+    }
+
+    /// Report each scanner limit the first time a response hits it.
+    ///
+    /// A warning means the hash this server computed is one the browser will not, so a script is
+    /// about to be refused — and the only other evidence is a blank page and a console message
+    /// nobody is watching. Logged at `error` for that reason.
+    ///
+    /// A poisoned lock is ignored rather than propagated: nothing here can panic while it is
+    /// held, and a request must not fail over the bookkeeping for a log line.
+    fn report(&self, warnings: &[ScanWarning]) {
+        if warnings.is_empty() {
+            return;
+        }
+        let Ok(mut reported) = self.reported.lock() else {
+            return;
+        };
+        for warning in warnings {
+            if reported.insert(*warning) {
+                tracing::error!(
+                    %warning,
+                    "inline-script scan hit a scanner limit; the policy may refuse a script this page needs"
+                );
+            }
+        }
+    }
+}
+
+/// The policy both halves start from: everything that does not depend on the response.
+fn base_policy(config: &CspConfig) -> Csp {
+    let base = Csp::spa_wasm()
+        // Every image and every font is served from this origin; the preset's `https:` and
+        // `data:` would admit the whole web and an inline payload for nothing in return.
+        .remove_source(SourceDirective::ImgSrc, &Source::Scheme(Scheme::Https))
+        .remove_source(SourceDirective::FontSrc, &Source::Scheme(Scheme::Data))
+        // `dioxus-web`'s document provider evaluates JavaScript through
+        // `js_sys::Function::new_with_args` (`new Function(…)`) — it is how `document::Title`,
+        // `document::Stylesheet`, `document::Meta` and friends are applied during hydration.
+        // Without this the call throws an uncaught `EvalError` that aborts the wasm client and
+        // freezes client-side navigation. `'wasm-unsafe-eval'`, which the preset already carries,
+        // covers only the module instantiation.
+        .allow_unsafe_eval()
+        .set(Directive::UpgradeInsecureRequests)
+        .expect("upgrade-insecure-requests has no source list to route");
+
+    let base = if config.cloudflare.turnstile {
+        cloudflare::turnstile(base)
+    } else {
+        base
+    };
+    if config.cloudflare.web_analytics {
+        cloudflare::web_analytics(base)
+    } else {
+        base
+    }
+}
+
+/// A rendered policy as a header value.
+///
+/// Infallible in practice and asserted as such: `csp-shell` assembles the value from types that
+/// were checked when they were built, so it is ASCII and carries no `;` the builder did not emit
+/// itself. Serving a document with no policy at all would be the worse outcome of the two.
+fn header_value(policy: String) -> HeaderValue {
+    HeaderValue::try_from(policy)
+        .expect("a rendered policy is a valid header value by construction")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SitePolicy, header};
+    use axum::http::HeaderMap;
+    use portfolio_config::{CloudflareConfig, CspConfig};
+
+    /// A page shaped like the ones Dioxus renders: an external module script, which needs no
+    /// hash, and two inline ones, whose text is only known per response.
+    const PAGE: &str = concat!(
+        "<!DOCTYPE html><html><head><script src=\"/wasm/web.js\"></script>",
+        "<script>window.__streaming = 1;</script></head>",
+        "<body><div id=\"main\"></div>",
+        "<script>window.initial_dioxus_hydration_data=\"abc\";</script></body></html>"
+    );
+
+    fn document_policy(config: &CspConfig, html: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        SitePolicy::new(config).apply_to_document(&mut headers, html);
+        headers
+    }
+
+    fn policy_of(headers: &HeaderMap) -> &str {
+        headers
+            .get(header::CONTENT_SECURITY_POLICY)
+            .expect("a document must carry a policy")
+            .to_str()
+            .expect("the policy is ASCII")
+    }
+
+    /// The directives that carried over from the string constant this replaced, plus the two the
+    /// preset tightened. Asserted on the subresource policy, which is the base both halves share.
+    #[test]
+    fn the_base_policy_states_what_the_site_needs_and_no_more() {
+        let policy = SitePolicy::new(&CspConfig::default()).subresource();
+        let policy = policy.to_str().expect("the policy is ASCII");
+
+        for expected in [
+            "default-src 'self'",
+            "script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'",
+            "style-src 'self' 'unsafe-inline'",
+            "connect-src 'self'",
+            "img-src 'self' data:",
+            "font-src 'self'",
+            "object-src 'none'",
+            "base-uri 'none'",
+            "form-action 'self'",
+            "frame-ancestors 'none'",
+            "upgrade-insecure-requests",
+        ] {
+            assert!(
+                policy.contains(expected),
+                "{expected} missing from {policy}"
+            );
+        }
+        // The preset's own `https:` for images and `data:` for fonts are gone, and nothing
+        // reintroduced a blanket inline-script allowance on a response that has no script at all.
+        assert!(!policy.contains("img-src 'self' https:"), "{policy}");
+        assert!(!policy.contains("font-src 'self' data:"), "{policy}");
+        assert!(!policy.contains("'unsafe-inline'; script"), "{policy}");
+        assert!(!policy.contains("sha256-"), "{policy}");
+    }
+
+    /// The default: one hash per inline script in the document, `'unsafe-inline'` gone, and the
+    /// external script left to `'self'`.
+    #[test]
+    fn a_document_is_hashed_rather_than_admitted_wholesale() {
+        let headers = document_policy(&CspConfig::default(), PAGE);
+        let policy = policy_of(&headers);
+
+        assert_eq!(policy.matches("'sha256-").count(), 2, "{policy}");
+        // `'unsafe-inline'` survives in `style-src`, which the preset sets and no hash covers;
+        // what must be gone is the script-src one.
+        let script_src = policy
+            .split("; ")
+            .find(|d| d.starts_with("script-src"))
+            .expect("script-src is set");
+        assert!(!script_src.contains("'unsafe-inline'"), "{script_src}");
+    }
+
+    /// The same document rendered twice hashes identically, so a policy derived per response is
+    /// still stable for a page that did not change. Only the nonce moves.
+    #[test]
+    fn the_hashes_are_a_function_of_the_document() {
+        let no_nonce = CspConfig {
+            cloudflare: CloudflareConfig {
+                script_nonce: false,
+                ..CloudflareConfig::default()
+            },
+            ..CspConfig::default()
+        };
+        let first = document_policy(&no_nonce, PAGE);
+        let second = document_policy(&no_nonce, PAGE);
+        assert_eq!(policy_of(&first), policy_of(&second));
+
+        // A different document is a different policy, which is the point of deriving it.
+        let other = document_policy(&no_nonce, "<script>other()</script>");
+        assert_ne!(policy_of(&first), policy_of(&other));
+
+        // No nonce reserved means no cache obligation to discharge.
+        assert!(!policy_of(&first).contains("'nonce-"));
+        assert!(!first.contains_key(header::CACHE_CONTROL));
+    }
+
+    /// Cloudflare's edge injection is covered by a nonce that is minted per response and never
+    /// cached — the two halves of the contract, asserted together because either alone is
+    /// `'unsafe-inline'` with extra steps.
+    #[test]
+    fn the_cloudflare_nonce_is_fresh_per_response_and_uncacheable() {
+        let first = document_policy(&CspConfig::default(), PAGE);
+        let second = document_policy(&CspConfig::default(), PAGE);
+
+        assert!(
+            policy_of(&first).contains("'nonce-"),
+            "{}",
+            policy_of(&first)
+        );
+        assert_ne!(
+            policy_of(&first),
+            policy_of(&second),
+            "a nonce reused across responses restricts nothing"
+        );
+        assert_eq!(
+            first
+                .get(header::CACHE_CONTROL)
+                .map(|v| v.to_str().unwrap()),
+            Some("no-cache")
+        );
+    }
+
+    /// A subresource never carries the nonce: it is minted for the document Cloudflare rewrites,
+    /// and handing the same slot to a cacheable asset would pin one value into a shared cache.
+    #[test]
+    fn the_subresource_policy_reserves_no_nonce() {
+        let policy = SitePolicy::new(&CspConfig::default()).subresource();
+        assert!(!policy.to_str().unwrap().contains("'nonce-"));
+    }
+
+    /// The escape hatch, in both directions: `'unsafe-inline'` comes back and every hash goes,
+    /// because a policy carrying both would make the browser ignore the former.
+    #[test]
+    fn turning_hashing_off_restores_unsafe_inline_alone() {
+        let config = CspConfig {
+            hash_inline_scripts: false,
+            cloudflare: CloudflareConfig {
+                script_nonce: false,
+                ..CloudflareConfig::default()
+            },
+        };
+        let headers = document_policy(&config, PAGE);
+        let policy = policy_of(&headers);
+
+        let script_src = policy
+            .split("; ")
+            .find(|d| d.starts_with("script-src"))
+            .expect("script-src is set");
+        assert!(script_src.contains("'unsafe-inline'"), "{script_src}");
+        assert!(!policy.contains("'sha256-"), "{policy}");
+        assert!(!policy.contains("'nonce-"), "{policy}");
+    }
+
+    /// Turnstile needs its origin in two directives — the script that loads the widget and the
+    /// frame the widget renders in. Admitting only the first is the failure the preset exists to
+    /// prevent, and it looks like a working policy.
+    #[test]
+    fn turnstile_admits_its_origin_in_both_directives_it_needs() {
+        let config = CspConfig {
+            cloudflare: CloudflareConfig {
+                turnstile: true,
+                ..CloudflareConfig::default()
+            },
+            ..CspConfig::default()
+        };
+        let policy = SitePolicy::new(&config).subresource();
+        let policy = policy.to_str().unwrap();
+
+        assert!(policy.contains("script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval' https://challenges.cloudflare.com"), "{policy}");
+        assert!(
+            policy.contains("frame-src 'self' https://challenges.cloudflare.com"),
+            "{policy}"
+        );
+        // The frame directive was absent, so the preset seeded it from `default-src` before
+        // appending: creating it empty would have revoked same-origin frames.
+        assert!(!policy.contains("frame-src https://"), "{policy}");
+    }
+
+    /// Web Analytics is two hosts in two directives, and the `static.` prefix on only one of them
+    /// is the detail a hand-written policy gets wrong.
+    #[test]
+    fn web_analytics_admits_the_beacon_and_the_endpoint_it_reports_to() {
+        let config = CspConfig {
+            cloudflare: CloudflareConfig {
+                web_analytics: true,
+                ..CloudflareConfig::default()
+            },
+            ..CspConfig::default()
+        };
+        let policy = SitePolicy::new(&config).subresource();
+        let policy = policy.to_str().unwrap();
+
+        assert!(
+            policy.contains("https://static.cloudflareinsights.com"),
+            "{policy}"
+        );
+        assert!(
+            policy.contains("connect-src 'self' https://cloudflareinsights.com"),
+            "{policy}"
+        );
+    }
+
+    /// A product that is off admits nothing. A preset switched on by default would widen the
+    /// policy for a script this site never loads.
+    #[test]
+    fn a_product_that_is_off_admits_no_origin() {
+        let policy = SitePolicy::new(&CspConfig::default()).subresource();
+        let policy = policy.to_str().unwrap();
+
+        assert!(!policy.contains("cloudflare.com"), "{policy}");
+        assert!(!policy.contains("cloudflareinsights.com"), "{policy}");
+        assert!(!policy.contains("frame-src"), "{policy}");
+    }
+}

--- a/apps/web/src/server/mod.rs
+++ b/apps/web/src/server/mod.rs
@@ -8,6 +8,7 @@
 mod api;
 mod assets;
 mod cache;
+mod csp;
 mod seo;
 
 use std::collections::HashSet;
@@ -23,7 +24,7 @@ use axum::{
     routing::get,
 };
 use dioxus::server::{DioxusRouterExt, IncrementalRendererConfig, ServeConfig};
-use portfolio_config::{AssetsConfig, IsrConfig};
+use portfolio_config::{AssetsConfig, CspConfig, IsrConfig};
 use portfolio_data::LANGUAGES;
 use serde::Deserialize;
 use tower_http::{
@@ -34,28 +35,6 @@ use tower_http::{
     set_header::SetResponseHeaderLayer,
     trace::TraceLayer,
 };
-
-/// Content-Security-Policy. `'unsafe-inline'` covers Dioxus's inline hydration
-/// bootstrap and the serialized-state `<script>`; `'wasm-unsafe-eval'`
-/// instantiates the WASM module. `'unsafe-eval'` is required because
-/// `dioxus-web`'s document provider evaluates JavaScript via `new Function(...)`
-/// (`js_sys::Function::new_with_args`) — this is how `document::Title`,
-/// `document::Stylesheet`, `document::Link`, `document::Meta`, etc. are applied
-/// on the client during hydration. Without it, `new Function` throws an
-/// (uncaught) `EvalError` that aborts the wasm client and freezes client-side
-/// navigation. Server-function calls are same-origin `fetch`, so
-/// `connect-src 'self'` suffices.
-const CSP: &str = "default-src 'self'; \
-     script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; \
-     style-src 'self' 'unsafe-inline'; \
-     font-src 'self'; \
-     img-src 'self' data:; \
-     connect-src 'self'; \
-     object-src 'none'; \
-     base-uri 'self'; \
-     form-action 'self'; \
-     frame-ancestors 'none'; \
-     upgrade-insecure-requests";
 
 /// Everything this server reads from its configuration.
 ///
@@ -73,6 +52,8 @@ struct ServerConfig {
     #[serde(default)]
     assets: AssetsConfig,
     #[serde(default)]
+    csp: CspConfig,
+    #[serde(default)]
     isr: IsrConfig,
 }
 
@@ -89,20 +70,36 @@ const EX_CONFIG: i32 = 78;
 /// be loaded is a start-up failure, not a per-request one, and failing here
 /// means the container never reports ready rather than serving a degraded site.
 pub fn serve() {
-    let config = match portfolio_config::load::<ServerConfig>() {
-        Ok(config) => Arc::new(config),
-        Err(err) => {
-            // Before `dioxus::serve` installs the logger, so `tracing` would
-            // discard this.
-            eprintln!("portfolio: cannot start, the configuration is not usable: {err}");
-            std::process::exit(EX_CONFIG);
-        }
-    };
+    let config = Arc::new(load_config());
 
     dioxus::serve(move || {
         let config = Arc::clone(&config);
         async move { Ok(router(&config)) }
     });
+}
+
+/// Reads the configuration, or ends the process with [`EX_CONFIG`].
+///
+/// Two ways to be unusable, and both are start-up failures: a value that cannot be *loaded* (a
+/// missing file, an unparseable number, one key supplied by two layers), and a set of values that
+/// load individually but cannot be *served* together — see
+/// [`CspConfig::validate`](portfolio_config::CspConfig::validate). Failing here means the
+/// container never reports ready, rather than serving every visitor a blank page.
+fn load_config() -> ServerConfig {
+    // Runs before `dioxus::serve` installs the logger, so `tracing` would discard this.
+    let refuse = |err: &dyn std::fmt::Display| -> ! {
+        eprintln!("portfolio: cannot start, the configuration is not usable: {err}");
+        std::process::exit(EX_CONFIG)
+    };
+
+    let config = match portfolio_config::load::<ServerConfig>() {
+        Ok(config) => config,
+        Err(err) => refuse(&err),
+    };
+    if let Err(err) = config.csp.validate() {
+        refuse(&err);
+    }
+    config
 }
 
 /// The full application router: the Dioxus SSR/asset router with our routes and
@@ -113,36 +110,64 @@ fn router(config: &ServerConfig) -> Router {
         SetResponseHeaderLayer::overriding(name, HeaderValue::from_static(value))
     };
 
+    let policy = Arc::new(csp::SitePolicy::new(&config.csp));
     let (dioxus_app, isr_enabled) = dioxus_app_router(&config.isr);
     let app = dioxus_app
         .merge(api_router(config.assets.clone()))
         .merge(assets::router());
-    // Locale handling for page navigations, innermost so it sees the request
-    // before the router and the response before compression: it stamps the
-    // negotiated language onto `<html lang>`, declares the `Vary` axes the
-    // response actually depends on, and — when ISR is active — tags the URI so
+    // Page handling for navigations, innermost so it sees the request before the
+    // router and the response before compression: it stamps the negotiated
+    // language onto `<html lang>`, declares the `Vary` axes the response actually
+    // depends on, gives the document the Content-Security-Policy derived from the
+    // very bytes it is about to send, and — when ISR is active — tags the URI so
     // the per-path incremental cache keeps a separate entry per language.
-    let app = app.layer(middleware::from_fn_with_state(isr_enabled, localize_page));
+    let app = app.layer(middleware::from_fn_with_state(
+        PageState {
+            isr_enabled,
+            policy: Arc::clone(&policy),
+        },
+        localize_page,
+    ));
 
-    app.layer(static_header(header::CONTENT_SECURITY_POLICY, CSP))
-        .layer(static_header(header::X_CONTENT_TYPE_OPTIONS, "nosniff"))
-        .layer(static_header(header::X_FRAME_OPTIONS, "DENY"))
-        .layer(static_header(header::REFERRER_POLICY, "no-referrer"))
-        .layer(static_header(
-            header::STRICT_TRANSPORT_SECURITY,
-            "max-age=31536000; includeSubDomains; preload",
-        ))
-        .layer(static_header(
-            HeaderName::from_static("permissions-policy"),
-            "camera=(), microphone=(), geolocation=(), interest-cohort=()",
-        ))
-        // Compress text assets per Accept-Encoding; already-encoded payloads are
-        // skipped, so this never double-compresses the SSR HTML.
-        .layer(CompressionLayer::new().compress_when(compression_predicate()))
-        // Assign a `Cache-Control` TTL per asset class, but only when a handler
-        // did not already set one (so the API's own headers win). Runs last.
-        .layer(middleware::from_fn(cache::set_cache_control))
-        .layer(TraceLayer::new_for_http())
+    // The policy for everything that is not a document, and only where the layer
+    // above has not already set a stricter, document-specific one — hence
+    // `if_not_present` rather than the `overriding` every other header uses.
+    app.layer(SetResponseHeaderLayer::if_not_present(
+        header::CONTENT_SECURITY_POLICY,
+        policy.subresource(),
+    ))
+    .layer(static_header(header::X_CONTENT_TYPE_OPTIONS, "nosniff"))
+    .layer(static_header(header::X_FRAME_OPTIONS, "DENY"))
+    .layer(static_header(header::REFERRER_POLICY, "no-referrer"))
+    .layer(static_header(
+        header::STRICT_TRANSPORT_SECURITY,
+        "max-age=31536000; includeSubDomains; preload",
+    ))
+    .layer(static_header(
+        HeaderName::from_static("permissions-policy"),
+        "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+    ))
+    // Compress text assets per Accept-Encoding; already-encoded payloads are
+    // skipped, so this never double-compresses the SSR HTML.
+    .layer(CompressionLayer::new().compress_when(compression_predicate()))
+    // Assign a `Cache-Control` TTL per asset class, but only when a handler
+    // did not already set one (so the API's own headers win). Runs last.
+    .layer(middleware::from_fn(cache::set_cache_control))
+    .layer(TraceLayer::new_for_http())
+}
+
+/// What [`localize_page`] carries per request.
+///
+/// Cloned for every request the middleware sees, so the policy — which owns a rendered header
+/// value and, when hashing is on, the builder each document's hashes are folded into — is behind
+/// an [`Arc`] rather than copied.
+#[derive(Clone)]
+struct PageState {
+    /// Whether the incremental cache is active, and therefore whether the request URI has to
+    /// carry the negotiated locale for the cache to key on.
+    isr_enabled: bool,
+    /// The Content-Security-Policy this server serves. See [`csp`].
+    policy: Arc<csp::SitePolicy>,
 }
 
 /// The response-compression predicate. Starts from tower-http's default (which
@@ -337,6 +362,9 @@ fn ensure_uncacheable_sentinel(dir: &std::path::Path) -> std::io::Result<()> {
 /// 3. The opening `<html>` tag is stamped with `lang`, so the language is
 ///    declared in the very first bytes a crawler or a JavaScript-less reader
 ///    receives rather than only after the client has hydrated.
+/// 4. The document is given its own Content-Security-Policy, derived from the
+///    inline scripts in the very bytes about to be sent (see [`csp`]). It rides
+///    along here because the body has to be buffered for point 3 regardless.
 ///
 /// The decision mirrors `crate::i18n::detect_locale` exactly (both go through
 /// `negotiate_locale`), so the cache key, the `<html lang>` and the HTML
@@ -344,7 +372,7 @@ fn ensure_uncacheable_sentinel(dir: &std::path::Path) -> std::io::Result<()> {
 /// are left untouched (they never hit the incremental cache and carry no
 /// language).
 async fn localize_page(
-    axum::extract::State(isr_enabled): axum::extract::State<bool>,
+    axum::extract::State(state): axum::extract::State<PageState>,
     mut request: axum::extract::Request,
     next: middleware::Next,
 ) -> axum::response::Response {
@@ -372,13 +400,13 @@ async fn localize_page(
     // untagged, language-blind cache entry — whichever locale happened to fill
     // it first. Requests that are not pages map to the sentinel anyway, so
     // tagging them would change nothing.
-    if isr_enabled && is_cacheable_path(request.uri().path()) {
+    if state.isr_enabled && is_cacheable_path(request.uri().path()) {
         *request.uri_mut() = with_locale_query(request.uri(), &locale);
     }
 
     // Whether the response is a page at all is decided by its content type, not
     // by what the request asked for, so the 404 page is localized too.
-    localize_html_response(next.run(request).await, locale).await
+    rewrite_html_response(next.run(request).await, locale, &state.policy).await
 }
 
 /// Largest HTML page body this server will buffer in order to stamp `<html
@@ -387,13 +415,15 @@ async fn localize_page(
 /// large `text/html` response.
 const MAX_HTML_REWRITE_BYTES: usize = 4 * 1024 * 1024;
 
-/// Marks `response` as language-dependent (`Vary`) and stamps `lang="<locale>"`
-/// onto its opening `<html>` tag.
+/// Finishes a document response: marks it language-dependent (`Vary`), stamps
+/// `lang="<locale>"` onto its opening `<html>` tag, and gives it the
+/// Content-Security-Policy derived from the bytes it will actually carry.
 ///
 /// Only `text/html` responses are touched: a request that merely *accepts* HTML
 /// may still be answered with JSON or an asset (a browser navigating straight to
 /// `/api/v1/profile`, say), and those neither vary by language nor have a tag to
-/// annotate. Everything else passes straight through.
+/// annotate. Everything else passes straight through and picks up the
+/// subresource policy from the layer outside this one.
 ///
 /// The tag sits in the first bytes of the document, but the SSR body arrives as
 /// a stream whose chunk boundaries are not ours to rely on, so the page is
@@ -402,9 +432,14 @@ const MAX_HTML_REWRITE_BYTES: usize = 4 * 1024 * 1024;
 /// kilobytes; enabling out-of-order streaming would mean revisiting this. A body
 /// that is unreadable or larger than [`MAX_HTML_REWRITE_BYTES`] fails the
 /// request rather than silently serving a truncated page.
-async fn localize_html_response(
+///
+/// The buffer is what makes the per-document policy affordable too: the inline
+/// scripts are hashed out of the same string, after the `lang` rewrite, so the
+/// hashes describe the response as sent rather than an earlier version of it.
+async fn rewrite_html_response(
     mut response: axum::response::Response,
     locale: String,
+    policy: &csp::SitePolicy,
 ) -> axum::response::Response {
     let is_html = response
         .headers()
@@ -427,11 +462,15 @@ async fn localize_html_response(
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     };
     let Ok(html) = std::str::from_utf8(&bytes) else {
+        // Already broken: a document that is not UTF-8 cannot be scanned for the
+        // scripts a policy would have to admit, so it also keeps the subresource
+        // policy the outer layer supplies rather than a hashed one.
         tracing::error!("page body was not valid UTF-8; serving it unmodified");
         return axum::response::Response::from_parts(parts, Body::from(bytes));
     };
 
     let localized = with_html_lang(html, &locale);
+    policy.apply_to_document(&mut parts.headers, &localized);
     // The rewrite changes the body length, so any `Content-Length` computed
     // before it is now a lie. Drop it and let the new body's known size speak.
     parts.headers.remove(header::CONTENT_LENGTH);
@@ -671,6 +710,14 @@ mod tests {
     async fn json(response: axum::response::Response) -> Value {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// The middleware state, with the policy the deployment's defaults produce.
+    fn page_state(isr_enabled: bool) -> PageState {
+        PageState {
+            isr_enabled,
+            policy: Arc::new(csp::SitePolicy::new(&portfolio_config::CspConfig::default())),
+        }
     }
 
     /// Builds a response with the given content type and a body large enough to
@@ -1073,7 +1120,10 @@ mod tests {
 
         let app = Router::new()
             .route("/", get(echo_uri))
-            .layer(middleware::from_fn_with_state(true, localize_page));
+            .layer(middleware::from_fn_with_state(
+                page_state(true),
+                localize_page,
+            ));
 
         let seen = |accept: Option<&'static str>| {
             let app = app.clone();
@@ -1107,7 +1157,10 @@ mod tests {
         // A request may accept HTML and still be answered with JSON; those do
         // not vary by language and have no tag to stamp.
         let response = api_router(AssetsConfig::default())
-            .layer(middleware::from_fn_with_state(false, localize_page))
+            .layer(middleware::from_fn_with_state(
+                page_state(false),
+                localize_page,
+            ))
             .oneshot(
                 Request::builder()
                     .uri("/api/v1/profile")
@@ -1120,5 +1173,109 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         assert!(!response.headers().contains_key(header::VARY));
+    }
+
+    /// A document's policy is derived from the document: the hash of the inline script it
+    /// carries, the nonce Cloudflare copies onto what it injects at the edge, and the
+    /// `Cache-Control` that keeps that nonce from being shared between readers.
+    ///
+    /// What the directives say belongs to [`csp`] and is tested there; what this pins is that
+    /// the response pipeline actually reaches it, on the same buffered body it rewrites.
+    #[tokio::test]
+    async fn a_page_carries_a_policy_derived_from_its_own_html() {
+        async fn page() -> axum::response::Response {
+            axum::http::Response::builder()
+                .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+                .body(Body::from(
+                    "<!DOCTYPE html><html><body><script>window.x=1;</script></body></html>",
+                ))
+                .unwrap()
+        }
+
+        let response = Router::new()
+            .route("/", get(page))
+            .layer(middleware::from_fn_with_state(
+                page_state(false),
+                localize_page,
+            ))
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let headers = response.headers();
+        let policy = headers
+            .get(header::CONTENT_SECURITY_POLICY)
+            .expect("a document must carry a policy")
+            .to_str()
+            .unwrap();
+        assert!(policy.contains("'sha256-"), "{policy}");
+        assert!(policy.contains("'nonce-"), "{policy}");
+        assert_eq!(headers.get(header::CACHE_CONTROL).unwrap(), "no-cache");
+    }
+
+    /// The document policy survives the layer that supplies the subresource one.
+    ///
+    /// This mirrors the two layers [`router`] puts either side of the page middleware, and it is
+    /// the assumption the whole design rests on: the subresource policy is applied *outside*
+    /// [`localize_page`], so it runs on the way out, after the document already has its own. Only
+    /// `if_not_present` makes that safe — with the `overriding` every other security header uses,
+    /// a document's hashes would be replaced by a policy that admits no inline script at all, and
+    /// every page would render blank.
+    #[tokio::test]
+    async fn the_subresource_layer_does_not_overwrite_a_document_policy() {
+        async fn page() -> axum::response::Response {
+            axum::http::Response::builder()
+                .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+                .body(Body::from(
+                    "<html><body><script>window.x=1;</script></body></html>",
+                ))
+                .unwrap()
+        }
+
+        let state = page_state(false);
+        let subresource = state.policy.subresource();
+        let response = Router::new()
+            .route("/", get(page))
+            .layer(middleware::from_fn_with_state(state, localize_page))
+            .layer(SetResponseHeaderLayer::if_not_present(
+                header::CONTENT_SECURITY_POLICY,
+                subresource.clone(),
+            ))
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        let served = response.headers().get(header::CONTENT_SECURITY_POLICY);
+        assert_ne!(served, Some(&subresource));
+        assert!(
+            served.unwrap().to_str().unwrap().contains("'sha256-"),
+            "the document policy was replaced by the subresource one"
+        );
+    }
+
+    /// A response that is not a document gets no policy here, so the one the outer layer applies
+    /// — which admits no inline script at all — is the one that stands.
+    #[tokio::test]
+    async fn non_documents_are_left_to_the_subresource_policy() {
+        let response = api_router(AssetsConfig::default())
+            .layer(middleware::from_fn_with_state(
+                page_state(false),
+                localize_page,
+            ))
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/profile")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(
+            !response
+                .headers()
+                .contains_key(header::CONTENT_SECURITY_POLICY)
+        );
     }
 }

--- a/config.example.toml
+++ b/config.example.toml
@@ -45,6 +45,60 @@ dist_dir = "public"
 # now fails the boot instead of silently meaning "permanent".
 ttl_secs = 0
 
+# ── the Content-Security-Policy ──────────────────────────────────────────────
+#
+# The policy itself is not configurable: it is built from `csp-shell` in
+# `apps/web/src/server/csp.rs`, where the directives sit next to the reason each
+# one is what it is. What is configurable is the part that depends on the
+# deployment rather than on the code.
+
+[csp]
+# Derive a `'sha256-…'` source for every inline <script> in the document being
+# served, instead of admitting all inline script with `'unsafe-inline'`. The
+# hashes are computed from the response body itself, so they cannot drift from
+# what is sent — Dioxus renders its hydration data inline, and its text is only
+# known per response.
+#
+# Set to false as an escape hatch, not as a preference: it restores
+# `'unsafe-inline'`, which admits an injected <script> exactly as readily as the
+# hydration bootstrap. It exists because the opposite failure is silent — an
+# inline script the scanner does not see is refused by the browser and the page
+# renders blank — and because a development server that injects its own
+# live-reload script downstream of this process is outside what can be hashed
+# here. Turning it off also requires turning `csp.cloudflare.script_nonce` off:
+# a browser ignores `'unsafe-inline'` as soon as the policy carries any nonce,
+# so the combination fails the boot rather than serving a blank page.
+hash_inline_scripts = true
+
+[csp.cloudflare]
+# Reserve a per-response nonce in `script-src` for the inline <script>
+# Cloudflare's bot products (Bot Fight Mode, JavaScript Detections, the
+# challenge platform) inject at the edge — after this server has hashed what it
+# renders, so no hash can cover it. Without the nonce, `script-src` refuses it
+# and the detection silently never runs: bot management looks enabled and does
+# nothing. Cloudflare reads the nonce out of the response header and copies it
+# onto what it injects, so nothing is stamped into the document.
+#
+# On by default because this site is delivered through a Cloudflare Tunnel with
+# those products active. Two conditions come with it: every document is served
+# `Cache-Control: no-cache` (the server does this), and **no Cloudflare Cache
+# Rule may cache the shell** — a "Cache Everything" rule overrides the origin's
+# header and pins one nonce across every reader, which nothing inside this
+# process can detect. That one belongs in the deployment checklist.
+script_nonce = true
+
+# Admit https://challenges.cloudflare.com in `script-src` *and* `frame-src`, for
+# a Turnstile widget rendered in a page this server serves. Off: this site has
+# no form behind a challenge, and a managed-challenge interstitial is a
+# Cloudflare-served document carrying its own policy.
+turnstile = false
+
+# Admit the Cloudflare Web Analytics beacon (https://static.cloudflareinsights.com)
+# and the endpoint it reports to (https://cloudflareinsights.com). Off: this
+# site measures nothing. Only for the manual snippet — the automatic edge
+# injection is an inline script, which is what `script_nonce` above is for.
+web_analytics = false
+
 # ── the update-repos builder (build time only) ───────────────────────────────
 
 [github]

--- a/crates/config/src/csp.rs
+++ b/crates/config/src/csp.rs
@@ -1,0 +1,215 @@
+//! What the served `Content-Security-Policy` has to make room for.
+//!
+//! The policy itself is not configurable — it is built in the SSR server from `csp-shell`, and a
+//! site that could be handed arbitrary directives through a `ConfigMap` would have no policy at
+//! all. What *is* configurable is the small set of facts this crate cannot know: whether the
+//! inline scripts in the served document are covered by their hashes, and which Cloudflare
+//! products are switched on in front of the origin.
+
+use core::fmt;
+
+use serde::Deserialize;
+
+/// How the SSR server builds the `Content-Security-Policy` it sends.
+///
+/// Every field defaults to what this deployment actually runs, so an empty `[csp]` block — or no
+/// block at all — produces the policy the site is meant to serve. The knobs exist for the two
+/// situations a redeploy is too slow for: an inline script the scanner does not see, and a
+/// Cloudflare product switched on or off in the dashboard.
+// No `deny_unknown_fields`, for the reason given on `AssetsConfig`: the `_FILE` indirection keys
+// share this namespace.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CspConfig {
+    /// Derive a `'sha256-…'` source for every inline `<script>` in the document being served,
+    /// instead of admitting all inline script with `'unsafe-inline'`.
+    ///
+    /// On — the default — the server hashes the response body it is about to send, so the only
+    /// inline scripts that run are the ones it rendered itself. That is the whole point of the
+    /// exercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus
+    /// hydration bootstrap.
+    ///
+    /// Off is the escape hatch, and it exists because the failure mode is silent: an inline
+    /// script the scanner does not see is refused by the browser, and the evidence is a blank
+    /// page and a console message nobody is watching. Turning it off restores `'unsafe-inline'`
+    /// through an environment variable and a restart rather than a redeploy. Known cases: a
+    /// development server that injects its own live-reload script downstream of this process,
+    /// and any future renderer change that emits script this server never sees.
+    ///
+    /// The two settings are mutually exclusive in the browser, not merely different: a policy
+    /// carrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch
+    /// here rather than two independent ones.
+    #[serde(default = "CspConfig::default_hash_inline_scripts")]
+    pub hash_inline_scripts: bool,
+
+    /// The Cloudflare products in front of this origin that the policy has to make room for.
+    #[serde(default)]
+    pub cloudflare: CloudflareConfig,
+}
+
+impl CspConfig {
+    /// Hashing is the default; see the field.
+    const fn default_hash_inline_scripts() -> bool {
+        true
+    }
+
+    /// Reject a combination of values that would serve a policy refusing this site's own scripts.
+    ///
+    /// Called at boot, before the listener exists, so the container fails to start rather than
+    /// serving every visitor a blank page.
+    ///
+    /// # Errors
+    ///
+    /// [`CspConfigError::NonceWithoutInlineHashes`] when a nonce is reserved while inline scripts
+    /// are admitted by `'unsafe-inline'`.
+    pub const fn validate(&self) -> Result<(), CspConfigError> {
+        if self.cloudflare.script_nonce && !self.hash_inline_scripts {
+            return Err(CspConfigError::NonceWithoutInlineHashes);
+        }
+        Ok(())
+    }
+}
+
+impl Default for CspConfig {
+    fn default() -> Self {
+        Self {
+            hash_inline_scripts: Self::default_hash_inline_scripts(),
+            cloudflare: CloudflareConfig::default(),
+        }
+    }
+}
+
+/// The Cloudflare products this origin sits behind, as the policy has to see them.
+///
+/// Each field is one `csp-shell` preset. A preset carries the part that is easy to get wrong and
+/// silent when it is: not only which origins a product loads from, but which directives they have
+/// to appear in — admitting Turnstile's script without its frame renders an empty box.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CloudflareConfig {
+    /// Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge.
+    ///
+    /// On by default, because this site is delivered through a Cloudflare Tunnel with the bot
+    /// products active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`
+    /// challenge cookies, which is the observable half of the same feature. Those products inject
+    /// an inline `<script>` into the HTML *after* it leaves this process, so no hash this server
+    /// computes can cover it; `script-src` refuses it and the detection silently never runs.
+    /// Cloudflare's documented answer is to parse the `Content-Security-Policy` response header
+    /// and copy the nonce onto what it injects, so nothing has to be stamped into the document.
+    ///
+    /// It carries one obligation the server discharges (`Cache-Control: no-cache` on every
+    /// document, so a nonce is never shared between readers) and one it cannot: **no Cloudflare
+    /// Cache Rule may cache the shell**. A "Cache Everything" rule overrides the origin's
+    /// `Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing
+    /// inside this process can see that.
+    #[serde(default = "CloudflareConfig::default_script_nonce")]
+    pub script_nonce: bool,
+
+    /// Admit `https://challenges.cloudflare.com` in `script-src` **and** `frame-src`, for a
+    /// Turnstile widget rendered in a page this server serves.
+    ///
+    /// Off: this site has no form behind a challenge. A managed-challenge interstitial needs
+    /// nothing here either — that is a Cloudflare-served document carrying its own policy.
+    #[serde(default)]
+    pub turnstile: bool,
+
+    /// Admit the Cloudflare Web Analytics beacon (`https://static.cloudflareinsights.com`) and the
+    /// endpoint it reports to (`https://cloudflareinsights.com`).
+    ///
+    /// Off: this site measures nothing, which the privacy page states. Only for the *manual*
+    /// snippet — the automatic edge injection is an inline script and needs
+    /// [`script_nonce`](Self::script_nonce) instead.
+    #[serde(default)]
+    pub web_analytics: bool,
+}
+
+impl CloudflareConfig {
+    /// The nonce is the default; see the field.
+    const fn default_script_nonce() -> bool {
+        true
+    }
+}
+
+impl Default for CloudflareConfig {
+    fn default() -> Self {
+        Self {
+            script_nonce: Self::default_script_nonce(),
+            turnstile: false,
+            web_analytics: false,
+        }
+    }
+}
+
+/// A `[csp]` block that cannot be served.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CspConfigError {
+    /// `csp.cloudflare.script_nonce` is on while `csp.hash_inline_scripts` is off.
+    NonceWithoutInlineHashes,
+}
+
+impl fmt::Display for CspConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NonceWithoutInlineHashes => f.write_str(
+                "csp.cloudflare.script_nonce reserves a nonce in script-src, and a browser \
+                 ignores 'unsafe-inline' as soon as the policy carries any nonce or hash — so \
+                 with csp.hash_inline_scripts = false this server's own inline scripts would be \
+                 refused and every page would render blank. Set csp.hash_inline_scripts = true, \
+                 or turn the nonce off",
+            ),
+        }
+    }
+}
+
+impl core::error::Error for CspConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{CloudflareConfig, CspConfig, CspConfigError};
+
+    /// The defaults are the deployment: hashes on, the Cloudflare nonce on, and no origin
+    /// admitted for a product this site does not use. A preset switched on by default would
+    /// widen the policy for a script nobody loads.
+    #[test]
+    fn the_defaults_describe_this_deployment() {
+        let config = CspConfig::default();
+        assert!(config.hash_inline_scripts);
+        assert!(config.cloudflare.script_nonce);
+        assert!(!config.cloudflare.turnstile);
+        assert!(!config.cloudflare.web_analytics);
+        assert_eq!(config.validate(), Ok(()));
+    }
+
+    /// The escape hatch is usable on its own: dropping to `'unsafe-inline'` also has to drop the
+    /// nonce, or the policy it produces refuses the scripts it exists to permit.
+    #[test]
+    fn a_nonce_without_inline_hashes_is_refused() {
+        let config = CspConfig {
+            hash_inline_scripts: false,
+            cloudflare: CloudflareConfig::default(),
+        };
+        assert_eq!(
+            config.validate(),
+            Err(CspConfigError::NonceWithoutInlineHashes)
+        );
+    }
+
+    #[test]
+    fn dropping_the_nonce_makes_the_escape_hatch_valid() {
+        let config = CspConfig {
+            hash_inline_scripts: false,
+            cloudflare: CloudflareConfig {
+                script_nonce: false,
+                ..CloudflareConfig::default()
+            },
+        };
+        assert_eq!(config.validate(), Ok(()));
+    }
+
+    /// The error names both keys, because the operator who reads it has to change one of them.
+    #[test]
+    fn the_refusal_names_the_two_keys_that_conflict() {
+        let message = CspConfigError::NonceWithoutInlineHashes.to_string();
+        assert!(message.contains("csp.cloudflare.script_nonce"));
+        assert!(message.contains("csp.hash_inline_scripts"));
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -16,7 +16,7 @@
 //! This crate owns the *blocks* and the dialect; each binary declares the aggregate it actually
 //! reads, so a struct field is evidence that something consumes it:
 //!
-//! - the SSR server ([`AssetsConfig`], [`IsrConfig`]),
+//! - the SSR server ([`AssetsConfig`], [`CspConfig`], [`IsrConfig`]),
 //! - the `update-repos` builder ([`GithubConfig`]).
 //!
 //! # Why the loader half only
@@ -45,11 +45,13 @@
 //! variable, and each block documents what the alternative reading would have cost.
 
 mod assets;
+mod csp;
 mod github;
 mod isr;
 mod loader;
 
 pub use assets::AssetsConfig;
+pub use csp::{CloudflareConfig, CspConfig, CspConfigError};
 pub use github::GithubConfig;
 pub use isr::IsrConfig;
 pub use loader::{ConfigError, load, terrace};

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -51,12 +51,14 @@ pub fn load<T: DeserializeOwned>() -> Result<T, ConfigError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{GithubConfig, IsrConfig, load};
+    use crate::{CspConfig, GithubConfig, IsrConfig, load};
     use secrecy::ExposeSecret as _;
     use serde::Deserialize;
 
     #[derive(Debug, Deserialize)]
     struct Sample {
+        #[serde(default)]
+        csp: CspConfig,
         #[serde(default)]
         github: GithubConfig,
         #[serde(default)]
@@ -77,9 +79,16 @@ mod tests {
             jail.clear_env();
             jail.set_env("PORTFOLIO_GITHUB__USERNAME", "TimSchoenle");
             jail.set_env("PORTFOLIO_ISR__TTL_SECS", "3600");
+            // Two levels of nesting, which is the deepest key this workspace has and the one
+            // spelling a README table could quietly get wrong.
+            jail.set_env("PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE", "true");
 
             let config: Sample = load().map_err(|e| e.to_string()).unwrap();
             assert_eq!(config.github.username(), Some("TimSchoenle"));
+            assert!(config.csp.cloudflare.turnstile);
+            // Its siblings keep their defaults rather than being reset by the nested override.
+            assert!(config.csp.cloudflare.script_nonce);
+            assert!(config.csp.hash_inline_scripts);
             assert_eq!(
                 config.isr.invalidate_after(),
                 Some(std::time::Duration::from_secs(3600))


### PR DESCRIPTION
## What

Replaces the hand-written `Content-Security-Policy` string constant with a policy built by [csp-shell](https://github.com/TimSchoenle/csp-shell), and puts its Cloudflare presets behind the layered configuration.

Two policies now leave the server:

- **Documents** get one derived from the bytes they carry. The body is already buffered to stamp `<html lang>`, so each inline script is hashed out of that same string — `'unsafe-inline'` is gone from `script-src`.
- **Everything else** (assets, the JSON API, the SEO documents) gets a policy that admits no inline script at all, because none of them has any. Applied as an `if_not_present` layer *outside* the page middleware, so a document keeps the policy it was given.

## Why

`script-src` carried `'unsafe-inline'` because Dioxus renders its hydration data inline (`window.initial_dioxus_hydration_data="…"`) and that text is only known per response. The allowance admits an injected `<script>` exactly as readily as the hydration bootstrap. Hashing the response body removes it without a shell rewrite.

## Cloudflare

Cloudflare's bot products (Bot Fight Mode, JavaScript Detections, the challenge platform) inject their own inline `<script>` **at the edge**, after this process has hashed what it rendered — no hash can cover it, `script-src` refuses it, and the detection silently never runs. A nonce can cover it: Cloudflare parses the response header and copies the nonce onto what it injects, so nothing is stamped into the document.

On by default, because the privacy page already documents the `_cf_bm`, `cf_clearance` and `cf_chl_rc_*` cookies those products set — the observable half of the same feature. Turnstile and Web Analytics stay off; this site uses neither, and a preset switched on by default would widen the policy for a script nobody loads.

| Key | Default | |
| --- | --- | --- |
| `csp.hash_inline_scripts` | `true` | `false` restores `'unsafe-inline'` |
| `csp.cloudflare.script_nonce` | `true` | the edge-injection nonce |
| `csp.cloudflare.turnstile` | `false` | `script-src` **and** `frame-src` |
| `csp.cloudflare.web_analytics` | `false` | the beacon and the endpoint it reports to |

## For the reviewer

**Deployment obligation, not enforceable from inside the process:** no Cloudflare Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's `Cache-Control`, pinning one nonce across every reader for the lifetime of the entry. The server discharges its half (`Cache-Control: no-cache` on every document, taken from `Headers::cache_control` rather than left to the cache middleware). Documented in the README and `config.example.toml`.

**Directives that moved.** `Csp::spa_wasm` is a tighter starting point than the constant was: `base-uri` is now `'none'` (this site renders no `<base>` element — Dioxus applies a base path by nesting the router), `img-src`/`font-src` drop the preset's `https:`/`data:` since every image and font is same-origin, and `upgrade-insecure-requests` is restored. `'unsafe-eval'` stays for the one reason it has ever been here (`dioxus-web`'s document provider applies `document::Title` and friends through `new Function(…)`), now through the crate's named method rather than a string fragment.

**The escape hatch is deliberate.** This failure mode is silent — a script the scanner never saw is refused and the page renders blank with a console message nobody is watching — so `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS=false` restores `'unsafe-inline'` on a restart rather than a redeploy. It must move together with the nonce, since a browser ignores `'unsafe-inline'` as soon as the policy carries one; supplying one without the other fails the boot with `EX_CONFIG` and a message naming both keys.

**csp-shell is pinned by tag**, like `terrace-config`, and is not on crates.io. Server-only via `dep:` under `apps/web`'s `server` feature — its `nonce` feature pulls `getrandom`, which has no default backend on `wasm32-unknown-unknown`.

## Verification

Built the real bundle, ran the SSR binary against it, loaded it in a browser:

- the served page carries three inline scripts and the header three hashes; each matches a SHA-256 computed independently outside the crate — none missing, none extra
- `window.dx_hydrate` is a function and `window.initial_dioxus_hydration_data` is a string in the loaded page, so all three executed; the wasm module loaded and hydrated with **no CSP violation** in the console
- the nonce differs between two requests; subresources carry the hash-free, nonce-free policy
- `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS=false` alone exits `78` with the message naming both keys; with the nonce also off, `'unsafe-inline'` returns

The container smoke test in `build.yaml` now asserts that hash-to-script correspondence, that `script-src` has no `'unsafe-inline'`, and that the nonce is fresh per response — that job is the only place the real bundle is served, and this failure mode is invisible everywhere else.

All `CONTRIBUTING.md` checks pass: `cargo fmt --check`, the workspace tests (59 web + 17 config), and clippy on the wasm, server and workspace targets with `-D warnings`.
