### PR TITLE
feat: split the config reference per binary and adopt terrace-config v0.4.0

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -7,13 +7,16 @@ Two variables, `serverConfigTable` and `builderConfigTable`, one per binary, fro
     cargo run -p portfolio-config --features config-schema --example config-schema \
       -- --format markdown --scope server
     cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown --scope builder --no-loader-vars
+      -- --format markdown --scope builder
 
 which walk the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
 binaries actually load — and emit each key with its TOML path, type, environment spelling,
-`_FILE` indirection, default and purpose. The server scope leads with the variables the loader
-reads before any layer exists; the builder scope drops them, because they are the same two.
-Both are interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+default and purpose. The server scope leads with the variables the loader reads before any layer
+exists; the builder scope renders keys alone, because they are the same two variables. Both are
+interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+
+Neither table has a `_FILE` column: it is the environment spelling plus a constant suffix, which
+the layer list above the tables already states once.
 
 They are two tables and not one on purpose. A single list of every key reads as though a
 deployment needs a GitHub token; it does not, because `github.*` belongs to a build-time tool

--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -2,15 +2,22 @@
 Template for the repository README. CI renders it on every pull request and commits the result
 to README.md, so edit this file — never README.md itself.
 
-One variable, `configTable`, and it is the output of
+Two variables, `serverConfigTable` and `builderConfigTable`, one per binary, from
 
     cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown
+      -- --format markdown --scope server
+    cargo run -p portfolio-config --features config-schema --example config-schema \
+      -- --format markdown --scope builder --no-loader-vars
 
-which walks the `Describe` derives in `crates/config` and emits both Markdown tables: the
-variables the loader reads before the layers exist, then every configuration key with its TOML
-path, type, environment spelling, `_FILE` indirection, default and purpose. It is interpolated
-through a triple-stash, because it is Markdown to be emitted as-is rather than text to escape.
+which walk the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
+binaries actually load — and emit each key with its TOML path, type, environment spelling,
+`_FILE` indirection, default and purpose. The server scope leads with the variables the loader
+reads before any layer exists; the builder scope drops them, because they are the same two.
+Both are interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+
+They are two tables and not one on purpose. A single list of every key reads as though a
+deployment needs a GitHub token; it does not, because `github.*` belongs to a build-time tool
+that exits during the image build.
 
 That is what keeps the configuration reference honest across a rename: the key table is not a
 copy of the types, it is the types, and a pull request that renames a field arrives with the
@@ -165,16 +172,33 @@ fails the boot instead of one silently winning, because a stale environment
 variable shadowing a rotated mounted secret keeps the process running on the old
 credential.
 
-Both tables below are **generated from the types in `crates/config`** — the two
-variables the loader reads before any layer exists, then every key it can carry.
+The tables below are **generated from the aggregates the binaries load** —
+`ServerConfig` and `BuilderConfig` in `crates/config`. They are split the way the
+binaries are, because the two configurations are not one: what a deployment sets
+and what the image build sets have no overlap at all.
+
 Regenerate them with:
 
 ```bash
 cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format markdown
+  -- --format markdown --scope server
 ```
 
-{{{configTable}}}
+#### What the server reads
+
+The two variables the loader itself reads, then every key `apps/web` loads. This
+is the whole surface a **deployment** configures.
+
+{{{serverConfigTable}}}
+
+#### What the `update-repos` builder reads
+
+`github.*` is read only by the build-time repository lister, which runs during the
+image build and exits. **The server never loads it**, so a deployment needs no
+GitHub token and no `github` block — the Docker build supplies the token as a
+BuildKit secret and nothing survives into the image.
+
+{{{builderConfigTable}}}
 
 The `config-schema` feature is off in every build that ships, so the derive and
 the `serde_json` it pulls stay out of the image; CI's `--all-features` gates are

--- a/.github/workflows/update-files.yaml
+++ b/.github/workflows/update-files.yaml
@@ -115,18 +115,28 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
+      # One run per binary, because the reference is two tables: what a deployment configures
+      # (`ServerConfig`) and what the image build configures (`BuilderConfig`). A single table
+      # would read as though every deployment needs a GitHub token, which none does. The builder
+      # scope drops the loader variables — they are the same two the server scope already listed.
+      #
       # The generator reads nothing from the environment, so it produces the same tables here as
       # on a developer's machine — which is what lets the render step below skip its commit when
       # the configuration has not changed. Cargo's progress goes to stderr, so stdout is the
-      # document and nothing else; `$(…)` drops its trailing newline, and `--arg` makes it a JSON
-      # string, so the payload is strict JSON on one line whatever the table contains.
+      # document and nothing else; `$(…)` drops its trailing newline, and `--arg` makes each a
+      # JSON string, so the payload is strict JSON on one line whatever the tables contain.
       - name: Generate the configuration reference
         id: config-schema
         run: |
           set -euo pipefail
-          table="$(cargo run -q -p portfolio-config --features config-schema \
-            --example config-schema -- --format markdown)"
-          variables="$(jq -cn --arg table "$table" '{configTable: $table}')"
+          generate() {
+            cargo run -q -p portfolio-config --features config-schema \
+              --example config-schema -- --format markdown "$@"
+          }
+          server="$(generate --scope server)"
+          builder="$(generate --scope builder --no-loader-vars)"
+          variables="$(jq -cn --arg server "$server" --arg builder "$builder" \
+            '{serverConfigTable: $server, builderConfigTable: $builder}')"
           echo "variables=${variables}" >> "$GITHUB_OUTPUT"
 
       - name: Render and commit the README

--- a/.github/workflows/update-files.yaml
+++ b/.github/workflows/update-files.yaml
@@ -71,8 +71,8 @@ jobs:
               body: 'Cargo.lock has been updated to match Cargo.toml.'
             })
 
-  # `README.md` is rendered from `.github/templates/README.md.hbs`, whose one variable is the
-  # configuration reference generated out of the `Describe` derives in `crates/config`. The table
+  # `README.md` is rendered from `.github/templates/README.md.hbs`, whose variables are the
+  # configuration reference generated out of the `Describe` derives in `crates/config`. The tables
   # therefore cannot drift from the types: renaming a key renames it in the README, in the same
   # pull request.
   #
@@ -118,7 +118,8 @@ jobs:
       # One run per binary, because the reference is two tables: what a deployment configures
       # (`ServerConfig`) and what the image build configures (`BuilderConfig`). A single table
       # would read as though every deployment needs a GitHub token, which none does. The builder
-      # scope drops the loader variables — they are the same two the server scope already listed.
+      # scope renders its keys alone, since the loader variables it would otherwise repeat are the
+      # same two the server scope already listed.
       #
       # The generator reads nothing from the environment, so it produces the same tables here as
       # on a developer's machine — which is what lets the render step below skip its commit when
@@ -134,7 +135,7 @@ jobs:
               --example config-schema -- --format markdown "$@"
           }
           server="$(generate --scope server)"
-          builder="$(generate --scope builder --no-loader-vars)"
+          builder="$(generate --scope builder)"
           variables="$(jq -cn --arg server "$server" --arg builder "$builder" \
             '{serverConfigTable: $server, builderConfigTable: $builder}')"
           echo "variables=${variables}" >> "$GITHUB_OUTPUT"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ from the `Describe` derives on `ServerConfig` and `BuilderConfig` in
 cargo run -p portfolio-config --features config-schema --example config-schema \
   -- --format markdown --scope server
 cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format markdown --scope builder --no-loader-vars
+  -- --format markdown --scope builder
 cargo run -p portfolio-config --features config-schema --example config-schema
                          # every key, as the versioned JSON contract
 ```
@@ -67,13 +67,13 @@ The split is deliberate: `github.*` is read only by the build-time `update-repos
 tool, and one flat table would tell an operator their deployment needs a GitHub
 token. It does not.
 
-One rule follows from the table being generated: a field's `///` comment is **one
-summary sentence on one line** — it is copied verbatim into a Markdown table cell.
-Longer reasoning goes in `//` comments above the field.
+Document fields the way rustdoc asks: a summary sentence, a blank line, then as
+much reasoning as it takes. Only the summary reaches the table, so nothing has to
+be kept short for the README's sake.
 
-A new config block needs no second registration. Add it to the aggregate the
-binary loads and it is in the README, because that aggregate is what the
-generator describes.
+A new config block needs no registration. Add it to the aggregate the binary
+loads and it is in the README, because that aggregate is what the generator
+describes.
 
 The `config-schema` feature is off by default and is never enabled by a build
 that ships; `cargo clippy --all-features --all-targets` is what keeps the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,23 +50,30 @@ cargo clippy -p portfolio-data -p resume-generator -p update-repos -- -D warning
 template, never the README. CI renders it on every pull request and commits the
 result back to the branch, so there is no toolchain to install locally.
 
-Its one variable is the configuration reference, generated from the `Describe`
-derives on the blocks in `crates/config`:
+Its variables are the configuration reference — one table per binary, generated
+from the `Describe` derives on `ServerConfig` and `BuilderConfig` in
+`crates/config`:
 
 ```bash
 cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format markdown   # the tables the README embeds
+  -- --format markdown --scope server
+cargo run -p portfolio-config --features config-schema --example config-schema \
+  -- --format markdown --scope builder --no-loader-vars
 cargo run -p portfolio-config --features config-schema --example config-schema
-                         # the same thing as the versioned JSON contract
+                         # every key, as the versioned JSON contract
 ```
 
-Two rules follow from the table being generated:
+The split is deliberate: `github.*` is read only by the build-time `update-repos`
+tool, and one flat table would tell an operator their deployment needs a GitHub
+token. It does not.
 
-- A field's `///` comment is **one summary sentence on one line** — it is copied
-  verbatim into a Markdown table cell. Longer reasoning goes in `//` comments
-  above the field.
-- A new config block only reaches the README once it is listed in the
-  `Documented` aggregate in `crates/config/examples/config-schema.rs`.
+One rule follows from the table being generated: a field's `///` comment is **one
+summary sentence on one line** — it is copied verbatim into a Markdown table cell.
+Longer reasoning goes in `//` comments above the field.
+
+A new config block needs no second registration. Add it to the aggregate the
+binary loads and it is in the README, because that aggregate is what the
+generator describes.
 
 The `config-schema` feature is off by default and is never enabled by a build
 that ships; `cargo clippy --all-features --all-targets` is what keeps the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,8 +4764,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.3.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.3.0#7db6ed052dd340ea0e98f500a6c8dba0cebea3ae"
+version = "0.4.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.4.0#ac5c8e31bc384075de00099f8838c375c1df8c23"
 dependencies = [
  "figment",
  "serde",
@@ -4776,8 +4776,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config-macros"
-version = "0.3.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.3.0#7db6ed052dd340ea0e98f500a6c8dba0cebea3ae"
+version = "0.4.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.4.0#ac5c8e31bc384075de00099f8838c375c1df8c23"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ portfolio-data = { path = "crates/data" }
 # configuration reference in `README.md`, and `portfolio-config` turns it on
 # through its own off-by-default `config-schema` feature, so `serde_json`, `syn`
 # and the derive stay out of every binary this workspace ships.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.3.0", default-features = false, features = [
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.4.0", default-features = false, features = [
     "loader",
 ] }
 # Keeps the GitHub token out of `Debug` output and off every accidental log

--- a/README.md
+++ b/README.md
@@ -2,15 +2,22 @@
 Template for the repository README. CI renders it on every pull request and commits the result
 to README.md, so edit this file — never README.md itself.
 
-One variable, `configTable`, and it is the output of
+Two variables, `serverConfigTable` and `builderConfigTable`, one per binary, from
 
     cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown
+      -- --format markdown --scope server
+    cargo run -p portfolio-config --features config-schema --example config-schema \
+      -- --format markdown --scope builder --no-loader-vars
 
-which walks the `Describe` derives in `crates/config` and emits both Markdown tables: the
-variables the loader reads before the layers exist, then every configuration key with its TOML
-path, type, environment spelling, `_FILE` indirection, default and purpose. It is interpolated
-through a triple-stash, because it is Markdown to be emitted as-is rather than text to escape.
+which walk the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
+binaries actually load — and emit each key with its TOML path, type, environment spelling,
+`_FILE` indirection, default and purpose. The server scope leads with the variables the loader
+reads before any layer exists; the builder scope drops them, because they are the same two.
+Both are interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+
+They are two tables and not one on purpose. A single list of every key reads as though a
+deployment needs a GitHub token; it does not, because `github.*` belongs to a build-time tool
+that exits during the image build.
 
 That is what keeps the configuration reference honest across a rename: the key table is not a
 copy of the types, it is the types, and a pull request that renames a field arrives with the
@@ -165,14 +172,22 @@ fails the boot instead of one silently winning, because a stale environment
 variable shadowing a rotated mounted secret keeps the process running on the old
 credential.
 
-Both tables below are **generated from the types in `crates/config`** — the two
-variables the loader reads before any layer exists, then every key it can carry.
+The tables below are **generated from the aggregates the binaries load** —
+`ServerConfig` and `BuilderConfig` in `crates/config`. They are split the way the
+binaries are, because the two configurations are not one: what a deployment sets
+and what the image build sets have no overlap at all.
+
 Regenerate them with:
 
 ```bash
 cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format markdown
+  -- --format markdown --scope server
 ```
+
+#### What the server reads
+
+The two variables the loader itself reads, then every key `apps/web` loads. This
+is the whole surface a **deployment** configures.
 
 | Variable | Role | Default | Purpose |
 |---|---|---|---|
@@ -188,6 +203,16 @@ cargo run -p portfolio-config --features config-schema --example config-schema \
 | `csp.cloudflare.web_analytics` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS_FILE` | `false` | — | Admit the Cloudflare Web Analytics beacon and the endpoint it reports to. |
 | `isr.cache_dir` | `PathBuf` | `PORTFOLIO_ISR__CACHE_DIR` | `PORTFOLIO_ISR__CACHE_DIR_FILE` | unset (ISR off; the image sets `/tmp/isr`) | — | Writable directory rendered HTML is cached into. Unset or empty disables ISR. |
 | `isr.ttl_secs` | `u64` | `PORTFOLIO_ISR__TTL_SECS` | `PORTFOLIO_ISR__TTL_SECS_FILE` | `0` (permanent) | — | Revalidation interval in seconds. Zero means a permanent cache. |
+
+#### What the `update-repos` builder reads
+
+`github.*` is read only by the build-time repository lister, which runs during the
+image build and exits. **The server never loads it**, so a deployment needs no
+GitHub token and no `github` block — the Docker build supplies the token as a
+BuildKit secret and nothing survives into the image.
+
+| TOML | Type | Environment | File indirection | Default | Flags | Purpose |
+|---|---|---|---|---|---|---|
 | `github.username` | `String` | `PORTFOLIO_GITHUB__USERNAME` | `PORTFOLIO_GITHUB__USERNAME_FILE` | unset (the site's own `CONFIG.github_username`) | — | User whose repositories to list. |
 | `github.token` | `SecretString` | `PORTFOLIO_GITHUB__TOKEN` | `PORTFOLIO_GITHUB__TOKEN_FILE` | unset | secret | Bearer token lifting the GitHub API rate limit. |
 | `github.repos` | `Vec<String>` | `PORTFOLIO_GITHUB__REPOS` | `PORTFOLIO_GITHUB__REPOS_FILE` | `[]` (every active repository the user owns) | — | Explicit repository set, bypassing the "every active repository" listing and its filtering. |

--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ Two variables, `serverConfigTable` and `builderConfigTable`, one per binary, fro
     cargo run -p portfolio-config --features config-schema --example config-schema \
       -- --format markdown --scope server
     cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown --scope builder --no-loader-vars
+      -- --format markdown --scope builder
 
 which walk the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
 binaries actually load — and emit each key with its TOML path, type, environment spelling,
-`_FILE` indirection, default and purpose. The server scope leads with the variables the loader
-reads before any layer exists; the builder scope drops them, because they are the same two.
-Both are interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+default and purpose. The server scope leads with the variables the loader reads before any layer
+exists; the builder scope renders keys alone, because they are the same two variables. Both are
+interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+
+Neither table has a `_FILE` column: it is the environment spelling plus a constant suffix, which
+the layer list above the tables already states once.
 
 They are two tables and not one on purpose. A single list of every key reads as though a
 deployment needs a GitHub token; it does not, because `github.*` belongs to a build-time tool
@@ -194,15 +197,15 @@ is the whole surface a **deployment** configures.
 | `PORTFOLIO_CONFIG` | config | `config.toml` | Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order. |
 | `PORTFOLIO_SECRETS_DIR` | secrets dir | — | Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells. |
 
-| TOML | Type | Environment | File indirection | Default | Flags | Purpose |
-|---|---|---|---|---|---|---|
-| `assets.dist_dir` | `PathBuf` | `PORTFOLIO_ASSETS__DIST_DIR` | `PORTFOLIO_ASSETS__DIST_DIR_FILE` | `public` | — | Directory holding the `dx bundle` output, relative to the working directory. |
-| `csp.hash_inline_scripts` | `bool` | `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS` | `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS_FILE` | `true` | — | Hash every inline `<script>` in the document being served instead of admitting all inline script with `'unsafe-inline'`. |
-| `csp.cloudflare.script_nonce` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE` | `PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE_FILE` | `true` | — | Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge. |
-| `csp.cloudflare.turnstile` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE` | `PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE_FILE` | `false` | — | Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile widget. |
-| `csp.cloudflare.web_analytics` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS_FILE` | `false` | — | Admit the Cloudflare Web Analytics beacon and the endpoint it reports to. |
-| `isr.cache_dir` | `PathBuf` | `PORTFOLIO_ISR__CACHE_DIR` | `PORTFOLIO_ISR__CACHE_DIR_FILE` | unset (ISR off; the image sets `/tmp/isr`) | — | Writable directory rendered HTML is cached into. Unset or empty disables ISR. |
-| `isr.ttl_secs` | `u64` | `PORTFOLIO_ISR__TTL_SECS` | `PORTFOLIO_ISR__TTL_SECS_FILE` | `0` (permanent) | — | Revalidation interval in seconds. Zero means a permanent cache. |
+| TOML | Type | Environment | Default | Flags | Purpose |
+|---|---|---|---|---|---|
+| `assets.dist_dir` | `PathBuf` | `PORTFOLIO_ASSETS__DIST_DIR` | `public` | — | Directory holding the `dx bundle` output, relative to the working directory. |
+| `csp.hash_inline_scripts` | `bool` | `PORTFOLIO_CSP__HASH_INLINE_SCRIPTS` | `true` | — | Hash every inline `<script>` in the document being served instead of admitting all inline script with `'unsafe-inline'`. |
+| `csp.cloudflare.script_nonce` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE` | `true` | — | Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge. |
+| `csp.cloudflare.turnstile` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE` | `false` | — | Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile widget. |
+| `csp.cloudflare.web_analytics` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS` | `false` | — | Admit the Cloudflare Web Analytics beacon and the endpoint it reports to. |
+| `isr.cache_dir` | `PathBuf` | `PORTFOLIO_ISR__CACHE_DIR` | unset (ISR off; the image sets `/tmp/isr`) | — | Writable directory rendered HTML is cached into. Unset or empty disables ISR. |
+| `isr.ttl_secs` | `u64` | `PORTFOLIO_ISR__TTL_SECS` | `0` (permanent) | — | Revalidation interval in seconds. Zero means a permanent cache. |
 
 #### What the `update-repos` builder reads
 
@@ -211,11 +214,11 @@ image build and exits. **The server never loads it**, so a deployment needs no
 GitHub token and no `github` block — the Docker build supplies the token as a
 BuildKit secret and nothing survives into the image.
 
-| TOML | Type | Environment | File indirection | Default | Flags | Purpose |
-|---|---|---|---|---|---|---|
-| `github.username` | `String` | `PORTFOLIO_GITHUB__USERNAME` | `PORTFOLIO_GITHUB__USERNAME_FILE` | unset (the site's own `CONFIG.github_username`) | — | User whose repositories to list. |
-| `github.token` | `SecretString` | `PORTFOLIO_GITHUB__TOKEN` | `PORTFOLIO_GITHUB__TOKEN_FILE` | unset | secret | Bearer token lifting the GitHub API rate limit. |
-| `github.repos` | `Vec<String>` | `PORTFOLIO_GITHUB__REPOS` | `PORTFOLIO_GITHUB__REPOS_FILE` | `[]` (every active repository the user owns) | — | Explicit repository set, bypassing the "every active repository" listing and its filtering. |
+| TOML | Type | Environment | Default | Flags | Purpose |
+|---|---|---|---|---|---|
+| `github.username` | `String` | `PORTFOLIO_GITHUB__USERNAME` | unset (the site's own `CONFIG.github_username`) | — | User whose repositories to list. |
+| `github.token` | `SecretString` | `PORTFOLIO_GITHUB__TOKEN` | unset | secret | Bearer token lifting the GitHub API rate limit. |
+| `github.repos` | `Vec<String>` | `PORTFOLIO_GITHUB__REPOS` | `[]` (every active repository the user owns) | — | Explicit repository set, bypassing the "every active repository" listing and its filtering. |
 
 The `config-schema` feature is off in every build that ships, so the derive and
 the `serde_json` it pulls stay out of the image; CI's `--all-features` gates are

--- a/apps/update-repos/src/main.rs
+++ b/apps/update-repos/src/main.rs
@@ -21,7 +21,7 @@
 //! ```
 //!
 //! Configuration is layered (see `portfolio_config`); the keys this binary reads
-//! are the [`GithubConfig`] block:
+//! are the `github` block of [`BuilderConfig`]:
 //!
 //! ```text
 //! PORTFOLIO_GITHUB__USERNAME    user whose repos to fetch
@@ -46,9 +46,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use portfolio_config::GithubConfig;
+use portfolio_config::BuilderConfig;
 use portfolio_data::CONFIG;
-use serde::Deserialize;
 use time::OffsetDateTime;
 
 use crate::builder::ReposBuilder;
@@ -56,17 +55,6 @@ use crate::error::UpdateReposError;
 
 /// Where `repos.json` is committed, relative to the workspace root.
 const DEFAULT_OUTPUT: &str = "apps/web/repos.json";
-
-/// Everything this builder reads from its configuration.
-///
-/// One block, so the aggregate looks redundant — it is not: it is what fixes the
-/// key path to `github.*`, which is the half of the environment spelling
-/// `portfolio_config` cannot decide on this binary's behalf.
-#[derive(Debug, Deserialize)]
-struct Config {
-    #[serde(default)]
-    github: GithubConfig,
-}
 
 fn main() -> ExitCode {
     match run() {
@@ -138,6 +126,6 @@ fn run() -> Result<(), UpdateReposError> {
 /// unauthenticated fetch: silently dropping the token would turn a typo in a
 /// secret's path into an intermittent rate-limit failure much later, in a job
 /// that has nothing to do with the mistake.
-fn config() -> Result<Config, UpdateReposError> {
+fn config() -> Result<BuilderConfig, UpdateReposError> {
     portfolio_config::load().map_err(UpdateReposError::from)
 }

--- a/apps/web/src/server/mod.rs
+++ b/apps/web/src/server/mod.rs
@@ -24,9 +24,8 @@ use axum::{
     routing::get,
 };
 use dioxus::server::{DioxusRouterExt, IncrementalRendererConfig, ServeConfig};
-use portfolio_config::{AssetsConfig, CspConfig, IsrConfig};
+use portfolio_config::{AssetsConfig, IsrConfig, ServerConfig};
 use portfolio_data::LANGUAGES;
-use serde::Deserialize;
 use tower_http::{
     compression::{
         CompressionLayer,
@@ -38,25 +37,6 @@ use tower_http::{
 
 /// Everything this server reads from its configuration.
 ///
-/// The blocks belong to `portfolio-config`, which owns the layering; the
-/// aggregate belongs here, so a field exists exactly when this binary consumes
-/// it. See that crate's docs for the layers and their precedence.
-///
-/// Notably absent: the listen address. `IP`, `PORT` and `RUST_LOG` are the
-/// Dioxus toolchain's contract with the binary — `dx serve` sets them to tell a
-/// development build which port it is being proxied on — so folding them into
-/// the `PORTFOLIO_` namespace would take a name the framework still reads and
-/// leave two sources of truth for one socket.
-#[derive(Debug, Deserialize)]
-struct ServerConfig {
-    #[serde(default)]
-    assets: AssetsConfig,
-    #[serde(default)]
-    csp: CspConfig,
-    #[serde(default)]
-    isr: IsrConfig,
-}
-
 /// Exit code for a configuration the process cannot start with (`EX_CONFIG`
 /// from `sysexits.h`), so an operator can tell a bad config apart from a crash
 /// without reading the logs.

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -22,38 +22,22 @@
 //! cannot express which binary reads a key documents an operational requirement that is not real,
 //! so the roots below are split the way the binaries are.
 //!
-//! # There is no documentation-only type here
+//! # No type is declared here at all
 //!
-//! Both scopes describe the aggregates the binaries actually pass to `portfolio_config::load` —
-//! [`ServerConfig`] and [`BuilderConfig`], which live in `crates/config` for exactly this reason.
+//! Every scope describes an aggregate the binaries actually pass to `portfolio_config::load` —
+//! [`ServerConfig`] or [`BuilderConfig`], which live in `crates/config` for exactly this reason.
 //! Nothing is mirrored, so nothing can drift: a block added to what a binary loads is a block in
 //! the README, and there is no second list to remember.
 //!
-//! [`Documented`] is the one type declared here, and it is a *view* rather than a list.
-//! `#[serde(flatten)]` with `#[config(nested)]` contributes a field's keys at the current level
-//! with no segment of its own, so the union produces exactly the key paths its two halves do —
-//! `assets.dist_dir`, not `server.assets.dist_dir`.
+//! `all` is `Schema::merge` of the two rather than a union type, so even the whole-workspace
+//! document is built out of what the binaries load. A key both halves described would be kept
+//! once and a key described *differently* by each would panic, which is the right answer for a
+//! reference that has to have one.
 
 use std::process::ExitCode;
 
 use portfolio_config::{BuilderConfig, ServerConfig};
-use serde::Serialize;
-use terrace_config::schema::Describe;
-
-/// Every key the workspace can be configured with, in one document.
-///
-/// A flattened view of the two aggregates, for the machine-readable contract — the audience that
-/// wants one document rather than one per binary. See the module docs for why it cannot disagree
-/// with its halves.
-#[derive(Default, Serialize, Describe)]
-struct Documented {
-    #[config(nested)]
-    #[serde(flatten)]
-    server: ServerConfig,
-    #[config(nested)]
-    #[serde(flatten)]
-    builder: BuilderConfig,
-}
+use terrace_config::schema::{Column, Schema};
 
 fn main() -> ExitCode {
     let options = match Options::from_args() {
@@ -85,39 +69,42 @@ fn main() -> ExitCode {
 /// The `Default` column comes from a value built here, not from the process environment: the
 /// documentation job runs where none of these variables exist, and that is the point.
 fn render(options: &Options) -> Result<String, portfolio_config::ConfigError> {
-    let terrace = portfolio_config::terrace();
-    let mut schema = match options.scope {
-        Scope::All => terrace
-            .schema::<Documented>()
-            .with_defaults_from(&Documented::default())?,
-        Scope::Server => terrace
-            .schema::<ServerConfig>()
-            .with_defaults_from(&ServerConfig::default())?,
-        Scope::Builder => terrace
-            .schema::<BuilderConfig>()
-            .with_defaults_from(&BuilderConfig::default())?,
+    let schema = match options.scope {
+        Scope::All => server()?.merge(builder()?),
+        Scope::Server => server()?,
+        Scope::Builder => builder()?,
     };
-
-    // `to_markdown` emits the loader-variable table whenever there is one, and there is no way to
-    // ask for that table on its own. The two variables apply to every binary, so a README
-    // printing them above each scope would repeat itself; clearing them is how a second table
-    // says "these are keys, the variables are up there".
-    if !options.loader_vars {
-        schema.loader.clear();
-    }
 
     match options.format {
         Format::Json => schema.to_json(),
-        Format::Markdown => Ok(schema.to_markdown()),
+        // The loader variables lead the server table and are absent from every other one. They
+        // apply to both binaries, so a page repeating them above each scope would say the same
+        // thing twice; the server scope is where an operator setting a deployment up will be.
+        Format::Markdown => Ok(match options.scope {
+            Scope::All | Scope::Server => schema.to_markdown(),
+            Scope::Builder => schema.to_markdown_keys(Column::DEFAULT),
+        }),
     }
+}
+
+/// The keys the SSR server loads, with the defaults it starts from.
+fn server() -> Result<Schema, portfolio_config::ConfigError> {
+    portfolio_config::terrace()
+        .schema::<ServerConfig>()
+        .with_defaults_from(&ServerConfig::default())
+}
+
+/// The keys the `update-repos` builder loads, with the defaults it starts from.
+fn builder() -> Result<Schema, portfolio_config::ConfigError> {
+    portfolio_config::terrace()
+        .schema::<BuilderConfig>()
+        .with_defaults_from(&BuilderConfig::default())
 }
 
 /// What to emit, and how much of it.
 struct Options {
     format: Format,
     scope: Scope,
-    /// Whether to lead with the variables the loader reads before any layer exists.
-    loader_vars: bool,
 }
 
 /// Which rendering to emit.
@@ -139,12 +126,11 @@ enum Scope {
 }
 
 impl Options {
-    /// Everything, as JSON, with the loader variables: the output that loses nothing.
+    /// Everything, as JSON: the output that loses nothing.
     fn from_args() -> Result<Self, String> {
         let mut options = Self {
             format: Format::Json,
             scope: Scope::All,
-            loader_vars: true,
         };
         let mut args = std::env::args().skip(1);
         while let Some(flag) = args.next() {
@@ -166,7 +152,6 @@ impl Options {
                         None => return Err(format!("--scope takes a value; {USAGE}")),
                     };
                 }
-                "--no-loader-vars" => options.loader_vars = false,
                 other => return Err(format!("unknown argument `{other}`; {USAGE}")),
             }
         }
@@ -174,5 +159,4 @@ impl Options {
     }
 }
 
-const USAGE: &str =
-    "usage: config-schema [--format json|markdown] [--scope all|server|builder] [--no-loader-vars]";
+const USAGE: &str = "usage: config-schema [--format json|markdown] [--scope all|server|builder]";

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -2,50 +2,57 @@
 //!
 //! ```text
 //! cargo run -p portfolio-config --features config-schema --example config-schema \
-//!   -- --format markdown
+//!   -- --format markdown --scope server
 //! ```
 //!
-//! `.github/workflows/update-files.yaml` runs exactly that, feeds the result to
-//! `.github/templates/README.md.hbs` as the `configTable` variable, and commits the rendered
-//! `README.md` back to the pull request. The table therefore cannot drift from the types: a key
-//! renamed in `crates/config` is a key renamed in the README, in the same commit.
+//! `.github/workflows/update-files.yaml` runs it once per scope, feeds the results to
+//! `.github/templates/README.md.hbs`, and commits the rendered `README.md` back to the pull
+//! request. The tables therefore cannot drift from the types: a key renamed in `crates/config`
+//! is a key renamed in the README, in the same commit.
 //!
 //! Nothing here reads the environment, so the output is the same on a developer's machine and on
 //! a runner where none of the variables it describes are set. That is what makes the render
 //! deterministic enough for the action to skip the commit when nothing changed.
 //!
-//! # Why the root type is here and not in the crate
+//! # Why there are scopes
 //!
-//! `portfolio-config` deliberately owns *blocks* rather than one aggregate: each binary declares
-//! the struct it actually reads, so a field is evidence that something consumes it. A root type
-//! in the library would be a fourth aggregate nobody loads, and would quietly become the place
-//! fields are added "so they appear somewhere".
+//! One flat table of every key says that a deployment needs a GitHub token. It does not.
+//! `github.*` belongs to `update-repos`, a build-time tool that lists repositories and exits
+//! during the image build; the SSR server never loads it and never sees it. A reference that
+//! cannot express which binary reads a key documents an operational requirement that is not real,
+//! so the roots below are split the way the binaries are.
 //!
-//! The documentation still needs one root, because the operator setting this workspace up reads
-//! one file and one environment — not three. [`Documented`] is that root and only that: it exists
-//! under the `config-schema` feature, it is never loaded, and it is the one place a new block has
-//! to be listed to reach the README.
+//! # There is no documentation-only type here
+//!
+//! Both scopes describe the aggregates the binaries actually pass to `portfolio_config::load` —
+//! [`ServerConfig`] and [`BuilderConfig`], which live in `crates/config` for exactly this reason.
+//! Nothing is mirrored, so nothing can drift: a block added to what a binary loads is a block in
+//! the README, and there is no second list to remember.
+//!
+//! [`Documented`] is the one type declared here, and it is a *view* rather than a list.
+//! `#[serde(flatten)]` with `#[config(nested)]` contributes a field's keys at the current level
+//! with no segment of its own, so the union produces exactly the key paths its two halves do —
+//! `assets.dist_dir`, not `server.assets.dist_dir`.
 
 use std::process::ExitCode;
 
-use portfolio_config::{AssetsConfig, CspConfig, GithubConfig, IsrConfig};
+use portfolio_config::{BuilderConfig, ServerConfig};
 use serde::Serialize;
 use terrace_config::schema::Describe;
 
-/// Every block this workspace can be configured with, under the path an operator spells it at.
+/// Every key the workspace can be configured with, in one document.
 ///
-/// The union of what the SSR server reads (`assets`, `csp`, `isr`) and what the `update-repos`
-/// builder reads (`github`). No binary loads this type; see the module docs.
+/// A flattened view of the two aggregates, for the machine-readable contract — the audience that
+/// wants one document rather than one per binary. See the module docs for why it cannot disagree
+/// with its halves.
 #[derive(Default, Serialize, Describe)]
 struct Documented {
     #[config(nested)]
-    assets: AssetsConfig,
+    #[serde(flatten)]
+    server: ServerConfig,
     #[config(nested)]
-    csp: CspConfig,
-    #[config(nested)]
-    isr: IsrConfig,
-    #[config(nested)]
-    github: GithubConfig,
+    #[serde(flatten)]
+    builder: BuilderConfig,
 }
 
 fn main() -> ExitCode {
@@ -78,10 +85,26 @@ fn main() -> ExitCode {
 /// The `Default` column comes from a value built here, not from the process environment: the
 /// documentation job runs where none of these variables exist, and that is the point.
 fn render(options: &Options) -> Result<String, portfolio_config::ConfigError> {
-    let schema = portfolio_config::terrace()
-        .schema::<Documented>()
-        .with_defaults_from(&Documented::default())?
-        .subset(&options.only);
+    let terrace = portfolio_config::terrace();
+    let mut schema = match options.scope {
+        Scope::All => terrace
+            .schema::<Documented>()
+            .with_defaults_from(&Documented::default())?,
+        Scope::Server => terrace
+            .schema::<ServerConfig>()
+            .with_defaults_from(&ServerConfig::default())?,
+        Scope::Builder => terrace
+            .schema::<BuilderConfig>()
+            .with_defaults_from(&BuilderConfig::default())?,
+    };
+
+    // `to_markdown` emits the loader-variable table whenever there is one, and there is no way to
+    // ask for that table on its own. The two variables apply to every binary, so a README
+    // printing them above each scope would repeat itself; clearing them is how a second table
+    // says "these are keys, the variables are up there".
+    if !options.loader_vars {
+        schema.loader.clear();
+    }
 
     match options.format {
         Format::Json => schema.to_json(),
@@ -92,8 +115,9 @@ fn render(options: &Options) -> Result<String, portfolio_config::ConfigError> {
 /// What to emit, and how much of it.
 struct Options {
     format: Format,
-    /// The subtree to keep. Empty means the whole configuration.
-    only: String,
+    scope: Scope,
+    /// Whether to lead with the variables the loader reads before any layer exists.
+    loader_vars: bool,
 }
 
 /// Which rendering to emit.
@@ -104,12 +128,23 @@ enum Format {
     Markdown,
 }
 
+/// Whose configuration to report.
+enum Scope {
+    /// Every key in the workspace, which is what a machine-readable contract wants.
+    All,
+    /// The keys the SSR server loads.
+    Server,
+    /// The keys the `update-repos` builder loads.
+    Builder,
+}
+
 impl Options {
-    /// JSON and everything, unless asked otherwise: those are the outputs that lose nothing.
+    /// Everything, as JSON, with the loader variables: the output that loses nothing.
     fn from_args() -> Result<Self, String> {
         let mut options = Self {
             format: Format::Json,
-            only: String::new(),
+            scope: Scope::All,
+            loader_vars: true,
         };
         let mut args = std::env::args().skip(1);
         while let Some(flag) = args.next() {
@@ -122,11 +157,16 @@ impl Options {
                         None => return Err(format!("--format takes a value; {USAGE}")),
                     };
                 }
-                "--only" => {
-                    options.only = args
-                        .next()
-                        .ok_or_else(|| format!("--only takes a key prefix; {USAGE}"))?;
+                "--scope" => {
+                    options.scope = match args.next().as_deref() {
+                        Some("all") => Scope::All,
+                        Some("server") => Scope::Server,
+                        Some("builder") => Scope::Builder,
+                        Some(other) => return Err(format!("unknown scope `{other}`; {USAGE}")),
+                        None => return Err(format!("--scope takes a value; {USAGE}")),
+                    };
                 }
+                "--no-loader-vars" => options.loader_vars = false,
                 other => return Err(format!("unknown argument `{other}`; {USAGE}")),
             }
         }
@@ -134,4 +174,5 @@ impl Options {
     }
 }
 
-const USAGE: &str = "usage: config-schema [--format json|markdown] [--only <key-prefix>]";
+const USAGE: &str =
+    "usage: config-schema [--format json|markdown] [--scope all|server|builder] [--no-loader-vars]";

--- a/crates/config/src/aggregates.rs
+++ b/crates/config/src/aggregates.rs
@@ -1,0 +1,65 @@
+//! What each binary in this workspace loads.
+//!
+//! The rest of this crate owns *blocks*. This module owns the two aggregates that say which
+//! blocks a given binary reads — the mapping the crate docs used to state only as prose.
+//!
+//! They live here rather than in the binaries because the configuration reference in `README.md`
+//! is generated from them. A generator cannot describe a private type in a crate it does not
+//! depend on, so the alternative was a documentation root that *mirrored* each aggregate — and a
+//! mirror can disagree with the thing it mirrors without anything failing, which is exactly the
+//! drift generating the table exists to remove. Documenting the type the binary actually passes
+//! to [`load`](crate::load) is the only version of this with no gap in it.
+//!
+//! A field is still evidence that something consumes it: each struct here is loaded by exactly
+//! one binary, and nothing else constructs one.
+
+use serde::Deserialize;
+
+use crate::{AssetsConfig, CspConfig, GithubConfig, IsrConfig};
+
+/// What the SSR server (`apps/web`) loads.
+///
+/// Notably absent: the listen address. `IP`, `PORT` and `RUST_LOG` are the Dioxus toolchain's
+/// contract with the binary — `dx serve` sets them to tell a development build which port it is
+/// being proxied on — so folding them into the `PORTFOLIO_` namespace would take a name the
+/// framework still reads and leave two sources of truth for one socket.
+#[derive(Debug, Default, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
+pub struct ServerConfig {
+    /// Where the built client bundle is, for the readiness probe.
+    #[cfg_attr(feature = "config-schema", config(nested))]
+    #[serde(default)]
+    pub assets: AssetsConfig,
+    /// What the served `Content-Security-Policy` has to make room for.
+    #[cfg_attr(feature = "config-schema", config(nested))]
+    #[serde(default)]
+    pub csp: CspConfig,
+    /// Where rendered pages are cached, and for how long.
+    #[cfg_attr(feature = "config-schema", config(nested))]
+    #[serde(default)]
+    pub isr: IsrConfig,
+}
+
+/// What the `update-repos` builder loads.
+///
+/// One block, so the aggregate looks redundant — it is not: it is what fixes the key path to
+/// `github.*` rather than to the bare field names underneath.
+///
+/// Nothing the *server* reads belongs here, and that separation is load-bearing rather than
+/// tidy: `github.token` is a build-time credential for a tool that lists repositories and exits
+/// during the image build. A deployment never supplies it, and a reference that could not say so
+/// would document a requirement that does not exist.
+#[derive(Debug, Default, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
+pub struct BuilderConfig {
+    /// Credentials and scope for the build-time repository listing.
+    #[cfg_attr(feature = "config-schema", config(nested))]
+    #[serde(default)]
+    pub github: GithubConfig,
+}

--- a/crates/config/src/assets.rs
+++ b/crates/config/src/assets.rs
@@ -21,11 +21,10 @@ use serde::Deserialize;
     derive(serde::Serialize, terrace_config::schema::Describe)
 )]
 pub struct AssetsConfig {
-    // The image runs from `/app`, next to `public/`, so the default resolves without anything
-    // being set. Every `///` line on a field in this crate is one summary sentence on one line:
-    // it is copied verbatim into the README's generated key table, where a second paragraph
-    // becomes a `<br>` in a table cell. The reasoning goes in comments like this one.
     /// Directory holding the `dx bundle` output, relative to the working directory.
+    ///
+    /// The image runs from `/app`, next to `public/`, so the default resolves without anything
+    /// being set.
     #[serde(default = "AssetsConfig::default_dist_dir")]
     pub dist_dir: PathBuf,
 }

--- a/crates/config/src/csp.rs
+++ b/crates/config/src/csp.rs
@@ -24,22 +24,24 @@ use serde::Deserialize;
     derive(serde::Serialize, terrace_config::schema::Describe)
 )]
 pub struct CspConfig {
-    // On — the default — the server hashes the response body it is about to send, so the only
-    // inline scripts that run are the ones it rendered itself. That is the whole point of the
-    // exercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus
-    // hydration bootstrap.
-    //
-    // Off is the escape hatch, and it exists because the failure mode is silent: an inline
-    // script the scanner does not see is refused by the browser, and the evidence is a blank
-    // page and a console message nobody is watching. Turning it off restores `'unsafe-inline'`
-    // through an environment variable and a restart rather than a redeploy. Known cases: a
-    // development server that injects its own live-reload script downstream of this process,
-    // and any future renderer change that emits script this server never sees.
-    //
-    // The two settings are mutually exclusive in the browser, not merely different: a policy
-    // carrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch
-    // here rather than two independent ones.
-    /// Hash every inline `<script>` in the document being served instead of admitting all inline script with `'unsafe-inline'`.
+    /// Hash every inline `<script>` in the document being served instead of admitting all inline
+    /// script with `'unsafe-inline'`.
+    ///
+    /// On — the default — the server hashes the response body it is about to send, so the only
+    /// inline scripts that run are the ones it rendered itself. That is the whole point of the
+    /// exercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus
+    /// hydration bootstrap.
+    ///
+    /// Off is the escape hatch, and it exists because the failure mode is silent: an inline
+    /// script the scanner does not see is refused by the browser, and the evidence is a blank
+    /// page and a console message nobody is watching. Turning it off restores `'unsafe-inline'`
+    /// through an environment variable and a restart rather than a redeploy. Known cases: a
+    /// development server that injects its own live-reload script downstream of this process,
+    /// and any future renderer change that emits script this server never sees.
+    ///
+    /// The two settings are mutually exclusive in the browser, not merely different: a policy
+    /// carrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch
+    /// here rather than two independent ones.
     #[serde(default = "CspConfig::default_hash_inline_scripts")]
     pub hash_inline_scripts: bool,
 
@@ -92,33 +94,37 @@ impl Default for CspConfig {
     derive(serde::Serialize, terrace_config::schema::Describe)
 )]
 pub struct CloudflareConfig {
-    // On by default, because this site is delivered through a Cloudflare Tunnel with the bot
-    // products active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`
-    // challenge cookies, which is the observable half of the same feature. Those products inject
-    // an inline `<script>` into the HTML *after* it leaves this process, so no hash this server
-    // computes can cover it; `script-src` refuses it and the detection silently never runs.
-    // Cloudflare's documented answer is to parse the `Content-Security-Policy` response header
-    // and copy the nonce onto what it injects, so nothing has to be stamped into the document.
-    //
-    // It carries one obligation the server discharges (`Cache-Control: no-cache` on every
-    // document, so a nonce is never shared between readers) and one it cannot: no Cloudflare
-    // Cache Rule may cache the shell. A "Cache Everything" rule overrides the origin's
-    // `Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing
-    // inside this process can see that.
     /// Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge.
+    ///
+    /// On by default, because this site is delivered through a Cloudflare Tunnel with the bot
+    /// products active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`
+    /// challenge cookies, which is the observable half of the same feature. Those products inject
+    /// an inline `<script>` into the HTML *after* it leaves this process, so no hash this server
+    /// computes can cover it; `script-src` refuses it and the detection silently never runs.
+    /// Cloudflare's documented answer is to parse the `Content-Security-Policy` response header
+    /// and copy the nonce onto what it injects, so nothing has to be stamped into the document.
+    ///
+    /// It carries one obligation the server discharges (`Cache-Control: no-cache` on every
+    /// document, so a nonce is never shared between readers) and one it cannot: **no Cloudflare
+    /// Cache Rule may cache the shell**. A "Cache Everything" rule overrides the origin's
+    /// `Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing
+    /// inside this process can see that.
     #[serde(default = "CloudflareConfig::default_script_nonce")]
     pub script_nonce: bool,
 
-    // Off: this site has no form behind a challenge. A managed-challenge interstitial needs
-    // nothing here either — that is a Cloudflare-served document carrying its own policy.
-    /// Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile widget.
+    /// Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile
+    /// widget.
+    ///
+    /// Off: this site has no form behind a challenge. A managed-challenge interstitial needs
+    /// nothing here either — that is a Cloudflare-served document carrying its own policy.
     #[serde(default)]
     pub turnstile: bool,
 
-    // Off: this site measures nothing, which the privacy page states. Only for the *manual*
-    // snippet — the automatic edge injection is an inline script and needs
-    // [`script_nonce`](Self::script_nonce) instead.
     /// Admit the Cloudflare Web Analytics beacon and the endpoint it reports to.
+    ///
+    /// Off: this site measures nothing, which the privacy page states. Only for the *manual*
+    /// snippet — the automatic edge injection is an inline script and needs
+    /// [`script_nonce`](Self::script_nonce) instead.
     #[serde(default)]
     pub web_analytics: bool,
 }

--- a/crates/config/src/github.rs
+++ b/crates/config/src/github.rs
@@ -15,37 +15,41 @@ use serde::Deserialize;
     derive(serde::Serialize, terrace_config::schema::Describe)
 )]
 pub struct GithubConfig {
-    // Unset falls back to `portfolio_data::CONFIG`, which is the site's own identity and
-    // therefore the only sensible default — resolved by the builder rather than here, so this
-    // crate stays a schema and does not depend on the site data.
     /// User whose repositories to list.
+    ///
+    /// Unset falls back to `portfolio_data::CONFIG`, which is the site's own identity and
+    /// therefore the only sensible default — resolved by the builder rather than here, so this
+    /// crate stays a schema and does not depend on the site data.
     #[cfg_attr(
         feature = "config-schema",
         config(note = "the site's own `CONFIG.github_username`")
     )]
     #[serde(default)]
     pub username: Option<String>,
-    // Optional: the listing is public, so an unauthenticated build still works, just against the
-    // anonymous quota.
-    //
-    // This is the one secret in the workspace, and the reason the loader is `terrace-config`:
-    // supply it as `PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token` (or from a secrets
-    // directory) so it never enters the process environment, where `/proc/<pid>/environ`, a
-    // crash dump or a `docker inspect` would carry it.
-    //
-    // `skip_serializing` rather than an impl: `SecretString` deliberately has no `Serialize`, and
-    // the schema generator serialises the default config to read the `Default` column out of it.
-    // The key still appears in the table — the derive reports it either way — with `unset` for a
-    // default it never had, which is both true and the only safe thing to print.
     /// Bearer token lifting the GitHub API rate limit.
-    #[cfg_attr(feature = "config-schema", config(secret), serde(skip_serializing))]
-    #[serde(default)]
+    ///
+    /// Optional: the listing is public, so an unauthenticated build still works, just against the
+    /// anonymous quota.
+    ///
+    /// This is the one secret in the workspace, and the reason the loader is `terrace-config`:
+    /// supply it as `PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token` (or from a secrets
+    /// directory) so it never enters the process environment, where `/proc/<pid>/environ`, a
+    /// crash dump or a `docker inspect` would carry it.
+    ///
+    /// `skip_serializing` rather than an impl: [`SecretString`] deliberately has no `Serialize`,
+    /// and the schema generator serialises the default config to read the `Default` column out of
+    /// it. The key still appears in the table — the derive reports it either way — with `unset`
+    /// for a default it never had, which is both true and the only safe thing to print. This is
+    /// the pattern `terrace-config` documents for a secret-bearing field.
+    #[cfg_attr(feature = "config-schema", config(secret))]
+    #[serde(default, skip_serializing)]
     pub token: Option<SecretString>,
-    // Spelled as an array: `repos = ["Portfolio", "actions"]` in TOML, and
-    // `PORTFOLIO_GITHUB__REPOS=[Portfolio,actions]` in the environment — figment parses the
-    // bracketed form, and a bare comma-separated string is *not* accepted, so the two spellings
-    // cannot drift apart.
     /// Explicit repository set, bypassing the "every active repository" listing and its filtering.
+    ///
+    /// Spelled as an array: `repos = ["Portfolio", "actions"]` in TOML, and
+    /// `PORTFOLIO_GITHUB__REPOS=[Portfolio,actions]` in the environment — figment parses the
+    /// bracketed form, and a bare comma-separated string is *not* accepted, so the two spellings
+    /// cannot drift apart.
     #[cfg_attr(
         feature = "config-schema",
         config(note = "every active repository the user owns")

--- a/crates/config/src/isr.rs
+++ b/crates/config/src/isr.rs
@@ -16,21 +16,23 @@ use serde::Deserialize;
     derive(serde::Serialize, terrace_config::schema::Describe)
 )]
 pub struct IsrConfig {
-    // Keep it *outside* the bundled `public/` asset tree so those content-hashed assets stay
-    // immutable. The image points it at a sub-directory of `/tmp`, which the deployment already
-    // provides as a writable mount even under a read-only root filesystem.
     /// Writable directory rendered HTML is cached into. Unset or empty disables ISR.
+    ///
+    /// Keep it *outside* the bundled `public/` asset tree so those content-hashed assets stay
+    /// immutable. The image points it at a sub-directory of `/tmp`, which the deployment already
+    /// provides as a writable mount even under a read-only root filesystem.
     #[cfg_attr(
         feature = "config-schema",
         config(note = "ISR off; the image sets `/tmp/isr`")
     )]
     #[serde(default)]
     pub cache_dir: Option<PathBuf>,
-    // Every page renders from compile-time data, so the only thing that changes the output is a
-    // new build, which starts from an empty cache anyway. A positive value opts into a finite,
-    // time-based TTL, which is useful only when a *persistent* cache volume is shared across
-    // deploys.
     /// Revalidation interval in seconds. Zero means a permanent cache.
+    ///
+    /// Every page renders from compile-time data, so the only thing that changes the output is a
+    /// new build, which starts from an empty cache anyway. A positive value opts into a finite,
+    /// time-based TTL, which is useful only when a *persistent* cache volume is shared across
+    /// deploys.
     #[cfg_attr(feature = "config-schema", config(note = "permanent"))]
     #[serde(default)]
     pub ttl_secs: u64,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -56,13 +56,13 @@
 //! every build that ships, so `serde_json` and the derive never reach a binary;
 //! `cargo clippy --all-features --all-targets` is what keeps the generator compiling.
 //!
-//! One consequence for anyone editing this crate: **a field's `///` comment is one summary
-//! sentence on one line.** It is copied verbatim into a Markdown table cell, where a second
-//! paragraph becomes a `<br>`. Longer reasoning goes in `//` comments above the field, which is
-//! why the blocks below read the way they do.
+//! Write field documentation as rustdoc asks for it: a summary sentence, a blank line, then as
+//! much reasoning as it takes. Only the summary reaches the Markdown table — `to_json` carries
+//! the whole comment for anything that wants the rest — so nothing has to be kept short for the
+//! README's sake, and nothing has to be annotated twice.
 //!
-//! A new block needs no second registration anywhere — adding it to the aggregate that loads it
-//! is what puts it in the README, because that aggregate is what the generator describes.
+//! A new block needs no registration anywhere — adding it to the aggregate that loads it is what
+//! puts it in the README, because that aggregate is what the generator describes.
 
 mod aggregates;
 mod assets;

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -13,11 +13,14 @@
 //!
 //! # What each binary composes
 //!
-//! This crate owns the *blocks* and the dialect; each binary declares the aggregate it actually
-//! reads, so a struct field is evidence that something consumes it:
+//! This crate owns the *blocks*, the dialect, and one aggregate per binary naming the blocks that
+//! binary reads — so a struct field is evidence that something consumes it:
 //!
-//! - the SSR server ([`AssetsConfig`], [`CspConfig`], [`IsrConfig`]),
-//! - the `update-repos` builder ([`GithubConfig`]).
+//! - the SSR server, [`ServerConfig`] ([`AssetsConfig`], [`CspConfig`], [`IsrConfig`]),
+//! - the `update-repos` builder, [`BuilderConfig`] ([`GithubConfig`]).
+//!
+//! The aggregates live here rather than in the binaries so the generated configuration reference
+//! can describe the types those binaries actually load; see [`aggregates`].
 //!
 //! # Why the loader half only
 //!
@@ -46,28 +49,29 @@
 //!
 //! # The configuration reference in `README.md` is generated from these types
 //!
-//! Every block above derives `terrace_config::schema::Describe` under the off-by-default
-//! `config-schema` feature, and `examples/config-schema.rs` walks it into the table CI renders
-//! into the README. The feature is off in every build that ships, so `serde_json` and the derive
-//! never reach a binary; `cargo clippy --all-features --all-targets` is what keeps the generator
-//! compiling.
+//! Every block and aggregate above derives `terrace_config::schema::Describe` under the
+//! off-by-default `config-schema` feature, and `examples/config-schema.rs` walks them into the
+//! tables CI renders into the README — one per aggregate, so the reference says which binary
+//! reads a key rather than implying every deployment needs all of them. The feature is off in
+//! every build that ships, so `serde_json` and the derive never reach a binary;
+//! `cargo clippy --all-features --all-targets` is what keeps the generator compiling.
 //!
-//! Two consequences for anyone editing this crate:
+//! One consequence for anyone editing this crate: **a field's `///` comment is one summary
+//! sentence on one line.** It is copied verbatim into a Markdown table cell, where a second
+//! paragraph becomes a `<br>`. Longer reasoning goes in `//` comments above the field, which is
+//! why the blocks below read the way they do.
 //!
-//! - **A field's `///` comment is one summary sentence on one line.** It is copied verbatim into
-//!   a Markdown table cell, where a second paragraph becomes a `<br>`. Longer reasoning goes in
-//!   `//` comments above the field, which is why the blocks below read the way they do.
-//! - **A new block is not documented until it is added to the example's aggregate.** This crate
-//!   deliberately has no root config type — each binary declares the aggregate it reads — so the
-//!   generator declares one of its own, and nothing but that file can notice a block missing
-//!   from it.
+//! A new block needs no second registration anywhere — adding it to the aggregate that loads it
+//! is what puts it in the README, because that aggregate is what the generator describes.
 
+mod aggregates;
 mod assets;
 mod csp;
 mod github;
 mod isr;
 mod loader;
 
+pub use aggregates::{BuilderConfig, ServerConfig};
 pub use assets::AssetsConfig;
 pub use csp::{CloudflareConfig, CspConfig, CspConfigError};
 pub use github::GithubConfig;


### PR DESCRIPTION
Follow-up to #1109, which was merged while this was in progress. Two commits, in order.

## 1 — Split the reference per binary, and own the aggregates

#1109 generated one flat table of every configuration key. Read as an operator would read it, that table says a deployment needs a GitHub token. It does not — `github.*` is read only by `update-repos`, a build-time tool that lists repositories and exits during the image build. The server never loads it, and the Docker build supplies the token as a BuildKit secret that does not survive into the image.

The README now renders one table per binary: *What the server reads* (`assets.*`, `csp.*`, `isr.*`, led by the loader's own two variables) and *What the `update-repos` builder reads* (`github.*`, with an explicit note that the server never loads it).

**The aggregates moved out of the binaries into `crates/config`** as `ServerConfig` and `BuilderConfig`. `apps/web` and `apps/update-repos` load those instead of declaring private copies.

That move is the point, not a side effect. A generator cannot describe a private type in a crate it does not depend on, so documenting the split any other way meant mirror structs in the example — and a mirror can disagree with the thing it mirrors without anything failing, which is precisely the drift that generating the table exists to remove. It also settles something `lib.rs` already asserted in prose: the binary-to-blocks mapping was written down with nothing checking it, and is now types.

## 2 — Adopt terrace-config v0.4.0

v0.4.0 ships the renderer changes this repo's integration asked for. Every one of them **deletes** something written here to work around its absence:

| v0.4.0 | What it removes here |
|---|---|
| `Column::Docs` renders a comment's summary, not all of it | The rule that doc comments be one sentence on one line, and the `//` comments the reasoning had been exiled to |
| `Schema::merge` | `Documented`, the flatten-union type |
| `to_markdown_keys` | `--no-loader-vars` and the `schema.loader.clear()` standing in for it |
| `Column::EnvFile` out of the default set | The seventh column |

**The rustdoc comes back.** #1109 had to demote the multi-paragraph documentation on `csp.hash_inline_scripts`, `cloudflare.script_nonce`, `github.token` and the `isr` fields to one-line summaries, with the reasoning moved into `//` comments, because the whole comment went into a table cell. All of it is `///` again.

**The rendered table did not move.** `summary_cell` takes the first paragraph, which is exactly the one-liner it replaces — verified by regenerating after re-wrapping the long summary lines to the column width and diffing: byte-identical. The only visible README change is the dropped `File indirection` column.

`#[serde(skip_serializing)]` on `github.token` also comes out of its `cfg_attr`; it is inert without a `Serialize` impl, and ungated is what upstream now documents.

## Net effect

Adding a block to what a binary loads is the whole registration. #1109 introduced a rule in `lib.rs` and `CONTRIBUTING.md` — *"a new block is not documented until it is added to the example's aggregate"* — and there is no longer a second list for it to point at. The generator declares no type of its own at all.

## Verification

```
cargo fmt --all --check
cargo clippy -p portfolio-config -p update-repos --all-features --all-targets -- -D warnings
cargo clippy -p web --no-default-features --features server --all-targets -- -D warnings
cargo test -p portfolio-config --all-features                # 17 passed
cargo test -p web --no-default-features --features server    # 67 passed
cargo check -p portfolio-config                              # default features
cargo tree -p portfolio-config -e normal -i terrace-config-macros   # absent, as it must be
```

All clean. `README.md` was rendered locally from the template and the generator, so `render-readme` should report no change on its first run.
