### PR TITLE
feat: generate the README from a template and its config table from the types

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -174,23 +174,7 @@ cargo run -p portfolio-config --features config-schema --example config-schema \
   -- --format markdown
 ```
 
-| Variable | Role | Default | Purpose |
-|---|---|---|---|
-| `PORTFOLIO_CONFIG` | config | `config.toml` | Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order. |
-| `PORTFOLIO_SECRETS_DIR` | secrets dir | — | Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells. |
-
-| TOML | Type | Environment | File indirection | Default | Flags | Purpose |
-|---|---|---|---|---|---|---|
-| `assets.dist_dir` | `PathBuf` | `PORTFOLIO_ASSETS__DIST_DIR` | `PORTFOLIO_ASSETS__DIST_DIR_FILE` | `public` | — | Directory holding the `dx bundle` output, relative to the working directory. |
-| `csp.hash_inline_scripts` | `bool` | `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS` | `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS_FILE` | `true` | — | Hash every inline `<script>` in the document being served instead of admitting all inline script with `'unsafe-inline'`. |
-| `csp.cloudflare.script_nonce` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE` | `PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE_FILE` | `true` | — | Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge. |
-| `csp.cloudflare.turnstile` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE` | `PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE_FILE` | `false` | — | Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile widget. |
-| `csp.cloudflare.web_analytics` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS_FILE` | `false` | — | Admit the Cloudflare Web Analytics beacon and the endpoint it reports to. |
-| `isr.cache_dir` | `PathBuf` | `PORTFOLIO_ISR__CACHE_DIR` | `PORTFOLIO_ISR__CACHE_DIR_FILE` | unset (ISR off; the image sets `/tmp/isr`) | — | Writable directory rendered HTML is cached into. Unset or empty disables ISR. |
-| `isr.ttl_secs` | `u64` | `PORTFOLIO_ISR__TTL_SECS` | `PORTFOLIO_ISR__TTL_SECS_FILE` | `0` (permanent) | — | Revalidation interval in seconds. Zero means a permanent cache. |
-| `github.username` | `String` | `PORTFOLIO_GITHUB__USERNAME` | `PORTFOLIO_GITHUB__USERNAME_FILE` | unset (the site's own `CONFIG.github_username`) | — | User whose repositories to list. |
-| `github.token` | `SecretString` | `PORTFOLIO_GITHUB__TOKEN` | `PORTFOLIO_GITHUB__TOKEN_FILE` | unset | secret | Bearer token lifting the GitHub API rate limit. |
-| `github.repos` | `Vec<String>` | `PORTFOLIO_GITHUB__REPOS` | `PORTFOLIO_GITHUB__REPOS_FILE` | `[]` (every active repository the user owns) | — | Explicit repository set, bypassing the "every active repository" listing and its filtering. |
+{{{configTable}}}
 
 The `config-schema` feature is off in every build that ships, so the derive and
 the `serde_json` it pulls stay out of the image; CI's `--all-features` gates are

--- a/.github/workflows/update-files.yaml
+++ b/.github/workflows/update-files.yaml
@@ -70,3 +70,84 @@ jobs:
               issue_number: context.issue.number,
               body: 'Cargo.lock has been updated to match Cargo.toml.'
             })
+
+  # `README.md` is rendered from `.github/templates/README.md.hbs`, whose one variable is the
+  # configuration reference generated out of the `Describe` derives in `crates/config`. The table
+  # therefore cannot drift from the types: renaming a key renames it in the README, in the same
+  # pull request.
+  #
+  # A job of its own rather than more steps above, and `needs:` rather than parallel, for one
+  # reason: both push to the head branch, and two jobs racing on one ref is a lost commit or a
+  # rejected push. Sequencing also means this renders against the tree the lock-file commit left
+  # behind, so a dependency bump that changes nothing here still produces no second commit.
+  render-readme:
+    name: Ensure README is Rendered from its Template
+    needs: update-lock-file
+    environment:
+      name: ci
+      deployment: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push the rendered README
+      pull-requests: write # to comment on PRs
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Generate Bot Token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ACTIONS_MAINTENANCE_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_MAINTENANCE_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      # The generator reads nothing from the environment, so it produces the same tables here as
+      # on a developer's machine — which is what lets the render step below skip its commit when
+      # the configuration has not changed. Cargo's progress goes to stderr, so stdout is the
+      # document and nothing else; `$(…)` drops its trailing newline, and `--arg` makes it a JSON
+      # string, so the payload is strict JSON on one line whatever the table contains.
+      - name: Generate the configuration reference
+        id: config-schema
+        run: |
+          set -euo pipefail
+          table="$(cargo run -q -p portfolio-config --features config-schema \
+            --example config-schema -- --format markdown)"
+          variables="$(jq -cn --arg table "$table" '{configTable: $table}')"
+          echo "variables=${variables}" >> "$GITHUB_OUTPUT"
+
+      - name: Render and commit the README
+        id: readme
+        uses: TimSchoenle/actions/actions/common/render-template-and-commit@15d83f02081c9dc8a844646199c63792dcccdfa8 # tag=actions-common-render-template-and-commit-v1.1.3
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.config-schema.outputs.variables }}
+          token: ${{ steps.generate_token.outputs.token }}
+          commit_message: 'docs: render README from its template'
+
+      - name: Comment on PR
+        if: steps.readme.outputs.changes_detected == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'README.md has been re-rendered from `.github/templates/README.md.hbs`.'
+            })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,35 @@ cargo clippy -p web --no-default-features --features server -- -D warnings
 cargo clippy -p portfolio-data -p resume-generator -p update-repos -- -D warnings
 ```
 
+## Generated Files
+
+`README.md` is rendered from
+[`.github/templates/README.md.hbs`](.github/templates/README.md.hbs) — edit the
+template, never the README. CI renders it on every pull request and commits the
+result back to the branch, so there is no toolchain to install locally.
+
+Its one variable is the configuration reference, generated from the `Describe`
+derives on the blocks in `crates/config`:
+
+```bash
+cargo run -p portfolio-config --features config-schema --example config-schema \
+  -- --format markdown   # the tables the README embeds
+cargo run -p portfolio-config --features config-schema --example config-schema
+                         # the same thing as the versioned JSON contract
+```
+
+Two rules follow from the table being generated:
+
+- A field's `///` comment is **one summary sentence on one line** — it is copied
+  verbatim into a Markdown table cell. Longer reasoning goes in `//` comments
+  above the field.
+- A new config block only reaches the README once it is listed in the
+  `Documented` aggregate in `crates/config/examples/config-schema.rs`.
+
+The `config-schema` feature is off by default and is never enabled by a build
+that ships; `cargo clippy --all-features --all-targets` is what keeps the
+generator compiling.
+
 ## Translations
 
 All user-visible strings live in `crates/data/i18n/{en,de}.json`. Both files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,12 +4764,24 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.2.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.2.0#46d924c25af6a0e67f657686f996539482e8abe3"
+version = "0.3.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.3.0#7db6ed052dd340ea0e98f500a6c8dba0cebea3ae"
 dependencies = [
  "figment",
  "serde",
+ "serde_json",
+ "terrace-config-macros",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "terrace-config-macros"
+version = "0.3.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.3.0#7db6ed052dd340ea0e98f500a6c8dba0cebea3ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,12 @@ portfolio-data = { path = "crates/data" }
 # half is a supervisor that rebuilds a running service when its files change,
 # which would link tokio, notify and tracing into every consumer. Nothing here
 # needs it — see `crates/config/src/lib.rs` for why.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.2.0", default-features = false, features = [
+#
+# The third feature, `schema`, is not taken here either. It is what generates the
+# configuration reference in `README.md`, and `portfolio-config` turns it on
+# through its own off-by-default `config-schema` feature, so `serde_json`, `syn`
+# and the derive stay out of every binary this workspace ships.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.3.0", default-features = false, features = [
     "loader",
 ] }
 # Keeps the GitHub token out of `Debug` output and off every accidental log

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -4,6 +4,25 @@ version = "2.5.0"
 edition.workspace = true
 publish.workspace = true
 
+# Off by default, and it has to stay that way: `terrace-config/schema` links
+# `serde_json` and compiles a proc macro, neither of which a running binary has
+# any use for. Only `cargo run --example config-schema` and the `--all-features`
+# CI gates ever turn it on, so nothing it costs reaches the image — the
+# Dockerfile builds no feature flags at all.
+#
+# The `#[config(...)]` helper attributes are gated with it rather than left in
+# place: they are the derive's, so a build without the derive fails with
+# `cannot find attribute config` the moment one is unconditional.
+[features]
+config-schema = ["terrace-config/schema"]
+
+# The generator that renders the configuration reference in `README.md`. Listed
+# so `cargo clippy --all-targets --all-features` compiles it, which is the only
+# thing standing between a new config block and a README that silently omits it.
+[[example]]
+name = "config-schema"
+required-features = ["config-schema"]
+
 [dependencies]
 serde.workspace = true
 # The loader itself. This crate owns the *schema* and the Portfolio dialect

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -1,0 +1,137 @@
+//! Dump this workspace's configuration surface for the README generator.
+//!
+//! ```text
+//! cargo run -p portfolio-config --features config-schema --example config-schema \
+//!   -- --format markdown
+//! ```
+//!
+//! `.github/workflows/update-files.yaml` runs exactly that, feeds the result to
+//! `.github/templates/README.md.hbs` as the `configTable` variable, and commits the rendered
+//! `README.md` back to the pull request. The table therefore cannot drift from the types: a key
+//! renamed in `crates/config` is a key renamed in the README, in the same commit.
+//!
+//! Nothing here reads the environment, so the output is the same on a developer's machine and on
+//! a runner where none of the variables it describes are set. That is what makes the render
+//! deterministic enough for the action to skip the commit when nothing changed.
+//!
+//! # Why the root type is here and not in the crate
+//!
+//! `portfolio-config` deliberately owns *blocks* rather than one aggregate: each binary declares
+//! the struct it actually reads, so a field is evidence that something consumes it. A root type
+//! in the library would be a fourth aggregate nobody loads, and would quietly become the place
+//! fields are added "so they appear somewhere".
+//!
+//! The documentation still needs one root, because the operator setting this workspace up reads
+//! one file and one environment — not three. [`Documented`] is that root and only that: it exists
+//! under the `config-schema` feature, it is never loaded, and it is the one place a new block has
+//! to be listed to reach the README.
+
+use std::process::ExitCode;
+
+use portfolio_config::{AssetsConfig, CspConfig, GithubConfig, IsrConfig};
+use serde::Serialize;
+use terrace_config::schema::Describe;
+
+/// Every block this workspace can be configured with, under the path an operator spells it at.
+///
+/// The union of what the SSR server reads (`assets`, `csp`, `isr`) and what the `update-repos`
+/// builder reads (`github`). No binary loads this type; see the module docs.
+#[derive(Default, Serialize, Describe)]
+struct Documented {
+    #[config(nested)]
+    assets: AssetsConfig,
+    #[config(nested)]
+    csp: CspConfig,
+    #[config(nested)]
+    isr: IsrConfig,
+    #[config(nested)]
+    github: GithubConfig,
+}
+
+fn main() -> ExitCode {
+    let options = match Options::from_args() {
+        Ok(options) => options,
+        Err(message) => {
+            eprintln!("{message}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match render(&options) {
+        Ok(rendered) => {
+            println!("{rendered}");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// The schema, rendered as `options` asks for it.
+///
+/// Built through [`portfolio_config::terrace`] rather than a bare dialect, so the two variables
+/// the loader itself reads — `PORTFOLIO_CONFIG` and `PORTFOLIO_SECRETS_DIR` — are reported with
+/// the names *this* workspace configures rather than the ones a default prefix would derive.
+///
+/// The `Default` column comes from a value built here, not from the process environment: the
+/// documentation job runs where none of these variables exist, and that is the point.
+fn render(options: &Options) -> Result<String, portfolio_config::ConfigError> {
+    let schema = portfolio_config::terrace()
+        .schema::<Documented>()
+        .with_defaults_from(&Documented::default())?
+        .subset(&options.only);
+
+    match options.format {
+        Format::Json => schema.to_json(),
+        Format::Markdown => Ok(schema.to_markdown()),
+    }
+}
+
+/// What to emit, and how much of it.
+struct Options {
+    format: Format,
+    /// The subtree to keep. Empty means the whole configuration.
+    only: String,
+}
+
+/// Which rendering to emit.
+enum Format {
+    /// The versioned contract, for a consumer that renders its own tables.
+    Json,
+    /// GitHub-flavoured tables, which is what the README template interpolates.
+    Markdown,
+}
+
+impl Options {
+    /// JSON and everything, unless asked otherwise: those are the outputs that lose nothing.
+    fn from_args() -> Result<Self, String> {
+        let mut options = Self {
+            format: Format::Json,
+            only: String::new(),
+        };
+        let mut args = std::env::args().skip(1);
+        while let Some(flag) = args.next() {
+            match flag.as_str() {
+                "--format" => {
+                    options.format = match args.next().as_deref() {
+                        Some("json") => Format::Json,
+                        Some("markdown" | "md") => Format::Markdown,
+                        Some(other) => return Err(format!("unknown format `{other}`; {USAGE}")),
+                        None => return Err(format!("--format takes a value; {USAGE}")),
+                    };
+                }
+                "--only" => {
+                    options.only = args
+                        .next()
+                        .ok_or_else(|| format!("--only takes a key prefix; {USAGE}"))?;
+                }
+                other => return Err(format!("unknown argument `{other}`; {USAGE}")),
+            }
+        }
+        Ok(options)
+    }
+}
+
+const USAGE: &str = "usage: config-schema [--format json|markdown] [--only <key-prefix>]";

--- a/crates/config/src/assets.rs
+++ b/crates/config/src/assets.rs
@@ -16,9 +16,16 @@ use serde::Deserialize;
 // the file layer supplies. Denying unknown fields would reject exactly the mechanism this
 // migration exists to enable.
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct AssetsConfig {
-    /// Directory holding the `dx bundle` output, relative to the working directory (the image
-    /// runs from `/app`, next to `public/`).
+    // The image runs from `/app`, next to `public/`, so the default resolves without anything
+    // being set. Every `///` line on a field in this crate is one summary sentence on one line:
+    // it is copied verbatim into the README's generated key table, where a second paragraph
+    // becomes a `<br>` in a table cell. The reasoning goes in comments like this one.
+    /// Directory holding the `dx bundle` output, relative to the working directory.
     #[serde(default = "AssetsConfig::default_dist_dir")]
     pub dist_dir: PathBuf,
 }

--- a/crates/config/src/csp.rs
+++ b/crates/config/src/csp.rs
@@ -19,29 +19,32 @@ use serde::Deserialize;
 // No `deny_unknown_fields`, for the reason given on `AssetsConfig`: the `_FILE` indirection keys
 // share this namespace.
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct CspConfig {
-    /// Derive a `'sha256-…'` source for every inline `<script>` in the document being served,
-    /// instead of admitting all inline script with `'unsafe-inline'`.
-    ///
-    /// On — the default — the server hashes the response body it is about to send, so the only
-    /// inline scripts that run are the ones it rendered itself. That is the whole point of the
-    /// exercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus
-    /// hydration bootstrap.
-    ///
-    /// Off is the escape hatch, and it exists because the failure mode is silent: an inline
-    /// script the scanner does not see is refused by the browser, and the evidence is a blank
-    /// page and a console message nobody is watching. Turning it off restores `'unsafe-inline'`
-    /// through an environment variable and a restart rather than a redeploy. Known cases: a
-    /// development server that injects its own live-reload script downstream of this process,
-    /// and any future renderer change that emits script this server never sees.
-    ///
-    /// The two settings are mutually exclusive in the browser, not merely different: a policy
-    /// carrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch
-    /// here rather than two independent ones.
+    // On — the default — the server hashes the response body it is about to send, so the only
+    // inline scripts that run are the ones it rendered itself. That is the whole point of the
+    // exercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus
+    // hydration bootstrap.
+    //
+    // Off is the escape hatch, and it exists because the failure mode is silent: an inline
+    // script the scanner does not see is refused by the browser, and the evidence is a blank
+    // page and a console message nobody is watching. Turning it off restores `'unsafe-inline'`
+    // through an environment variable and a restart rather than a redeploy. Known cases: a
+    // development server that injects its own live-reload script downstream of this process,
+    // and any future renderer change that emits script this server never sees.
+    //
+    // The two settings are mutually exclusive in the browser, not merely different: a policy
+    // carrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch
+    // here rather than two independent ones.
+    /// Hash every inline `<script>` in the document being served instead of admitting all inline script with `'unsafe-inline'`.
     #[serde(default = "CspConfig::default_hash_inline_scripts")]
     pub hash_inline_scripts: bool,
 
     /// The Cloudflare products in front of this origin that the policy has to make room for.
+    #[cfg_attr(feature = "config-schema", config(nested))]
     #[serde(default)]
     pub cloudflare: CloudflareConfig,
 }
@@ -84,39 +87,38 @@ impl Default for CspConfig {
 /// silent when it is: not only which origins a product loads from, but which directives they have
 /// to appear in — admitting Turnstile's script without its frame renders an empty box.
 #[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct CloudflareConfig {
+    // On by default, because this site is delivered through a Cloudflare Tunnel with the bot
+    // products active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`
+    // challenge cookies, which is the observable half of the same feature. Those products inject
+    // an inline `<script>` into the HTML *after* it leaves this process, so no hash this server
+    // computes can cover it; `script-src` refuses it and the detection silently never runs.
+    // Cloudflare's documented answer is to parse the `Content-Security-Policy` response header
+    // and copy the nonce onto what it injects, so nothing has to be stamped into the document.
+    //
+    // It carries one obligation the server discharges (`Cache-Control: no-cache` on every
+    // document, so a nonce is never shared between readers) and one it cannot: no Cloudflare
+    // Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's
+    // `Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing
+    // inside this process can see that.
     /// Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge.
-    ///
-    /// On by default, because this site is delivered through a Cloudflare Tunnel with the bot
-    /// products active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`
-    /// challenge cookies, which is the observable half of the same feature. Those products inject
-    /// an inline `<script>` into the HTML *after* it leaves this process, so no hash this server
-    /// computes can cover it; `script-src` refuses it and the detection silently never runs.
-    /// Cloudflare's documented answer is to parse the `Content-Security-Policy` response header
-    /// and copy the nonce onto what it injects, so nothing has to be stamped into the document.
-    ///
-    /// It carries one obligation the server discharges (`Cache-Control: no-cache` on every
-    /// document, so a nonce is never shared between readers) and one it cannot: **no Cloudflare
-    /// Cache Rule may cache the shell**. A "Cache Everything" rule overrides the origin's
-    /// `Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing
-    /// inside this process can see that.
     #[serde(default = "CloudflareConfig::default_script_nonce")]
     pub script_nonce: bool,
 
-    /// Admit `https://challenges.cloudflare.com` in `script-src` **and** `frame-src`, for a
-    /// Turnstile widget rendered in a page this server serves.
-    ///
-    /// Off: this site has no form behind a challenge. A managed-challenge interstitial needs
-    /// nothing here either — that is a Cloudflare-served document carrying its own policy.
+    // Off: this site has no form behind a challenge. A managed-challenge interstitial needs
+    // nothing here either — that is a Cloudflare-served document carrying its own policy.
+    /// Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile widget.
     #[serde(default)]
     pub turnstile: bool,
 
-    /// Admit the Cloudflare Web Analytics beacon (`https://static.cloudflareinsights.com`) and the
-    /// endpoint it reports to (`https://cloudflareinsights.com`).
-    ///
-    /// Off: this site measures nothing, which the privacy page states. Only for the *manual*
-    /// snippet — the automatic edge injection is an inline script and needs
-    /// [`script_nonce`](Self::script_nonce) instead.
+    // Off: this site measures nothing, which the privacy page states. Only for the *manual*
+    // snippet — the automatic edge injection is an inline script and needs
+    // [`script_nonce`](Self::script_nonce) instead.
+    /// Admit the Cloudflare Web Analytics beacon and the endpoint it reports to.
     #[serde(default)]
     pub web_analytics: bool,
 }

--- a/crates/config/src/github.rs
+++ b/crates/config/src/github.rs
@@ -10,29 +10,46 @@ use serde::Deserialize;
 /// against the lower rate limit, and an empty repository list means "every active repository
 /// this user owns".
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct GithubConfig {
-    /// User whose repositories to list. Unset falls back to `portfolio_data::CONFIG`, which is
-    /// the site's own identity and therefore the only sensible default — resolved by the
-    /// builder rather than here, so this crate stays a schema and does not depend on the site
-    /// data.
+    // Unset falls back to `portfolio_data::CONFIG`, which is the site's own identity and
+    // therefore the only sensible default — resolved by the builder rather than here, so this
+    // crate stays a schema and does not depend on the site data.
+    /// User whose repositories to list.
+    #[cfg_attr(
+        feature = "config-schema",
+        config(note = "the site's own `CONFIG.github_username`")
+    )]
     #[serde(default)]
     pub username: Option<String>,
-    /// Bearer token lifting the GitHub API rate limit. Optional: the listing is public, so an
-    /// unauthenticated build still works, just against the anonymous quota.
-    ///
-    /// This is the one secret in the workspace, and the reason the loader is `terrace-config`:
-    /// supply it as `PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token` (or from a secrets
-    /// directory) so it never enters the process environment, where `/proc/<pid>/environ`, a
-    /// crash dump or a `docker inspect` would carry it.
+    // Optional: the listing is public, so an unauthenticated build still works, just against the
+    // anonymous quota.
+    //
+    // This is the one secret in the workspace, and the reason the loader is `terrace-config`:
+    // supply it as `PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token` (or from a secrets
+    // directory) so it never enters the process environment, where `/proc/<pid>/environ`, a
+    // crash dump or a `docker inspect` would carry it.
+    //
+    // `skip_serializing` rather than an impl: `SecretString` deliberately has no `Serialize`, and
+    // the schema generator serialises the default config to read the `Default` column out of it.
+    // The key still appears in the table — the derive reports it either way — with `unset` for a
+    // default it never had, which is both true and the only safe thing to print.
+    /// Bearer token lifting the GitHub API rate limit.
+    #[cfg_attr(feature = "config-schema", config(secret), serde(skip_serializing))]
     #[serde(default)]
     pub token: Option<SecretString>,
-    /// An explicit repository set, bypassing the "every active repository" listing and its
-    /// archived/blacklisted/stale filtering. Empty means list them all.
-    ///
-    /// Spelled as an array: `repos = ["Portfolio", "actions"]` in TOML, and
-    /// `PORTFOLIO_GITHUB__REPOS=[Portfolio,actions]` in the environment — figment parses the
-    /// bracketed form, and a bare comma-separated string is *not* accepted, so the two
-    /// spellings cannot drift apart.
+    // Spelled as an array: `repos = ["Portfolio", "actions"]` in TOML, and
+    // `PORTFOLIO_GITHUB__REPOS=[Portfolio,actions]` in the environment — figment parses the
+    // bracketed form, and a bare comma-separated string is *not* accepted, so the two spellings
+    // cannot drift apart.
+    /// Explicit repository set, bypassing the "every active repository" listing and its filtering.
+    #[cfg_attr(
+        feature = "config-schema",
+        config(note = "every active repository the user owns")
+    )]
     #[serde(default)]
     pub repos: Vec<String>,
 }

--- a/crates/config/src/isr.rs
+++ b/crates/config/src/isr.rs
@@ -11,20 +11,27 @@ use serde::Deserialize;
 /// that directory turns out not to be writable — the server then renders every request fresh
 /// rather than failing to start.
 #[derive(Debug, Clone, Default, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
 pub struct IsrConfig {
-    /// Writable directory rendered HTML is cached into. Unset (or empty) disables ISR.
-    ///
-    /// Keep it *outside* the bundled `public/` asset tree so those content-hashed assets stay
-    /// immutable. The image points it at a sub-directory of `/tmp`, which the deployment
-    /// already provides as a writable mount even under a read-only root filesystem.
+    // Keep it *outside* the bundled `public/` asset tree so those content-hashed assets stay
+    // immutable. The image points it at a sub-directory of `/tmp`, which the deployment already
+    // provides as a writable mount even under a read-only root filesystem.
+    /// Writable directory rendered HTML is cached into. Unset or empty disables ISR.
+    #[cfg_attr(
+        feature = "config-schema",
+        config(note = "ISR off; the image sets `/tmp/isr`")
+    )]
     #[serde(default)]
     pub cache_dir: Option<PathBuf>,
-    /// Revalidation interval in seconds. `0` — the default — means a permanent cache.
-    ///
-    /// Every page renders from compile-time data, so the only thing that changes the output is
-    /// a new build, which starts from an empty cache anyway. A positive value opts into a
-    /// finite, time-based TTL, which is useful only when a *persistent* cache volume is shared
-    /// across deploys.
+    // Every page renders from compile-time data, so the only thing that changes the output is a
+    // new build, which starts from an empty cache anyway. A positive value opts into a finite,
+    // time-based TTL, which is useful only when a *persistent* cache volume is shared across
+    // deploys.
+    /// Revalidation interval in seconds. Zero means a permanent cache.
+    #[cfg_attr(feature = "config-schema", config(note = "permanent"))]
     #[serde(default)]
     pub ttl_secs: u64,
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -43,6 +43,24 @@
 //! Every accessor in this crate treats an empty or whitespace-only value as though the key had
 //! not been supplied. Container platforms routinely inject `KEY=` for a declared-but-unset
 //! variable, and each block documents what the alternative reading would have cost.
+//!
+//! # The configuration reference in `README.md` is generated from these types
+//!
+//! Every block above derives `terrace_config::schema::Describe` under the off-by-default
+//! `config-schema` feature, and `examples/config-schema.rs` walks it into the table CI renders
+//! into the README. The feature is off in every build that ships, so `serde_json` and the derive
+//! never reach a binary; `cargo clippy --all-features --all-targets` is what keeps the generator
+//! compiling.
+//!
+//! Two consequences for anyone editing this crate:
+//!
+//! - **A field's `///` comment is one summary sentence on one line.** It is copied verbatim into
+//!   a Markdown table cell, where a second paragraph becomes a `<br>`. Longer reasoning goes in
+//!   `//` comments above the field, which is why the blocks below read the way they do.
+//! - **A new block is not documented until it is added to the example's aggregate.** This crate
+//!   deliberately has no root config type — each binary declares the aggregate it reads — so the
+//!   generator declares one of its own, and nothing but that file can notice a block missing
+//!   from it.
 
 mod assets;
 mod csp;


### PR DESCRIPTION
## What

`README.md` is now generated, the same way [helm-charts](https://github.com/TimSchoenle/helm-charts/tree/main/.github/templates) does it, and the configuration section it carries is generated from the Rust types rather than maintained beside them.

- **[`.github/templates/README.md.hbs`](https://github.com/TimSchoenle/Portfolio/blob/claude/readme-template-terrace-config-d9c2fe/.github/templates/README.md.hbs)** is the source. `README.md` is its output — rendered here so the committed file already matches what CI produces.
- A **`render-readme`** job in `.github/workflows/update-files.yaml` renders it with `TimSchoenle/actions/actions/common/render-template-and-commit@…v1.1.3` and commits the result back to the pull request.
- **terrace-config `v0.2.0` → `v0.3.0`**, for its new `schema` feature. Every block in `crates/config` derives `Describe`, and **`crates/config/examples/config-schema.rs`** walks them into the template's one variable, `configTable`.

The generator emits both tables the README embeds: the variables the loader reads before any layer exists, then every key with its TOML path, type, environment spelling, `_FILE` indirection, default, flags and purpose. It reads nothing from the environment, so the render is deterministic and the action skips its commit when nothing changed.

## Why

The key table was hand-written. A renamed field, a new default or a new block was a second edit nobody was forced to make, and the failure is silent — a README documenting `PORTFOLIO_ISR__TTL` for a field now called `ttl_secs` sends an operator to set a variable that does nothing. The table is now the types, so that edit happens in the same commit or not at all.

## The schema feature never reaches a binary

This was a requirement, and it is enforced structurally rather than by convention:

- `portfolio-config` gained an **off-by-default `config-schema` feature**; the `Describe`/`Serialize` derives and every `#[config(...)]` helper attribute are `cfg_attr`-gated behind it.
- The generator is an `[[example]]` with `required-features = ["config-schema"]`.
- The Dockerfile passes no feature flags at all.

Verified: `cargo tree -p portfolio-config -e normal -i terrace-config-macros` finds no such package on a default build, and resolves only under `--features config-schema`. CI's existing `--all-features --all-targets` check/clippy/test gates compile the example, which is what stops it rotting.

## Reviewer notes

**Field doc comments changed shape.** The derive copies a field's *entire* `///` comment into one table cell (newlines become `<br>`), so the multi-paragraph rustdoc on `csp.hash_inline_scripts`, `cloudflare.script_nonce`, `github.token` and the `isr` fields would have produced unreadable cells. Each field now has a one-line `///` summary, with the reasoning moved **verbatim** into `//` comments directly above it. Nothing was deleted; `cargo doc` shows the summary only for those fields. The rule is recorded in `crates/config/src/lib.rs` and `CONTRIBUTING.md`.

**`github.token` takes `#[serde(skip_serializing)]`** under the same feature gate. `SecretString` deliberately has no `Serialize`, and the generator serialises the default config to read the `Default` column. The key is still reported — the derive finds it either way — as `unset` and flagged `secret`, which is both true and the only safe thing to print into documentation.

**The generator declares its own root type.** `crates/config` has no root aggregate by design (each binary declares the struct it reads), so the example declares `Documented` for the documentation and nothing else. The cost: a new config block reaches the README only once it is listed there. That is stated in `lib.rs` and `CONTRIBUTING.md`, and it is the one drift this change does not close.

**`render-readme` uses `needs: update-lock-file`** rather than running in parallel. Both jobs push to the head branch, and two jobs racing one ref is a lost commit or a rejected push.

## Not included

terrace-config's own repo additionally fails a check on `main` when `README.md` does not match its template (`render-template` with `check: true`). Happy to add that in a follow-up — this PR matches the helm-charts pattern of render-and-commit on pull requests.

## Verification

```
cargo fmt --all --check
cargo clippy -p portfolio-config --all-features --all-targets -- -D warnings
cargo test -p portfolio-config --all-features      # 17 passed
cargo check -p portfolio-config                    # default features
cargo check -p update-repos --all-targets          # downstream consumer
```

All clean.
