### PR TITLE
feat(config): take terrace-config 0.5.0, and generate the example config

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -2,18 +2,28 @@
 Template for the repository README. CI renders it on every pull request and commits the result
 to README.md, so edit this file — never README.md itself.
 
-Two variables, `serverConfigTable` and `builderConfigTable`, one per binary, from
+Every variable comes from one command:
 
     cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown --scope server
-    cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown --scope builder
+      -- --format variables
 
-which walk the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
-binaries actually load — and emit each key with its TOML path, type, environment spelling,
-default and purpose. The server scope leads with the variables the loader reads before any layer
-exists; the builder scope renders keys alone, because they are the same two variables. Both are
-interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+which walks the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
+binaries actually load — and prints the whole payload as strict JSON:
+
+  - `serverConfigTable` and `builderConfigTable`, one Markdown table per binary, each key with
+    its TOML path, type, environment spelling, default and purpose. The server scope leads with
+    the variables the loader reads before any layer exists; the builder scope renders keys alone,
+    because they would be the same two variables. Both go through a triple-stash, being Markdown
+    to emit as-is rather than escape.
+  - `loader`, the dialect: the prefix, the nesting separator, the indirection suffix and the two
+    variables naming the layers.
+  - `keys`, the spellings of the handful of keys the prose below names — `keys.githubToken.env`,
+    `keys.githubToken.envFile`, and so on.
+
+Prefer an injected value to a typed one anywhere the two would say the same thing. A rename in
+`crates/config` then reaches the sentences as well as the tables, and a key the prose names and
+the types no longer have fails the generator instead of rendering a blank. `KEYS` in
+`crates/config/examples/config-schema.rs` is where a key joins that set.
 
 Neither table has a `_FILE` column: it is the environment spelling plus a constant suffix, which
 the layer list above the tables already states once.
@@ -157,17 +167,17 @@ docker build -t portfolio .
 
 Configuration is **layered and file-first**, via
 [terrace-config](https://github.com/TimSchoenle/terrace-config). `crates/config`
-owns the typed blocks and the `PORTFOLIO_` dialect; each binary declares the
+owns the typed blocks and the `{{ loader.envPrefix }}` dialect; each binary declares the
 aggregate it actually reads. Sources are merged in this order, lowest precedence
 first:
 
 1. **Struct defaults** — the `serde` defaults in `crates/config`.
-2. **TOML** at `$PORTFOLIO_CONFIG` — a file, or every `*.toml` inside it when it
+2. **TOML** at `${{ loader.configVar }}` — a file, or every `*.toml` inside it when it
    names a directory (so a `ConfigMap` can be split into fragments).
-3. **Environment** — `PORTFOLIO_`-prefixed variables, `__` for nesting.
-4. **Secrets directory** at `$PORTFOLIO_SECRETS_DIR` — one file per key, named
-   after it (`github__token`); this is what a Kubernetes `Secret` volume mounts.
-5. **File indirection** — `PORTFOLIO_<KEY>_FILE=/path` names a file holding the
+3. **Environment** — `{{ loader.envPrefix }}`-prefixed variables, `{{ loader.envNesting }}` for nesting.
+4. **Secrets directory** at `${{ loader.secretsDirVar }}` — one file per key, named
+   after it (`{{ keys.githubToken.secretsFile }}`); this is what a Kubernetes `Secret` volume mounts.
+5. **File indirection** — `{{ loader.envPrefix }}<KEY>{{ loader.fileSuffix }}=/path` names a file holding the
    value.
 
 The last three are **mutually exclusive per key**: a key supplied by two of them
@@ -180,7 +190,7 @@ The tables below are **generated from the aggregates the binaries load** —
 binaries are, because the two configurations are not one: what a deployment sets
 and what the image build sets have no overlap at all.
 
-Regenerate them with:
+Regenerate one on its own with:
 
 ```bash
 cargo run -p portfolio-config --features config-schema --example config-schema \
@@ -208,8 +218,16 @@ the `serde_json` it pulls stay out of the image; CI's `--all-features` gates are
 what keep the generator compiling.
 
 An empty value counts as unset everywhere, because container platforms routinely
-inject `KEY=` for a declared-but-unset variable. See
-[`config.example.toml`](./config.example.toml) for a commented starting point.
+inject `KEY=` for a declared-but-unset variable.
+[`config.example.toml`](./config.example.toml) is a commented starting point, and
+is generated from the same types as the tables above — every key at its default,
+commented out, so a copy of it and an empty file mean the same thing to the
+loader:
+
+```bash
+cargo run -p portfolio-config --features config-schema --example config-schema \
+  -- --format toml
+```
 
 `IP`, `PORT` and `RUST_LOG` are deliberately **outside** this namespace: they are
 the Dioxus toolchain's contract with the binary (`dx serve` sets them to tell a
@@ -218,12 +236,12 @@ them itself. `CI` likewise belongs to the CI provider.
 
 ### Secrets
 
-`github.token` is the only secret in the workspace, and it should arrive as a
+`{{ keys.githubToken.path }}` is the only secret in the workspace, and it should arrive as a
 **file**, never as an environment variable — `/proc/<pid>/environ`, a crash dump
 and `docker inspect` all carry the environment, and child processes inherit it:
 
 ```bash
-PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token cargo run --release -p update-repos
+{{ keys.githubToken.envFile }}=/run/secrets/gh_token cargo run --release -p update-repos
 ```
 
 The Docker build already does this: the `gh_token` BuildKit secret is mounted as
@@ -249,7 +267,7 @@ hardened pod spec out of the box.
 | --- | --- | --- |
 | `GET /api/health` | — | General health report with the current UTC time |
 | `GET /api/health/live` | `GET /livez` | **Liveness** — process is running; failure restarts the container |
-| `GET /api/health/ready` | `GET /readyz` | **Readiness** — the client bundle (`index.html` under `assets.dist_dir`, default `public/`) is present and servable; failure removes the pod from the Service endpoints |
+| `GET /api/health/ready` | `GET /readyz` | **Readiness** — the client bundle (`index.html` under `{{ keys.assetsDistDir.path }}`, default `{{ keys.assetsDistDir.default }}/`) is present and servable; failure removes the pod from the Service endpoints |
 
 All probe responses are `no-store` (never cached). Readiness returns `503` until
 the assets are present.
@@ -301,7 +319,7 @@ JavaScript Detections, the challenge platform — the `_cf_bm`, `cf_clearance` a
 edge, after this server has hashed what it rendered. No hash can cover it; a
 nonce can, because Cloudflare parses the `Content-Security-Policy` response
 header and copies the nonce onto what it injects. That is
-`csp.cloudflare.script_nonce`, on by default, and it brings one obligation the
+`{{ keys.cspScriptNonce.path }}`, on by default, and it brings one obligation the
 server discharges — every document is `Cache-Control: no-cache`, so a nonce is
 never shared between readers — and one it cannot:
 
@@ -315,8 +333,8 @@ the directives that product actually needs them in (Turnstile in `script-src`
 **and** `frame-src` — admitting only the first renders an empty box).
 
 **If a page ever renders blank**, that is the failure mode this design has:
-`PORTFOLIO_CSP__HASH_INLINE_SCRIPTS=false` together with
-`PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE=false` restores `'unsafe-inline'` on a
+`{{ keys.cspHashInlineScripts.env }}=false` together with
+`{{ keys.cspScriptNonce.env }}=false` restores `'unsafe-inline'` on a
 restart rather than a redeploy. The two must move together — a browser ignores
 `'unsafe-inline'` as soon as the policy carries a nonce — and supplying one
 without the other fails the boot with a message saying so.
@@ -363,19 +381,19 @@ blacklisted in `CONFIG.blacklisted_repos`, and any repository with no update in
 the last 365 days. It deserializes the rest directly into the shared
 `portfolio_data::Repo`/`ReposFile` models and writes the pretty-printed JSON,
 surfacing failures through a dedicated `UpdateReposError` model. An explicit
-repository set can be requested via `github.repos`, in which case each named
+repository set can be requested via `{{ keys.githubRepos.path }}`, in which case each named
 repository is fetched directly (without filtering):
 
 ```bash
 # Defaults: user = CONFIG.github_username, repos = all active repos
 #           (archived/blacklisted/>1y-stale excluded),
 #           output = apps/web/repos.json
-PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token \
+{{ keys.githubToken.envFile }}=/run/secrets/gh_token \
   cargo run --release -p update-repos -- apps/web/repos.json
 
 # Override the repo set for a one-off run (figment's bracketed array syntax,
 # so the environment and the TOML spelling stay the same shape)
-PORTFOLIO_GITHUB__REPOS='[Portfolio,actions]' cargo run --release -p update-repos
+{{ keys.githubRepos.env }}='[Portfolio,actions]' cargo run --release -p update-repos
 ```
 
 ## Contributing
@@ -383,10 +401,11 @@ PORTFOLIO_GITHUB__REPOS='[Portfolio,actions]' cargo run --release -p update-repo
 Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the
 development setup and the checks that must pass before opening a pull request.
 
-**This file is generated.** Edit
-[`.github/templates/README.md.hbs`](./.github/templates/README.md.hbs) instead —
-CI renders it on every pull request and commits the result back to the branch, so
-there is no toolchain to install locally.
+**This file is generated**, as is
+[`config.example.toml`](./config.example.toml). Edit the templates under
+[`.github/templates/`](./.github/templates) instead — CI renders both on every
+pull request and commits the results back to the branch, so there is no toolchain
+to install locally.
 
 ## Security
 

--- a/.github/templates/config.example.toml.hbs
+++ b/.github/templates/config.example.toml.hbs
@@ -1,0 +1,29 @@
+# Example configuration for the portfolio workspace.
+#
+# THIS FILE IS GENERATED. Every key below — its purpose, its type, its default and the
+# other spellings that supply it — comes from the `Describe` derives in `crates/config`,
+# so it cannot omit a key the binaries read or describe one they do not. Only this
+# preamble is hand-written, in `.github/templates/config.example.toml.hbs`; CI renders
+# both on every pull request.
+#
+# Point ${{ loader.configVar }} at a copy of this file, or at a directory holding several
+# `*.toml` fragments — merged in sorted order, which is what lets a Kubernetes ConfigMap
+# and a Secret land side by side:
+#
+#   {{ loader.configVar }}=./config.toml cargo run -p web --features server
+#
+# Every key is commented out at the value it already has, so a copy of this file and an
+# empty file mean the same thing to the loader; uncomment one only to change it. The three
+# spellings named above each key all outrank this file, and they are mutually exclusive per
+# key: supplying one key from two of them fails the boot rather than letting a stale
+# {{ loader.envPrefix }} variable shadow a rotated mounted secret. README.md carries the whole
+# precedence order.
+#
+# Secrets do not belong in a committed file. {{ keys.githubToken.envFile }} names a file
+# holding one, and {{ keys.githubToken.secretsFile }} inside ${{ loader.secretsDirVar }} is the same value as a
+# mounted `Secret` key.
+#
+# NOT configured here: IP, PORT and RUST_LOG belong to the Dioxus toolchain, which reads
+# them itself, and CI belongs to the CI provider.
+
+{{{exampleConfig}}}

--- a/.github/workflows/update-files.yaml
+++ b/.github/workflows/update-files.yaml
@@ -71,24 +71,25 @@ jobs:
               body: 'Cargo.lock has been updated to match Cargo.toml.'
             })
 
-  # `README.md` is rendered from `.github/templates/README.md.hbs`, whose variables are the
-  # configuration reference generated out of the `Describe` derives in `crates/config`. The tables
-  # therefore cannot drift from the types: renaming a key renames it in the README, in the same
-  # pull request.
+  # `README.md` and `config.example.toml` are both rendered from templates under
+  # `.github/templates/`, and both are interpolated from the same payload: the configuration
+  # reference generated out of the `Describe` derives in `crates/config`. Neither document can
+  # drift from the types — renaming a key renames it in the tables, in the prose that names it,
+  # and in the example file, all in the same pull request.
   #
   # A job of its own rather than more steps above, and `needs:` rather than parallel, for one
   # reason: both push to the head branch, and two jobs racing on one ref is a lost commit or a
   # rejected push. Sequencing also means this renders against the tree the lock-file commit left
   # behind, so a dependency bump that changes nothing here still produces no second commit.
-  render-readme:
-    name: Ensure README is Rendered from its Template
+  render-generated-files:
+    name: Ensure the Generated Files are Rendered from their Templates
     needs: update-lock-file
     environment:
       name: ci
       deployment: false
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to push the rendered README
+      contents: write # to push the rendered files
       pull-requests: write # to comment on PRs
     steps:
       - name: Harden Runner
@@ -115,31 +116,27 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
-      # One run per binary, because the reference is two tables: what a deployment configures
-      # (`ServerConfig`) and what the image build configures (`BuilderConfig`). A single table
-      # would read as though every deployment needs a GitHub token, which none does. The builder
-      # scope renders its keys alone, since the loader variables it would otherwise repeat are the
-      # same two the server scope already listed.
+      # One run, one payload, both templates. The names the templates read are declared beside
+      # the schema that produces them (`--format variables` in `examples/config-schema.rs`), so
+      # widening what the documents interpolate is a change to that file rather than to a shell
+      # snippet embedded here — and an unread name costs a template nothing, because strict mode
+      # fails on a reference the payload does not define, never on a definition nothing reads.
       #
-      # The generator reads nothing from the environment, so it produces the same tables here as
-      # on a developer's machine — which is what lets the render step below skip its commit when
-      # the configuration has not changed. Cargo's progress goes to stderr, so stdout is the
-      # document and nothing else; `$(…)` drops its trailing newline, and `--arg` makes each a
-      # JSON string, so the payload is strict JSON on one line whatever the tables contain.
-      - name: Generate the configuration reference
+      # The generator reads nothing from the environment, so it produces the same payload here as
+      # on a developer's machine, which is what lets the steps below skip their commits when the
+      # configuration has not changed. Cargo's progress goes to stderr, so stdout is the payload
+      # and nothing else; it is already strict JSON on one line, and `$(…)` drops the newline
+      # `println!` puts after it.
+      - name: Generate the configuration payload
         id: config-schema
         run: |
           set -euo pipefail
-          generate() {
-            cargo run -q -p portfolio-config --features config-schema \
-              --example config-schema -- --format markdown "$@"
-          }
-          server="$(generate --scope server)"
-          builder="$(generate --scope builder)"
-          variables="$(jq -cn --arg server "$server" --arg builder "$builder" \
-            '{serverConfigTable: $server, builderConfigTable: $builder}')"
+          variables="$(cargo run -q -p portfolio-config --features config-schema \
+            --example config-schema -- --format variables)"
           echo "variables=${variables}" >> "$GITHUB_OUTPUT"
 
+      # Each render commits only its own output — `file_pattern` defaults to it — so a document
+      # that did not change produces no commit, and neither can carry the other along.
       - name: Render and commit the README
         id: readme
         uses: TimSchoenle/actions/actions/common/render-template-and-commit@15d83f02081c9dc8a844646199c63792dcccdfa8 # tag=actions-common-render-template-and-commit-v1.1.3
@@ -150,15 +147,41 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           commit_message: 'docs: render README from its template'
 
+      - name: Render and commit the example configuration
+        id: example-config
+        uses: TimSchoenle/actions/actions/common/render-template-and-commit@15d83f02081c9dc8a844646199c63792dcccdfa8 # tag=actions-common-render-template-and-commit-v1.1.3
+        with:
+          template: .github/templates/config.example.toml.hbs
+          output: config.example.toml
+          variables: ${{ steps.config-schema.outputs.variables }}
+          token: ${{ steps.generate_token.outputs.token }}
+          commit_message: 'docs: render the example configuration from its template'
+
+      # One comment for both, naming only what actually changed. Two comment steps would post
+      # twice on the pull request that renames a key, which is precisely the one where both
+      # documents move together.
       - name: Comment on PR
-        if: steps.readme.outputs.changes_detected == 'true' && github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && (steps.readme.outputs.changes_detected == 'true'
+          || steps.example-config.outputs.changes_detected == 'true')
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          README_CHANGED: ${{ steps.readme.outputs.changes_detected }}
+          EXAMPLE_CHANGED: ${{ steps.example-config.outputs.changes_detected }}
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
+            const rendered = [
+              ['README.md', '.github/templates/README.md.hbs', process.env.README_CHANGED],
+              ['config.example.toml', '.github/templates/config.example.toml.hbs', process.env.EXAMPLE_CHANGED],
+            ]
+              .filter(([, , changed]) => changed === 'true')
+              .map(([output, template]) => `- \`${output}\`, from \`${template}\``)
+              .join('\n');
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: 'README.md has been re-rendered from `.github/templates/README.md.hbs`.'
+              body: `Re-rendered from the configuration types in \`crates/config\`:\n\n${rendered}`
             })

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,9 +3578,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 name = "portfolio-config"
 version = "2.5.0"
 dependencies = [
- "figment",
  "secrecy",
  "serde",
+ "serde_json",
  "terrace-config",
 ]
 
@@ -4764,20 +4764,21 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.4.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.4.0#ac5c8e31bc384075de00099f8838c375c1df8c23"
+version = "0.5.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
 dependencies = [
  "figment",
  "serde",
  "serde_json",
  "terrace-config-macros",
  "thiserror 2.0.20",
+ "tokio",
 ]
 
 [[package]]
 name = "terrace-config-macros"
-version = "0.4.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.4.0#ac5c8e31bc384075de00099f8838c375c1df8c23"
+version = "0.5.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,26 +30,34 @@ portfolio-data = { path = "crates/data" }
 # update to the loader is a deliberate commit here rather than whatever `main`
 # happened to be at build time.
 #
-# `loader` only, and `default-features = false` to say so: the crate's other
-# half is a supervisor that rebuilds a running service when its files change,
-# which would link tokio, notify and tracing into every consumer. Nothing here
-# needs it — see `crates/config/src/lib.rs` for why.
+# `default-features = false`, then back exactly what is used. The crate is five
+# features and this workspace takes two of them:
 #
-# The third feature, `schema`, is not taken here either. It is what generates the
-# configuration reference in `README.md`, and `portfolio-config` turns it on
-# through its own off-by-default `config-schema` feature, so `serde_json`, `syn`
-# and the derive stay out of every binary this workspace ships.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.4.0", default-features = false, features = [
+# - `loader` is the layering above, and the reason the dependency exists.
+# - `explain` is the report `load` cannot give: which layer supplied each key,
+#   and which keys more than one supplied. It costs no dependency at all — only
+#   the code that walks the layers a second time and renders it — and it is what
+#   both binaries print when a configuration is refused, where the error names
+#   the key and this names the mount it came from.
+#
+# `reload` is left out: it is a supervisor that rebuilds a running service when
+# its files change, and taking it would link tokio, notify and tracing into
+# every consumer for a reload this workspace cannot use — see
+# `crates/config/src/lib.rs` for the two reasons.
+#
+# `schema` is left out here and turned on by `portfolio-config`'s own
+# off-by-default `config-schema` feature, so `serde_json`, `syn` and the derive
+# reach the documentation generator and never a binary this workspace ships.
+# `testing` is left out for the same reason and taken as a dev-dependency in
+# `crates/config`, which is the only crate that loads anything.
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = [
     "loader",
+    "explain",
 ] }
 # Keeps the GitHub token out of `Debug` output and off every accidental log
 # line: a `SecretString` has no `Display`, and reading it is the explicit
 # `expose_secret()` call at the one place it is put on the wire.
 secrecy = { version = "0.10", features = ["serde"] }
-# `figment::Jail` sets and restores process-wide environment state, which is how
-# the config tests avoid `env::set_var` in a threaded test binary. Same figment
-# `terrace-config` resolves, plus its `test` feature.
-figment = { version = "0.10", features = ["test"] }
 
 # Dioxus 0.7 fullstack. `fullstack` enables server functions + hydration
 # serialization on both targets; `router` re-exports dioxus-router. The

--- a/README.md
+++ b/README.md
@@ -2,18 +2,28 @@
 Template for the repository README. CI renders it on every pull request and commits the result
 to README.md, so edit this file — never README.md itself.
 
-Two variables, `serverConfigTable` and `builderConfigTable`, one per binary, from
+Every variable comes from one command:
 
     cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown --scope server
-    cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format markdown --scope builder
+      -- --format variables
 
-which walk the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
-binaries actually load — and emit each key with its TOML path, type, environment spelling,
-default and purpose. The server scope leads with the variables the loader reads before any layer
-exists; the builder scope renders keys alone, because they are the same two variables. Both are
-interpolated through a triple-stash, being Markdown to emit as-is rather than escape.
+which walks the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
+binaries actually load — and prints the whole payload as strict JSON:
+
+  - `serverConfigTable` and `builderConfigTable`, one Markdown table per binary, each key with
+    its TOML path, type, environment spelling, default and purpose. The server scope leads with
+    the variables the loader reads before any layer exists; the builder scope renders keys alone,
+    because they would be the same two variables. Both go through a triple-stash, being Markdown
+    to emit as-is rather than escape.
+  - `loader`, the dialect: the prefix, the nesting separator, the indirection suffix and the two
+    variables naming the layers.
+  - `keys`, the spellings of the handful of keys the prose below names — `keys.githubToken.env`,
+    `keys.githubToken.envFile`, and so on.
+
+Prefer an injected value to a typed one anywhere the two would say the same thing. A rename in
+`crates/config` then reaches the sentences as well as the tables, and a key the prose names and
+the types no longer have fails the generator instead of rendering a blank. `KEYS` in
+`crates/config/examples/config-schema.rs` is where a key joins that set.
 
 Neither table has a `_FILE` column: it is the environment spelling plus a constant suffix, which
 the layer list above the tables already states once.
@@ -180,7 +190,7 @@ The tables below are **generated from the aggregates the binaries load** —
 binaries are, because the two configurations are not one: what a deployment sets
 and what the image build sets have no overlap at all.
 
-Regenerate them with:
+Regenerate one on its own with:
 
 ```bash
 cargo run -p portfolio-config --features config-schema --example config-schema \
@@ -225,8 +235,16 @@ the `serde_json` it pulls stay out of the image; CI's `--all-features` gates are
 what keep the generator compiling.
 
 An empty value counts as unset everywhere, because container platforms routinely
-inject `KEY=` for a declared-but-unset variable. See
-[`config.example.toml`](./config.example.toml) for a commented starting point.
+inject `KEY=` for a declared-but-unset variable.
+[`config.example.toml`](./config.example.toml) is a commented starting point, and
+is generated from the same types as the tables above — every key at its default,
+commented out, so a copy of it and an empty file mean the same thing to the
+loader:
+
+```bash
+cargo run -p portfolio-config --features config-schema --example config-schema \
+  -- --format toml
+```
 
 `IP`, `PORT` and `RUST_LOG` are deliberately **outside** this namespace: they are
 the Dioxus toolchain's contract with the binary (`dx serve` sets them to tell a
@@ -400,10 +418,11 @@ PORTFOLIO_GITHUB__REPOS='[Portfolio,actions]' cargo run --release -p update-repo
 Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the
 development setup and the checks that must pass before opening a pull request.
 
-**This file is generated.** Edit
-[`.github/templates/README.md.hbs`](./.github/templates/README.md.hbs) instead —
-CI renders it on every pull request and commits the result back to the branch, so
-there is no toolchain to install locally.
+**This file is generated**, as is
+[`config.example.toml`](./config.example.toml). Edit the templates under
+[`.github/templates/`](./.github/templates) instead — CI renders both on every
+pull request and commits the results back to the branch, so there is no toolchain
+to install locally.
 
 ## Security
 

--- a/apps/update-repos/src/main.rs
+++ b/apps/update-repos/src/main.rs
@@ -61,6 +61,13 @@ fn main() -> ExitCode {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             eprintln!("update-repos: {err}");
+            // Only for the failure the report is about. The token this tool carries is the one
+            // secret in the workspace and arrives as a mounted file, so "which layer supplied
+            // `github.token`" is the question a failed build asks — and the report answers it
+            // without printing the value, which is why it can be in CI output at all.
+            if matches!(err, UpdateReposError::Config(_)) {
+                eprintln!("{}", portfolio_config::provenance());
+            }
             ExitCode::FAILURE
         }
     }

--- a/apps/web/src/server/mod.rs
+++ b/apps/web/src/server/mod.rs
@@ -67,8 +67,13 @@ pub fn serve() {
 /// container never reports ready, rather than serving every visitor a blank page.
 fn load_config() -> ServerConfig {
     // Runs before `dioxus::serve` installs the logger, so `tracing` would discard this.
+    //
+    // The error names the key; the report under it names the layer that supplied it, which is
+    // the half an operator cannot get at from inside a distroless image with no shell. It holds
+    // no configuration value, so it is safe in a log that is shipped and retained.
     let refuse = |err: &dyn std::fmt::Display| -> ! {
         eprintln!("portfolio: cannot start, the configuration is not usable: {err}");
+        eprintln!("{}", portfolio_config::provenance());
         std::process::exit(EX_CONFIG)
     };
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,124 +1,167 @@
 # Example configuration for the portfolio workspace.
 #
-# Point $PORTFOLIO_CONFIG at a copy of this file, or at a directory holding
-# several `*.toml` fragments (merged in sorted order — one file per concern is
-# what lets a Kubernetes ConfigMap and a Secret land side by side).
+# THIS FILE IS GENERATED. Every key below — its purpose, its type, its default and the
+# other spellings that supply it — comes from the `Describe` derives in `crates/config`,
+# so it cannot omit a key the binaries read or describe one they do not. Only this
+# preamble is hand-written, in `.github/templates/config.example.toml.hbs`; CI renders
+# both on every pull request.
+#
+# Point $PORTFOLIO_CONFIG at a copy of this file, or at a directory holding several
+# `*.toml` fragments — merged in sorted order, which is what lets a Kubernetes ConfigMap
+# and a Secret land side by side:
 #
 #   PORTFOLIO_CONFIG=./config.toml cargo run -p web --features server
 #
-# Every key here can equally be supplied as a `PORTFOLIO_`-prefixed environment
-# variable with `__` for nesting (`assets.dist_dir` → PORTFOLIO_ASSETS__DIST_DIR),
-# as a file in $PORTFOLIO_SECRETS_DIR named after the key (`assets__dist_dir`),
-# or as `PORTFOLIO_<KEY>_FILE=/path`. The last three are mutually exclusive per
-# key: supplying one key from two of them fails the boot rather than letting a
-# stale environment variable shadow a rotated secret.
+# Every key is commented out at the value it already has, so a copy of this file and an
+# empty file mean the same thing to the loader; uncomment one only to change it. The three
+# spellings named above each key all outrank this file, and they are mutually exclusive per
+# key: supplying one key from two of them fails the boot rather than letting a stale
+# PORTFOLIO_ variable shadow a rotated mounted secret. README.md carries the whole
+# precedence order.
 #
-# Every value below is the default, so an empty file behaves identically —
-# except `isr.cache_dir`, which has no default and which the container image
-# sets to /tmp/isr.
+# Secrets do not belong in a committed file. PORTFOLIO_GITHUB__TOKEN_FILE names a file
+# holding one, and github__token inside $PORTFOLIO_SECRETS_DIR is the same value as a
+# mounted `Secret` key.
 #
-# NOT configured here: IP, PORT and RUST_LOG belong to the Dioxus toolchain,
-# which reads them itself, and CI belongs to the CI provider.
-
-# ── the SSR server ───────────────────────────────────────────────────────────
+# NOT configured here: IP, PORT and RUST_LOG belong to the Dioxus toolchain, which reads
+# them itself, and CI belongs to the CI provider.
 
 [assets]
 # Directory holding the `dx bundle` output, relative to the working directory.
-# Only the readiness probe consults it: the bundle itself is served by the Dioxus
-# asset router, which resolves `public/` relative to the binary.
-dist_dir = "public"
-
-[isr]
-# Writable directory rendered HTML is cached into. Unset — as it is here —
-# disables incremental static regeneration and renders every request fresh.
-# Keep it outside the bundled `public/` tree so those content-hashed assets stay
-# immutable. The image sets this to /tmp/isr, which the deployment mounts as a
-# writable volume even under a read-only root filesystem.
 #
-# cache_dir = "/tmp/isr"
-
-# Revalidation interval in seconds. `0` means a permanent cache, which is right
-# for this site: every page renders from compile-time data, so the only thing
-# that changes the output is a redeploy — and that starts from an empty cache.
-# Set a positive value only when a *persistent* cache volume is shared across
-# deploys. Unlike the environment variable this replaced, an unparseable value
-# now fails the boot instead of silently meaning "permanent".
-ttl_secs = 0
-
-# ── the Content-Security-Policy ──────────────────────────────────────────────
-#
-# The policy itself is not configurable: it is built from `csp-shell` in
-# `apps/web/src/server/csp.rs`, where the directives sit next to the reason each
-# one is what it is. What is configurable is the part that depends on the
-# deployment rather than on the code.
+# The image runs from `/app`, next to `public/`, so the default resolves without anything
+# being set.
+# Type: PathBuf
+# Also from: PORTFOLIO_ASSETS__DIST_DIR, PORTFOLIO_ASSETS__DIST_DIR_FILE=/path/to/file,
+#   assets__dist_dir in the secrets directory
+# dist_dir = "public"
 
 [csp]
-# Derive a `'sha256-…'` source for every inline <script> in the document being
-# served, instead of admitting all inline script with `'unsafe-inline'`. The
-# hashes are computed from the response body itself, so they cannot drift from
-# what is sent — Dioxus renders its hydration data inline, and its text is only
-# known per response.
+# Hash every inline `<script>` in the document being served instead of admitting all inline
+# script with `'unsafe-inline'`.
 #
-# Set to false as an escape hatch, not as a preference: it restores
-# `'unsafe-inline'`, which admits an injected <script> exactly as readily as the
-# hydration bootstrap. It exists because the opposite failure is silent — an
-# inline script the scanner does not see is refused by the browser and the page
-# renders blank — and because a development server that injects its own
-# live-reload script downstream of this process is outside what can be hashed
-# here. Turning it off also requires turning `csp.cloudflare.script_nonce` off:
-# a browser ignores `'unsafe-inline'` as soon as the policy carries any nonce,
-# so the combination fails the boot rather than serving a blank page.
-hash_inline_scripts = true
+# On — the default — the server hashes the response body it is about to send, so the only
+# inline scripts that run are the ones it rendered itself. That is the whole point of the
+# exercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus
+# hydration bootstrap.
+#
+# Off is the escape hatch, and it exists because the failure mode is silent: an inline
+# script the scanner does not see is refused by the browser, and the evidence is a blank
+# page and a console message nobody is watching. Turning it off restores `'unsafe-inline'`
+# through an environment variable and a restart rather than a redeploy. Known cases: a
+# development server that injects its own live-reload script downstream of this process,
+# and any future renderer change that emits script this server never sees.
+#
+# The two settings are mutually exclusive in the browser, not merely different: a policy
+# carrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch
+# here rather than two independent ones.
+# Type: bool
+# Also from: PORTFOLIO_CSP__HASH_INLINE_SCRIPTS,
+#   PORTFOLIO_CSP__HASH_INLINE_SCRIPTS_FILE=/path/to/file, csp__hash_inline_scripts in the secrets
+#   directory
+# hash_inline_scripts = true
 
 [csp.cloudflare]
-# Reserve a per-response nonce in `script-src` for the inline <script>
-# Cloudflare's bot products (Bot Fight Mode, JavaScript Detections, the
-# challenge platform) inject at the edge — after this server has hashed what it
-# renders, so no hash can cover it. Without the nonce, `script-src` refuses it
-# and the detection silently never runs: bot management looks enabled and does
-# nothing. Cloudflare reads the nonce out of the response header and copies it
-# onto what it injects, so nothing is stamped into the document.
+# Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge.
 #
-# On by default because this site is delivered through a Cloudflare Tunnel with
-# those products active. Two conditions come with it: every document is served
-# `Cache-Control: no-cache` (the server does this), and **no Cloudflare Cache
-# Rule may cache the shell** — a "Cache Everything" rule overrides the origin's
-# header and pins one nonce across every reader, which nothing inside this
-# process can detect. That one belongs in the deployment checklist.
-script_nonce = true
+# On by default, because this site is delivered through a Cloudflare Tunnel with the bot
+# products active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`
+# challenge cookies, which is the observable half of the same feature. Those products inject
+# an inline `<script>` into the HTML *after* it leaves this process, so no hash this server
+# computes can cover it; `script-src` refuses it and the detection silently never runs.
+# Cloudflare's documented answer is to parse the `Content-Security-Policy` response header
+# and copy the nonce onto what it injects, so nothing has to be stamped into the document.
+#
+# It carries one obligation the server discharges (`Cache-Control: no-cache` on every
+# document, so a nonce is never shared between readers) and one it cannot: **no Cloudflare
+# Cache Rule may cache the shell**. A "Cache Everything" rule overrides the origin's
+# `Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing
+# inside this process can see that.
+# Type: bool
+# Also from: PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE,
+#   PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE_FILE=/path/to/file, csp__cloudflare__script_nonce in
+#   the secrets directory
+# script_nonce = true
 
-# Admit https://challenges.cloudflare.com in `script-src` *and* `frame-src`, for
-# a Turnstile widget rendered in a page this server serves. Off: this site has
-# no form behind a challenge, and a managed-challenge interstitial is a
-# Cloudflare-served document carrying its own policy.
-turnstile = false
+# Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile
+# widget.
+#
+# Off: this site has no form behind a challenge. A managed-challenge interstitial needs
+# nothing here either — that is a Cloudflare-served document carrying its own policy.
+# Type: bool
+# Also from: PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE,
+#   PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE_FILE=/path/to/file, csp__cloudflare__turnstile in the
+#   secrets directory
+# turnstile = false
 
-# Admit the Cloudflare Web Analytics beacon (https://static.cloudflareinsights.com)
-# and the endpoint it reports to (https://cloudflareinsights.com). Off: this
-# site measures nothing. Only for the manual snippet — the automatic edge
-# injection is an inline script, which is what `script_nonce` above is for.
-web_analytics = false
+# Admit the Cloudflare Web Analytics beacon and the endpoint it reports to.
+#
+# Off: this site measures nothing, which the privacy page states. Only for the *manual*
+# snippet — the automatic edge injection is an inline script and needs `script_nonce`
+# instead.
+# Type: bool
+# Also from: PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS,
+#   PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS_FILE=/path/to/file, csp__cloudflare__web_analytics in
+#   the secrets directory
+# web_analytics = false
 
-# ── the update-repos builder (build time only) ───────────────────────────────
+[isr]
+# Writable directory rendered HTML is cached into. Unset or empty disables ISR.
+#
+# Keep it *outside* the bundled `public/` asset tree so those content-hashed assets stay
+# immutable. The image points it at a sub-directory of `/tmp`, which the deployment already
+# provides as a writable mount even under a read-only root filesystem.
+# Type: PathBuf
+# Also from: PORTFOLIO_ISR__CACHE_DIR, PORTFOLIO_ISR__CACHE_DIR_FILE=/path/to/file, isr__cache_dir
+#   in the secrets directory
+# Unset by default: the value below is only the shape.
+# cache_dir = "<value>"
+
+# Revalidation interval in seconds. Zero means a permanent cache.
+#
+# Every page renders from compile-time data, so the only thing that changes the output is a
+# new build, which starts from an empty cache anyway. A positive value opts into a finite,
+# time-based TTL, which is useful only when a *persistent* cache volume is shared across
+# deploys.
+# Type: u64
+# Also from: PORTFOLIO_ISR__TTL_SECS, PORTFOLIO_ISR__TTL_SECS_FILE=/path/to/file, isr__ttl_secs in
+#   the secrets directory
+# ttl_secs = 0
 
 [github]
-# User whose repositories to list. Unset falls back to the site's own identity
-# from `crates/data`.
+# User whose repositories to list.
 #
-# username = "TimSchoenle"
+# Unset falls back to `portfolio_data::CONFIG`, which is the site's own identity and
+# therefore the only sensible default — resolved by the builder rather than here, so this
+# crate stays a schema and does not depend on the site data.
+# Type: String
+# Also from: PORTFOLIO_GITHUB__USERNAME, PORTFOLIO_GITHUB__USERNAME_FILE=/path/to/file,
+#   github__username in the secrets directory
+# Unset by default: the value below is only the shape.
+# username = "<value>"
 
-# An explicit repository set, bypassing the "every active repository" listing and
-# its archived/blacklisted/stale filtering. Empty lists them all.
-repos = []
+# Bearer token lifting the GitHub API rate limit.
+#
+# Optional: the listing is public, so an unauthenticated build still works, just against the
+# anonymous quota.
+#
+# This is the one secret in the workspace, and the reason the loader is `terrace-config`:
+# supply it as `PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token` (or from a secrets
+# directory) so it never enters the process environment, where `/proc/<pid>/environ`, a
+# crash dump or a `docker inspect` would carry it.
+# Type: SecretString
+# Also from: PORTFOLIO_GITHUB__TOKEN, PORTFOLIO_GITHUB__TOKEN_FILE=/path/to/file, github__token in
+#   the secrets directory
+# Secret: the value below is a placeholder.
+# token = "<secret>"
 
-# Bearer token lifting the GitHub API rate limit. DO NOT put it here.
+# Explicit repository set, bypassing the "every active repository" listing and its filtering.
 #
-# Supply it as a file so it never enters the process environment, where
-# /proc/<pid>/environ, a crash dump, `docker inspect` and every child process
-# would carry it:
-#
-#   PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token
-#
-# or as `github__token` inside $PORTFOLIO_SECRETS_DIR, which is what a Kubernetes
-# Secret volume mounts. In the process it is a `secrecy::SecretString`: no Debug,
-# no Display, and the one place it becomes a `&str` is the Authorization header.
+# Spelled as an array: `repos = ["Portfolio", "actions"]` in TOML, and
+# `PORTFOLIO_GITHUB__REPOS=[Portfolio,actions]` in the environment — figment parses the
+# bracketed form, and a bare comma-separated string is *not* accepted, so the two spellings
+# cannot drift apart.
+# Type: Vec<String>
+# Also from: PORTFOLIO_GITHUB__REPOS, PORTFOLIO_GITHUB__REPOS_FILE=/path/to/file, github__repos in
+#   the secrets directory
+# repos = []

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -36,4 +36,15 @@ terrace-config.workspace = true
 secrecy.workspace = true
 
 [dev-dependencies]
-figment.workspace = true
+# The loader's own test harness, which is why `src/loader.rs` arranges a mount
+# rather than a variable name: every name it writes is derived from the
+# `Terrace` under test, so a test cannot keep passing against a spelling this
+# crate no longer reads. A development dependency because `testing` is
+# deliberately outside `full` — a service asking for everything the crate does
+# at runtime should not link a test harness.
+terrace-config = { workspace = true, features = ["testing"] }
+# The `--format variables` payload the documentation job forwards to the
+# template action. `serde_json` reaches this crate only as a development
+# dependency, so it stays where `terrace-config/schema` already puts it — in
+# the generator — and out of every binary this workspace ships.
+serde_json.workspace = true

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -1,14 +1,14 @@
-//! Dump this workspace's configuration surface for the README generator.
+//! Dump this workspace's configuration surface for the documents CI renders from it.
 //!
 //! ```text
 //! cargo run -p portfolio-config --features config-schema --example config-schema \
 //!   -- --format markdown --scope server
 //! ```
 //!
-//! `.github/workflows/update-files.yaml` runs it once per scope, feeds the results to
-//! `.github/templates/README.md.hbs`, and commits the rendered `README.md` back to the pull
-//! request. The tables therefore cannot drift from the types: a key renamed in `crates/config`
-//! is a key renamed in the README, in the same commit.
+//! `.github/workflows/update-files.yaml` runs it once, feeds the result to the templates under
+//! `.github/templates/`, and commits the rendered `README.md` and `config.example.toml` back to
+//! the pull request. Neither document can drift from the types: a key renamed in `crates/config`
+//! is a key renamed in both, in the same commit.
 //!
 //! Nothing here reads the environment, so the output is the same on a developer's machine and on
 //! a runner where none of the variables it describes are set. That is what makes the render
@@ -33,11 +33,42 @@
 //! document is built out of what the binaries load. A key both halves described would be kept
 //! once and a key described *differently* by each would panic, which is the right answer for a
 //! reference that has to have one.
+//!
+//! # Why the payload is assembled here and not in YAML
+//!
+//! [`Format::Variables`] emits the whole render payload — both tables, the example file, and the
+//! spellings the prose in `README.md.hbs` names — as one strict-JSON object. The workflow step
+//! that used to run this binary once per scope and stitch the results together with `jq` now
+//! runs it once and forwards what it printed.
+//!
+//! That is not only shorter. The names the templates read are declared beside the schema that
+//! produces them, so widening what the documents interpolate is a change to this file rather
+//! than to a shell snippet embedded in YAML — and [`KEYS`] turns a key the prose names and the
+//! types no longer have into a failed CI step instead of a README with a blank in it.
 
+use std::error::Error;
 use std::process::ExitCode;
 
 use portfolio_config::{BuilderConfig, ServerConfig};
-use terrace_config::schema::{Column, Schema};
+use serde_json::{Map, Value, json};
+use terrace_config::schema::{Column, Docs, Key, Schema, TomlExample};
+
+/// The keys `README.md.hbs` names in prose, under the names it reads them by.
+///
+/// Prose cannot be generated from the types the way a table can, but the *spellings* inside it
+/// can: `PORTFOLIO_GITHUB__TOKEN_FILE` is derived rather than typed, so a renamed field renames
+/// it in every sentence that mentions it.
+///
+/// This list is the one thing here that is not derived, and it earns that: a path no key has is
+/// [refused](variables) rather than rendered empty, which makes a rename that outruns the prose
+/// a failed CI step. Adding to it is what lets the template stop hard-coding a spelling.
+const KEYS: &[(&str, &str)] = &[
+    ("assetsDistDir", "assets.dist_dir"),
+    ("cspHashInlineScripts", "csp.hash_inline_scripts"),
+    ("cspScriptNonce", "csp.cloudflare.script_nonce"),
+    ("githubRepos", "github.repos"),
+    ("githubToken", "github.token"),
+];
 
 fn main() -> ExitCode {
     let options = match Options::from_args() {
@@ -61,22 +92,19 @@ fn main() -> ExitCode {
 }
 
 /// The schema, rendered as `options` asks for it.
-///
-/// Built through [`portfolio_config::terrace`] rather than a bare dialect, so the two variables
-/// the loader itself reads — `PORTFOLIO_CONFIG` and `PORTFOLIO_SECRETS_DIR` — are reported with
-/// the names *this* workspace configures rather than the ones a default prefix would derive.
-///
-/// The `Default` column comes from a value built here, not from the process environment: the
-/// documentation job runs where none of these variables exist, and that is the point.
-fn render(options: &Options) -> Result<String, portfolio_config::ConfigError> {
+fn render(options: &Options) -> Result<String, Box<dyn Error>> {
+    if options.format == Format::Variables {
+        return variables();
+    }
+
     let schema = match options.scope {
-        Scope::All => server()?.merge(builder()?),
+        Scope::All => all()?,
         Scope::Server => server()?,
         Scope::Builder => builder()?,
     };
 
     match options.format {
-        Format::Json => schema.to_json(),
+        Format::Json => Ok(schema.to_json()?),
         // The loader variables lead the server table and are absent from every other one. They
         // apply to both binaries, so a page repeating them above each scope would say the same
         // thing twice; the server scope is where an operator setting a deployment up will be.
@@ -84,10 +112,92 @@ fn render(options: &Options) -> Result<String, portfolio_config::ConfigError> {
             Scope::All | Scope::Server => schema.to_markdown(),
             Scope::Builder => schema.to_markdown_keys(Column::DEFAULT),
         }),
+        Format::Toml => Ok(example_config(&schema)),
+        Format::Variables => unreachable!("returned above"),
     }
 }
 
+/// The whole render payload, as the strict JSON the template action takes.
+///
+/// One object for both templates. An unread name costs a template nothing — strict mode fails on
+/// a reference the payload does not *define*, never on a definition nothing reads — so the
+/// alternative, a payload per template, would only be two ways to get the same schema out.
+///
+/// # Errors
+/// If a path in [`KEYS`] names no key in the merged schema, which is a rename the prose in
+/// `README.md.hbs` has not caught up with.
+fn variables() -> Result<String, Box<dyn Error>> {
+    let all = all()?;
+
+    let mut keys = Map::new();
+    for (name, path) in KEYS {
+        let key = all
+            .keys
+            .iter()
+            .find(|key| key.path == *path)
+            .ok_or_else(|| format!("`{path}` is named in README.md.hbs but no key has it"))?;
+        keys.insert((*name).to_owned(), spellings(key));
+    }
+
+    // Trimmed, all three of them. Each rendering ends with a newline of its own, and every
+    // template that interpolates one follows the mustache with a newline too — so an untrimmed
+    // value is a blank line under every table and a blank line at the end of the example file.
+    // Trailing whitespace is not content in any of the three, and this is the one place it can
+    // be dropped for all of them.
+    let payload = json!({
+        "serverConfigTable": server()?.to_markdown().trim_end(),
+        "builderConfigTable": builder()?.to_markdown_keys(Column::DEFAULT).trim_end(),
+        "exampleConfig": example_config(&all).trim_end(),
+        "loader": {
+            "envPrefix": all.dialect.prefix,
+            "envNesting": all.dialect.nesting_separator,
+            "fileSuffix": all.dialect.indirection_suffix,
+            "configVar": portfolio_config::terrace().config_var_name(),
+            "secretsDirVar": portfolio_config::terrace().secrets_dir_var_name(),
+        },
+        "keys": keys,
+    });
+    Ok(serde_json::to_string(&payload)?)
+}
+
+/// Every way one key can be supplied, and what it is when nothing does.
+fn spellings(key: &Key) -> Value {
+    json!({
+        "path": key.path,
+        "env": key.env,
+        "envFile": key.env_file,
+        "secretsFile": key.secrets_file,
+        "default": key.default,
+    })
+}
+
+/// The body of `config.example.toml`: every key, commented out at its default.
+///
+/// No preamble, because the template supplies one — what this file is and how to point the
+/// loader at it are facts about the repository rather than about the schema, and the layering
+/// itself is documented once, in `README.md`. What is left is what only the types know.
+///
+/// [`Docs::Full`] rather than the default summary: this is the file an operator edits with no
+/// rustdoc open beside it, and every paragraph the fields carry is a paragraph the hand-written
+/// version of this file used to carry too.
+fn example_config(schema: &Schema) -> String {
+    schema.to_toml_example_with(&TomlExample::new().header(false).docs(Docs::Full))
+}
+
+/// Every key in the workspace, which is what a machine-readable contract and the example file
+/// both want.
+fn all() -> Result<Schema, portfolio_config::ConfigError> {
+    Ok(server()?.merge(builder()?))
+}
+
 /// The keys the SSR server loads, with the defaults it starts from.
+///
+/// Built through [`portfolio_config::terrace`] rather than a bare dialect, so the two variables
+/// the loader itself reads — `PORTFOLIO_CONFIG` and `PORTFOLIO_SECRETS_DIR` — are reported with
+/// the names *this* workspace configures rather than the ones a default prefix would derive.
+///
+/// The `Default` column comes from a value built here, not from the process environment: the
+/// documentation job runs where none of these variables exist, and that is the point.
 fn server() -> Result<Schema, portfolio_config::ConfigError> {
     portfolio_config::terrace()
         .schema::<ServerConfig>()
@@ -108,16 +218,22 @@ struct Options {
 }
 
 /// Which rendering to emit.
+#[derive(PartialEq, Eq, Clone, Copy)]
 enum Format {
     /// The versioned contract, for a consumer that renders its own tables.
     Json,
     /// GitHub-flavoured tables, which is what the README template interpolates.
     Markdown,
+    /// A commented `config.toml` holding every key at its default.
+    Toml,
+    /// Everything the templates interpolate, as one strict-JSON object.
+    Variables,
 }
 
 /// Whose configuration to report.
+#[derive(PartialEq, Eq, Clone, Copy)]
 enum Scope {
-    /// Every key in the workspace, which is what a machine-readable contract wants.
+    /// Every key in the workspace.
     All,
     /// The keys the SSR server loads.
     Server,
@@ -128,26 +244,26 @@ enum Scope {
 impl Options {
     /// Everything, as JSON: the output that loses nothing.
     fn from_args() -> Result<Self, String> {
-        let mut options = Self {
-            format: Format::Json,
-            scope: Scope::All,
-        };
+        let mut format = Format::Json;
+        let mut scope = None;
         let mut args = std::env::args().skip(1);
         while let Some(flag) = args.next() {
             match flag.as_str() {
                 "--format" => {
-                    options.format = match args.next().as_deref() {
+                    format = match args.next().as_deref() {
                         Some("json") => Format::Json,
                         Some("markdown" | "md") => Format::Markdown,
+                        Some("toml") => Format::Toml,
+                        Some("variables") => Format::Variables,
                         Some(other) => return Err(format!("unknown format `{other}`; {USAGE}")),
                         None => return Err(format!("--format takes a value; {USAGE}")),
                     };
                 }
                 "--scope" => {
-                    options.scope = match args.next().as_deref() {
-                        Some("all") => Scope::All,
-                        Some("server") => Scope::Server,
-                        Some("builder") => Scope::Builder,
+                    scope = match args.next().as_deref() {
+                        Some("all") => Some(Scope::All),
+                        Some("server") => Some(Scope::Server),
+                        Some("builder") => Some(Scope::Builder),
                         Some(other) => return Err(format!("unknown scope `{other}`; {USAGE}")),
                         None => return Err(format!("--scope takes a value; {USAGE}")),
                     };
@@ -155,8 +271,20 @@ impl Options {
                 other => return Err(format!("unknown argument `{other}`; {USAGE}")),
             }
         }
-        Ok(options)
+
+        // Refused rather than ignored: the payload carries a table *per* scope, so a caller
+        // asking for one scope of it is asking for something this cannot give, and silently
+        // handing back all of it would be found much later by whoever read the rendered page.
+        if format == Format::Variables && scope.is_some() {
+            return Err(format!("--format variables covers every scope; {USAGE}"));
+        }
+
+        Ok(Self {
+            format,
+            scope: scope.unwrap_or(Scope::All),
+        })
     }
 }
 
-const USAGE: &str = "usage: config-schema [--format json|markdown] [--scope all|server|builder]";
+const USAGE: &str =
+    "usage: config-schema [--format json|markdown|toml|variables] [--scope all|server|builder]";

--- a/crates/config/src/csp.rs
+++ b/crates/config/src/csp.rs
@@ -123,8 +123,8 @@ pub struct CloudflareConfig {
     /// Admit the Cloudflare Web Analytics beacon and the endpoint it reports to.
     ///
     /// Off: this site measures nothing, which the privacy page states. Only for the *manual*
-    /// snippet — the automatic edge injection is an inline script and needs
-    /// [`script_nonce`](Self::script_nonce) instead.
+    /// snippet — the automatic edge injection is an inline script and needs `script_nonce`
+    /// instead.
     #[serde(default)]
     pub web_analytics: bool,
 }

--- a/crates/config/src/github.rs
+++ b/crates/config/src/github.rs
@@ -35,12 +35,15 @@ pub struct GithubConfig {
     /// supply it as `PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token` (or from a secrets
     /// directory) so it never enters the process environment, where `/proc/<pid>/environ`, a
     /// crash dump or a `docker inspect` would carry it.
-    ///
-    /// `skip_serializing` rather than an impl: [`SecretString`] deliberately has no `Serialize`,
-    /// and the schema generator serialises the default config to read the `Default` column out of
-    /// it. The key still appears in the table — the derive reports it either way — with `unset`
-    /// for a default it never had, which is both true and the only safe thing to print. This is
-    /// the pattern `terrace-config` documents for a secret-bearing field.
+    // Not rustdoc: every `///` on a field in this crate is rendered into `config.example.toml`
+    // and into the README table, for an operator who is not reading the source. Why the
+    // attribute is `skip_serializing` is for whoever changes this line.
+    //
+    // `skip_serializing` rather than an impl: `SecretString` deliberately has no `Serialize`,
+    // and the schema generator serialises the default config to read the `Default` column out of
+    // it. The key still appears in the table — the derive reports it either way — with `unset`
+    // for a default it never had, which is both true and the only safe thing to print. This is
+    // the pattern `terrace-config` documents for a secret-bearing field.
     #[cfg_attr(feature = "config-schema", config(secret))]
     #[serde(default, skip_serializing)]
     pub token: Option<SecretString>,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -9,7 +9,7 @@
 //! stale environment variable shadowing a rotated mounted secret keeps the process running on
 //! the old credential.
 //!
-//! Call [`load`], which is the only entry point.
+//! Call [`load`], which is the only entry point, and [`provenance`] when it fails.
 //!
 //! # What each binary composes
 //!
@@ -24,9 +24,17 @@
 //!
 //! # Why the loader half only
 //!
-//! `terrace-config` also ships a supervisor that rebuilds a running service when the files its
-//! configuration came from change. This workspace deliberately does not take it, for two
-//! reasons that both have to hold before it would be worth the tokio/notify/`inotify` weight:
+//! Two of `terrace-config`'s five features are taken: `loader`, which is the layering above, and
+//! `explain`, which is [`provenance`] — the report naming which layer supplied each key, printed
+//! beside the error when a boot is refused. `explain` costs no dependency at all, and it is what
+//! answers the question the error cannot: an operator inside a distroless image with no shell
+//! cannot otherwise see that the variable they thought they removed is still shadowing the
+//! `Secret` they mounted.
+//!
+//! `reload` is the one deliberately left on the table. It is a supervisor that rebuilds a
+//! running service when the files its configuration came from change, and this workspace does
+//! not take it, for two reasons that both have to hold before it would be worth the
+//! tokio/notify/`inotify` weight:
 //!
 //! 1. **The server holds no secrets.** Rotation is what the supervisor exists to survive, and
 //!    the only secret in the workspace ([`GithubConfig::token`]) belongs to a one-shot build
@@ -40,6 +48,10 @@
 //!
 //! Both halves of that reasoning are recorded here rather than in a commit message because the
 //! second one changes the moment Dioxus grows a cancellable `serve`.
+//!
+//! The remaining two are development-time only: `schema` behind this crate's own off-by-default
+//! `config-schema` feature (see below), and `testing` as a dev-dependency, which is what the
+//! loader tests in `src/loader.rs` arrange their mounts through.
 //!
 //! # Blank means unset
 //!
@@ -76,4 +88,4 @@ pub use assets::AssetsConfig;
 pub use csp::{CloudflareConfig, CspConfig, CspConfigError};
 pub use github::GithubConfig;
 pub use isr::IsrConfig;
-pub use loader::{ConfigError, load, terrace};
+pub use loader::{ConfigError, load, provenance, terrace};

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -49,11 +49,41 @@ pub fn load<T: DeserializeOwned>() -> Result<T, ConfigError> {
     terrace().load()
 }
 
+/// Which layer supplied each key, as a block to print beside a failure.
+///
+/// [`load`]'s error names the key; this names the mount. Between them they answer the question
+/// an operator is actually asking — *why is the value not the one I set* — without a debugger,
+/// a rebuild, or a shell in an image that has none.
+///
+/// Assembled independently of the shadow policy, so the configuration this is most useful for
+/// is the one it can still report: a key supplied twice appears once with both of its sources
+/// rather than stopping the report the way it stopped the boot.
+///
+/// # Nothing here holds a value
+///
+/// The report records *where* each key came from and never *what* it was — a property of
+/// `terrace-config`'s `Explanation` type, which has no field to leak, rather than of remembering
+/// to redact. That is what makes printing one into a log that is shipped and retained safe by
+/// default, and it is why [`GithubConfig::token`](crate::GithubConfig::token) needs no special
+/// handling here.
+///
+/// Returns text whatever happens, the failure to assemble it included: this is called on a path
+/// that is already ending the process, and a diagnostic with an error of its own to handle would
+/// not be one.
+#[must_use]
+pub fn provenance() -> String {
+    match terrace().explain() {
+        Ok(explanation) => explanation.to_string(),
+        Err(err) => format!("the configuration layers could not be reported: {err}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{CspConfig, GithubConfig, IsrConfig, load};
+    use crate::{CspConfig, GithubConfig, IsrConfig, terrace};
     use secrecy::ExposeSecret as _;
     use serde::Deserialize;
+    use terrace_config::testing::Harness;
 
     #[derive(Debug, Deserialize)]
     struct Sample {
@@ -65,25 +95,31 @@ mod tests {
         isr: IsrConfig,
     }
 
+    /// A sandbox over the loader [`terrace`] builds, so every name a test arranges is derived
+    /// from the dialect under test rather than typed out beside it. That is the half worth
+    /// pinning here: `terrace-config` owns the layering and tests it, and what this crate adds
+    /// is the wiring to the names an operator actually sets.
+    fn harness() -> Harness {
+        Harness::over(terrace())
+    }
+
     /// The dialect end to end: the prefix, the `__` nesting, and the defaults that fill in
-    /// around what the environment supplied. `terrace-config` owns the layering and tests it;
-    /// what this pins is that this crate wires it to the names an operator actually sets.
+    /// around what the environment supplied.
+    ///
+    /// The variables are spelled out rather than derived through `Jail::env_key`, because the
+    /// spelling *is* the assertion — a `PORTFOLIO_` prefix and `__` for nesting are what
+    /// `README.md` and every deployment manifest state, and a derived name would agree with the
+    /// loader however the loader changed.
     #[test]
-    // `figment::Jail::expect_with` fixes the closure's error type to the large `figment::Error`.
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn the_environment_layer_speaks_the_documented_names() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
-            jail.set_env("PORTFOLIO_GITHUB__USERNAME", "TimSchoenle");
-            jail.set_env("PORTFOLIO_ISR__TTL_SECS", "3600");
+        harness().run(|jail| {
+            jail.env("PORTFOLIO_GITHUB__USERNAME", "TimSchoenle");
+            jail.env("PORTFOLIO_ISR__TTL_SECS", "3600");
             // Two levels of nesting, which is the deepest key this workspace has and the one
             // spelling a README table could quietly get wrong.
-            jail.set_env("PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE", "true");
+            jail.env("PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE", "true");
 
-            let config: Sample = load().map_err(|e| e.to_string()).unwrap();
+            let config: Sample = jail.load()?;
             assert_eq!(config.github.username(), Some("TimSchoenle"));
             assert!(config.csp.cloudflare.turnstile);
             // Its siblings keep their defaults rather than being reset by the nested override.
@@ -100,29 +136,14 @@ mod tests {
     }
 
     /// A mounted secret outranks the TOML layer, so a `ConfigMap` carrying a placeholder cannot
-    /// win over the `Secret` that carries the real token — through the variable names *this*
-    /// crate configures, which is the half a dependency cannot pin.
+    /// win over the `Secret` that carries the real token.
     #[test]
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn a_secrets_directory_outranks_the_toml_layer() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
-            jail.create_file("config.toml", "[github]\ntoken = \"placeholder\"\n")?;
-            jail.create_dir("secrets")?;
-            jail.create_file("secrets/github__token", "ghp_real\n")?;
-            jail.set_env(
-                "PORTFOLIO_CONFIG",
-                jail.directory().join("config.toml").display(),
-            );
-            jail.set_env(
-                "PORTFOLIO_SECRETS_DIR",
-                jail.directory().join("secrets").display(),
-            );
+        harness().run(|jail| {
+            jail.config("[github]\ntoken = \"placeholder\"\n")?;
+            jail.secret_key("github.token", "ghp_real\n")?;
 
-            let config: Sample = load().map_err(|e| e.to_string()).unwrap();
+            let config: Sample = jail.load()?;
             let token = config
                 .github
                 .into_token()
@@ -137,25 +158,43 @@ mod tests {
     /// figment: a `GITHUB_TOKEN` left behind by a half-finished migration must not keep the
     /// build running on a credential the operator believes they rotated.
     #[test]
-    #[expect(
-        clippy::result_large_err,
-        reason = "figment::Jail::expect_with fixes the closure's error type"
-    )]
     fn one_key_supplied_twice_is_refused() {
-        figment::Jail::expect_with(|jail| {
-            jail.clear_env();
-            jail.create_dir("secrets")?;
-            jail.create_file("secrets/github__token", "ghp_from_file")?;
-            jail.set_env(
-                "PORTFOLIO_SECRETS_DIR",
-                jail.directory().join("secrets").display(),
-            );
-            jail.set_env("PORTFOLIO_GITHUB__TOKEN", "ghp_from_env");
+        harness().run(|jail| {
+            jail.secret_key("github.token", "ghp_from_file")?;
+            jail.env_key("github.token", "ghp_from_env");
 
-            let error = load::<Sample>().expect_err("two sources for one key must not load");
+            let error = jail
+                .load::<Sample>()
+                .expect_err("two sources for one key must not load");
             assert!(
                 error.to_string().contains("github.token"),
                 "the error must name the key: {error}"
+            );
+            Ok(())
+        });
+    }
+
+    /// The report an operator gets when the boot above is refused: both mounts named, neither
+    /// value shown. [`crate::provenance`] is what prints it, and what it prints has to be the
+    /// contested key rather than a summary that omits it.
+    #[test]
+    fn the_report_names_every_layer_that_supplied_a_contested_key() {
+        harness().run(|jail| {
+            jail.secret_key("github.token", "ghp_from_file")?;
+            jail.env_key("github.token", "ghp_from_env");
+
+            let report = jail.explain()?.to_string();
+            assert!(
+                report.contains("github.token"),
+                "the report must name the key: {report}"
+            );
+            assert!(
+                report.contains("PORTFOLIO_GITHUB__TOKEN"),
+                "the report must name the variable that shadowed the mount: {report}"
+            );
+            assert!(
+                !report.contains("ghp_from_file") && !report.contains("ghp_from_env"),
+                "the report must carry no value: {report}"
             );
             Ok(())
         });


### PR DESCRIPTION
Updates `terrace-config` to **v0.5.0** and takes the features it gained where each one removes something this repository was maintaining by hand, then rewires the documentation job so both generated documents come from one payload.

## `explain` — the report `load` cannot give

On in the workspace feature set, because it costs no dependency at all: only the code that walks the layers a second time and renders which one supplied each key.

`portfolio_config::provenance()` prints it beside the error on the two paths that refuse a boot:

- the SSR server, which exits `EX_CONFIG` from inside a distroless image with no shell to investigate from;
- the `update-repos` builder, which carries the one secret in the workspace and reads it from a mount.

The error names the key, the report names the mount. An `Explanation` has no field holding a configuration *value*, so neither print can leak one — the token included.

## `testing` — the harness replaces the hand-rolled fixtures

The three `figment::Jail` fixtures in `crates/config/src/loader.rs` become `Harness::over(terrace())`. That removes the workspace `figment` dev-dependency and three `#[expect(clippy::result_large_err, …)]` attributes, and it closes a real gap: the harness derives every name it writes from the `Terrace` under test, so a test can no longer keep passing against a spelling the loader stopped reading. A fourth test now covers the report itself, including that it carries neither token.

## `schema` — `config.example.toml` is generated, not kept

6.6 KB of prose duplicating the rustdoc on the config types becomes a 27-line preamble in `.github/templates/config.example.toml.hbs` plus every key, type, default and spelling read out of the derives. The generated file parses as TOML and is entirely commented out, so a copy of it and an empty file still mean the same thing to the loader.

Two field comments moved to suit their new second audience — an operator editing the generated file rather than a maintainer reading rustdoc.

## One payload for both documents

`--format variables` prints the whole strict-JSON object the template action takes. The workflow step that ran the generator once per scope and stitched the results together with `jq` now runs it once and forwards what it printed, and both templates render from those same variables.

The payload carries more than the two tables:

| Name | What it is |
| --- | --- |
| `serverConfigTable`, `builderConfigTable` | one Markdown table per binary, as before |
| `exampleConfig` | the body of `config.example.toml` |
| `loader` | the dialect — prefix, nesting separator, indirection suffix, and the two variables naming the layers |
| `keys` | the spellings of the keys the README prose names |

So every `PORTFOLIO_*` name the prose used to hard-code is now injected. **The rendered text is byte-identical** — the diff on those paragraphs in `README.md` is empty, which is the check that the injections are right — but a rename in `crates/config` now reaches the sentences as well as the tables. A key the prose names and the types no longer have fails the generator instead of rendering a blank.

The action stays on `render-template-and-commit@v1.1.3`, which is its latest tag; it is now called twice, once per document, each committing only its own output.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo test --workspace --all-features` and `cargo test -p web --no-default-features --features server`: all green (18 in `portfolio-config`, including the new report test).
- Both documents rendered locally through Handlebars 4.7.9 with the action's own options (`noEscape`, `strict`, `preventIndent`, LF-normalized source); the committed files match their render byte for byte, and re-rendering is stable.
- The missing-key guard was exercised by pointing `KEYS` at a path no key has: the generator exits 1 naming it.
