### PR TITLE
feat(config): publish a configuration contract with the image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,61 @@ jobs:
       - name: Run Check
         uses: TimSchoenle/actions/actions/rust/cargo-check@5798c7bd8d1d98a0c7360114e91a0ac3b86bf145 # tag=actions-rust-cargo-check-v1.1.5
 
+  # The committed contract is what a deployment pipeline reads to check that what a chart renders
+  # is what this image loads, so it has to be the contract these types produce. Regenerating and
+  # diffing makes a configuration change visible in the pull request that makes it: a removed key
+  # shows up in the diff, next to the chart it is about to break.
+  #
+  # A gate rather than a render-and-commit like the README and the example file. Those two are
+  # documentation and a stale one is a stale page; this one is consumed by another repository's
+  # CI, and a copy that arrives one commit late is a gate passing against the wrong document.
+  #
+  # `--revision` and `--created` are deliberately not passed here. They move between builds of the
+  # same source, so the committed copy carries neither and the published one carries both — the
+  # configuration half is what this diff is about.
+  contract:
+    name: Config Contract
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Check the committed contract against the types
+        run: |
+          set -euo pipefail
+          cargo run -q -p portfolio-config --features config-schema \
+            --example config-schema -- --format contract > docs/config.contract.json
+          if ! git diff --exit-code -- docs/config.contract.json; then
+            echo "::error file=docs/config.contract.json::The configuration surface changed and the committed contract did not. Regenerate it with the command in this step and commit the result." >&2
+            exit 1
+          fi
+
+      # The block is hand-carried, because a `LABEL` key cannot be interpolated from a generator.
+      # This is the half a source diff can see; `examples/verify-labels.rs` is the half it cannot,
+      # and runs against the built image.
+      #
+      # The blank line `println!` leaves after the block is dropped, so the comparison is about
+      # the three labels and not about how each side was captured.
+      - name: Check the Dockerfile's label block against the contract
+        run: |
+          set -euo pipefail
+          cargo run -q -p portfolio-config --features config-schema \
+            --example config-schema -- --format dockerfile | sed '/^$/d' > /tmp/labels.expected
+          grep -A2 'LABEL dev.terrace.config' Dockerfile > /tmp/labels.actual
+          diff -u /tmp/labels.expected /tmp/labels.actual
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,8 +4764,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.5.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
+version = "0.6.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.6.0#fb37309b70ad1d47edd4c1fd0fb3bea86f0ce6c8"
 dependencies = [
  "figment",
  "serde",
@@ -4777,8 +4777,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config-macros"
-version = "0.5.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.5.0#b47ca70cefaf48484682a0913dbef48ba4eba10c"
+version = "0.6.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.6.0#fb37309b70ad1d47edd4c1fd0fb3bea86f0ce6c8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ portfolio-data = { path = "crates/data" }
 # reach the documentation generator and never a binary this workspace ships.
 # `testing` is left out for the same reason and taken as a dev-dependency in
 # `crates/config`, which is the only crate that loads anything.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.5.0", default-features = false, features = [
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.6.0", default-features = false, features = [
     "loader",
     "explain",
 ] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,21 @@ RUN cargo run --profile tools --locked -p resume-generator -- /app/resume-out \
     && cp /app/resume-out/resume-fingerprint.json apps/web/generated/ \
     && cp /app/resume-out/og-image.png apps/web/generated/
 
+# ── the configuration contract ────────────────────────────────────────────────
+# The document a deployment pipeline reads to check that what it renders is what
+# this image loads: every key in every spelling, the same keys as a JSON Schema,
+# and the variables outside the `PORTFOLIO_` namespace this container reads.
+#
+# On `generate` rather than on a toolchain of its own, and its own stage rather
+# than a step inside `web-builder`: it depends on `crates/config` alone, so it
+# rebuilds when a configuration type changes and stays cached across every
+# change to the site itself. Nothing the `config-schema` feature links —
+# `serde_json`, `syn`, the derive — reaches the binary the runtime stage copies.
+FROM generate AS contract-builder
+RUN mkdir -p /out \
+    && cargo run --locked -p portfolio-config --features config-schema \
+         --example config-schema -- --format contract > /out/contract.json
+
 # ── build the fullstack app (client wasm + native SSR server) ─────────────────
 FROM generate AS web-builder
 WORKDIR /app/apps/web
@@ -172,6 +187,23 @@ ARG VCS_REF=unknown
 ARG VERSION=dev
 ARG CREATED=unknown
 ARG SOURCE_URL
+# How anything finds the contract without pulling a layer. All three values are
+# constants for this service — the envelope version, where the file was COPYed,
+# and the loader's prefix — so this block is written out rather than
+# interpolated, and no ARG and no host-side generator run stands between the
+# source and the image.
+#
+# Hand-carried means it can be wrong in ways a source diff cannot see, so the
+# check is on the built image instead:
+#
+#   docker inspect -f '{{json .Config.Labels}}' "$image" |
+#     cargo run -p portfolio-config --features config-schema --example verify-labels
+#
+# `--format dockerfile` emits this block, and the Config Contract job diffs the
+# two so the copy here cannot drift from the document it points at.
+LABEL dev.terrace.config.contract.version="1" \
+      dev.terrace.config.contract.path="/config/contract.json" \
+      dev.terrace.config.prefix="PORTFOLIO_"
 LABEL org.opencontainers.image.title="portfolio" \
       org.opencontainers.image.description="Dioxus fullstack (SSR + hydration) portfolio served by Axum." \
       org.opencontainers.image.url="https://tim-schoenle.de" \
@@ -190,6 +222,11 @@ COPY --from=web-builder /app/target/dx/web/release/web /app
 # It lives under /tmp, which the deployment (Helm chart) already mounts as a
 # writable volume; a plain `docker run` uses this baked-in copy instead.
 COPY --from=web-builder --chown=${USER_ID}:${GROUP_ID} /isr-cache /tmp/isr
+# The offline copy of the contract: what makes the image self-describing with no
+# registry at all — an exported tarball, an air-gapped mirror, an initContainer
+# reading it in-cluster. The canonical copy is the OCI referrer attached to the
+# pushed digest; this one costs a few kilobytes and needs nothing to fetch it.
+COPY --from=contract-builder /out/contract.json /config/contract.json
 WORKDIR /app
 
 # The server reads its own settings through the layered `PORTFOLIO_` config

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -23,6 +23,27 @@ config-schema = ["terrace-config/schema"]
 name = "config-schema"
 required-features = ["config-schema"]
 
+
+
+
+
+# The post-build check on the image's `LABEL` block. All three values are
+# constants, so the block is written out in the `Dockerfile` rather than
+# generated — which means the ways it goes wrong are invisible to a source diff:
+# a line dropped on a branch nobody read, a base image contributing its own.
+# `Contract::verify_labels` reads back what `docker inspect` reports and names
+# the first label missing or wrong.
+[[example]]
+name = "verify-labels"
+required-features = ["config-schema"]
+
+
+
+
+
+
+
+
 [dependencies]
 serde.workspace = true
 # The loader itself. This crate owns the *schema* and the Portfolio dialect

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -51,7 +51,9 @@ use std::process::ExitCode;
 
 use portfolio_config::{BuilderConfig, ServerConfig};
 use serde_json::{Map, Value, json};
-use terrace_config::schema::{Column, Docs, Key, Schema, TomlExample};
+use terrace_config::schema::{
+    App, Column, Contract, DEFAULT_PATH, Docs, External, ExternalVar, Key, Schema, TomlExample,
+};
 
 /// The keys `README.md.hbs` names in prose, under the names it reads them by.
 ///
@@ -113,8 +115,85 @@ fn render(options: &Options) -> Result<String, Box<dyn Error>> {
             Scope::Builder => schema.to_markdown_keys(Column::DEFAULT),
         }),
         Format::Toml => Ok(example_config(&schema)),
+        // Whole-image renderings, so the scope they take is the one binary the image runs. See
+        // `contract` for why that is the server rather than `all`.
+        Format::Contract => Ok(contract()?.to_json()?),
+        Format::Labels => Ok(contract()?
+            .labels(DEFAULT_PATH)
+            .into_iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>()
+            .join("\n")),
+        // The block the Dockerfile carries verbatim. All three values are constants for this
+        // service, so nothing here is interpolated at build time and nothing has to run on the
+        // host to produce it — which is what makes `verify_labels` the check that matters: the
+        // block is hand-carried, so the only place to catch a wrong one is the built image.
+        Format::Dockerfile => Ok(contract()?.to_dockerfile_labels(DEFAULT_PATH)),
         Format::Variables => unreachable!("returned above"),
     }
+}
+
+/// The contract the runtime image publishes: every key the *server* loads, and everything else
+/// the container reads.
+///
+/// # Why the server scope and not `all`
+///
+/// A contract is a claim about one image. This workspace builds one — the `scratch` runtime stage
+/// holding the SSR server — and `github.*` is not in it: `update-repos` runs during the build,
+/// lists repositories and exits, and its token is a build secret a deployment never supplies.
+/// Publishing [`all`] would tell a chart's CI that `PORTFOLIO_GITHUB__TOKEN` is a variable this
+/// image reads, which is exactly the false requirement the scopes exist to avoid.
+///
+/// # The part no derive can see
+///
+/// `PORT`, `IP` and `RUST_LOG` are read by the Dioxus toolchain and by `tracing`, before any
+/// layer of this loader exists, and they carry no `PORTFOLIO_` prefix — so nothing in the types
+/// can report them. Declared here they are checked like any key: a chart passing `PORT: "http"`
+/// fails the same gate that a chart passing `PORTFOLIO_ISR__TTL_SECS: "soon"` fails.
+///
+/// The defaults are the ones the Dockerfile's `ENV` block bakes in, which is where the image's
+/// real behaviour is decided.
+fn contract() -> Result<Contract, Box<dyn Error>> {
+    Ok(server()?
+        .into_contract(
+            // `v`-prefixed, because that is how this repository tags its images and the field
+            // exists to be compared against a tag. `CARGO_PKG_VERSION` yields the bare form.
+            App::new("portfolio")
+                .version(concat!("v", env!("CARGO_PKG_VERSION")))
+                .source("https://github.com/TimSchoenle/Portfolio"),
+        )
+        .external(
+            External::new()
+                .var(
+                    ExternalVar::new("PORT")
+                        .owner("dioxus")
+                        .ty("u16")
+                        .default("8080")
+                        .docs("Bind port. Read by the Dioxus toolchain, not by this loader."),
+                )
+                .var(
+                    ExternalVar::new("IP")
+                        .owner("dioxus")
+                        .ty("IpAddr")
+                        .default("0.0.0.0")
+                        .docs("Bind address. Read by the Dioxus toolchain, not by this loader."),
+                )
+                .var(
+                    ExternalVar::new("RUST_LOG")
+                        .owner("tracing")
+                        .ty("String")
+                        .default("info")
+                        .docs("Verbosity, as `tracing` directives — `info`, `web=debug,info`."),
+                )
+                // What a pod carries that no image asked for, which `Unknown::Reject` names:
+                // the API server's five, and the container runtime's one. An image on `scratch`
+                // contributes none of its own. The third entry on that list — the service links —
+                // is not here and cannot be: their names are built from the release name, so they
+                // belong to `enableServiceLinks: false` on the pod.
+                .ignore("KUBERNETES_*")
+                .ignore("HOSTNAME"),
+        )
+        .build()?)
 }
 
 /// The whole render payload, as the strict JSON the template action takes.
@@ -228,6 +307,12 @@ enum Format {
     Toml,
     /// Everything the templates interpolate, as one strict-JSON object.
     Variables,
+    /// The versioned contract a container build attaches to its image.
+    Contract,
+    /// The image labels that make that contract discoverable, one `NAME=value` per line.
+    Labels,
+    /// The same three as a `LABEL` instruction, for the Dockerfile to carry.
+    Dockerfile,
 }
 
 /// Whose configuration to report.
@@ -255,6 +340,9 @@ impl Options {
                         Some("markdown" | "md") => Format::Markdown,
                         Some("toml") => Format::Toml,
                         Some("variables") => Format::Variables,
+                        Some("contract") => Format::Contract,
+                        Some("labels") => Format::Labels,
+                        Some("dockerfile") => Format::Dockerfile,
                         Some(other) => return Err(format!("unknown format `{other}`; {USAGE}")),
                         None => return Err(format!("--format takes a value; {USAGE}")),
                     };
@@ -279,6 +367,20 @@ impl Options {
             return Err(format!("--format variables covers every scope; {USAGE}"));
         }
 
+        // Same reasoning, one step further: a contract names the image it belongs to, and this
+        // workspace ships one. Its scope is decided by `contract`, not by a caller who could
+        // otherwise publish a document claiming the server reads a build-time credential.
+        if matches!(
+            format,
+            Format::Contract | Format::Labels | Format::Dockerfile
+        ) && scope.is_some()
+        {
+            return Err(format!(
+                "--format contract and --format labels describe the runtime image and fix their \
+                 own scope; {USAGE}"
+            ));
+        }
+
         Ok(Self {
             format,
             scope: scope.unwrap_or(Scope::All),
@@ -286,5 +388,5 @@ impl Options {
     }
 }
 
-const USAGE: &str =
-    "usage: config-schema [--format json|markdown|toml|variables] [--scope all|server|builder]";
+const USAGE: &str = "usage: config-schema \
+     [--format json|markdown|toml|variables|contract|labels|dockerfile]      [--scope all|server|builder]";

--- a/crates/config/examples/verify-labels.rs
+++ b/crates/config/examples/verify-labels.rs
@@ -1,0 +1,95 @@
+//! Check a built image's labels against the contract it should be carrying.
+//!
+//! ```text
+//! docker inspect -f '{{json .Config.Labels}}' "$image" \
+//!   | cargo run -p portfolio-config --features config-schema --example verify-labels
+//! ```
+//!
+//! This is the step the `LABEL` block in the `Dockerfile` needs and a source diff cannot give.
+//! The three values are constants, so they are written out by hand there — which means the ways
+//! they go wrong are all invisible to the repository: a `LABEL` line dropped on a branch nobody
+//! diffed, a base image contributing its own, a build that produced a different path than the one
+//! the block claims.
+//!
+//! Reads the labels as `docker inspect` and `crane config` report them — a JSON object under
+//! `Config.Labels` — so nothing here has to know which of the two produced them.
+
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::io::Read as _;
+use std::process::ExitCode;
+
+use portfolio_config::ServerConfig;
+use terrace_config::schema::{App, Contract, DEFAULT_PATH, External, ExternalVar, Schema};
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => {
+            println!("the image's labels match the contract");
+            ExitCode::SUCCESS
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input)?;
+
+    // `docker inspect` prints `null` for an image with no labels at all, which is a different
+    // failure from an image with the wrong ones and reads better said here.
+    let labels: BTreeMap<String, String> = match input.trim() {
+        "" | "null" => BTreeMap::new(),
+        text => serde_json::from_str(text)?,
+    };
+
+    let path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| DEFAULT_PATH.to_owned());
+    contract()?.verify_labels(&path, &labels)?;
+    Ok(())
+}
+
+/// The same contract `--format contract` publishes, so this checks the image against the document
+/// the build put in it rather than against a second description of it.
+fn contract() -> Result<Contract, Box<dyn Error>> {
+    Ok(schema()?
+        .into_contract(
+            App::new("portfolio")
+                .version(concat!("v", env!("CARGO_PKG_VERSION")))
+                .source("https://github.com/TimSchoenle/Portfolio"),
+        )
+        .external(
+            External::new()
+                .var(
+                    ExternalVar::new("PORT")
+                        .owner("dioxus")
+                        .ty("u16")
+                        .default("8080"),
+                )
+                .var(
+                    ExternalVar::new("IP")
+                        .owner("dioxus")
+                        .ty("IpAddr")
+                        .default("0.0.0.0"),
+                )
+                .var(
+                    ExternalVar::new("RUST_LOG")
+                        .owner("tracing")
+                        .ty("String")
+                        .default("info"),
+                )
+                .ignore("KUBERNETES_*")
+                .ignore("HOSTNAME"),
+        )
+        .build()?)
+}
+
+fn schema() -> Result<Schema, portfolio_config::ConfigError> {
+    portfolio_config::terrace()
+        .schema::<ServerConfig>()
+        .with_defaults_from(&ServerConfig::default())
+}

--- a/docs/config.contract.json
+++ b/docs/config.contract.json
@@ -1,0 +1,338 @@
+{
+  "terrace_contract": 1,
+  "app": {
+    "name": "portfolio",
+    "version": "v2.5.0",
+    "source": "https://github.com/TimSchoenle/Portfolio"
+  },
+  "schema": {
+    "schema_version": 1,
+    "dialect": {
+      "prefix": "PORTFOLIO_",
+      "nesting_separator": "__",
+      "indirection_suffix": "_FILE"
+    },
+    "loader": [
+      {
+        "env": "PORTFOLIO_CONFIG",
+        "role": "config",
+        "docs": "Names the TOML layer: a file, or a directory whose `*.toml` files are all merged in name order.",
+        "default": "config.toml"
+      },
+      {
+        "env": "PORTFOLIO_SECRETS_DIR",
+        "role": "secrets_dir",
+        "docs": "Names a directory of key-named files — a mounted Kubernetes `Secret` volume. Each file supplies the key its name spells.",
+        "default": null
+      }
+    ],
+    "keys": [
+      {
+        "path": "assets.dist_dir",
+        "env": "PORTFOLIO_ASSETS__DIST_DIR",
+        "env_file": "PORTFOLIO_ASSETS__DIST_DIR_FILE",
+        "secrets_file": "assets__dist_dir",
+        "docs": "Directory holding the `dx bundle` output, relative to the working directory.\n\nThe image runs from `/app`, next to `public/`, so the default resolves without anything\nbeing set.",
+        "ty": "PathBuf",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "public",
+        "default_value": "public",
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "csp.hash_inline_scripts",
+        "env": "PORTFOLIO_CSP__HASH_INLINE_SCRIPTS",
+        "env_file": "PORTFOLIO_CSP__HASH_INLINE_SCRIPTS_FILE",
+        "secrets_file": "csp__hash_inline_scripts",
+        "docs": "Hash every inline `<script>` in the document being served instead of admitting all inline\nscript with `'unsafe-inline'`.\n\nOn — the default — the server hashes the response body it is about to send, so the only\ninline scripts that run are the ones it rendered itself. That is the whole point of the\nexercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus\nhydration bootstrap.\n\nOff is the escape hatch, and it exists because the failure mode is silent: an inline\nscript the scanner does not see is refused by the browser, and the evidence is a blank\npage and a console message nobody is watching. Turning it off restores `'unsafe-inline'`\nthrough an environment variable and a restart rather than a redeploy. Known cases: a\ndevelopment server that injects its own live-reload script downstream of this process,\nand any future renderer change that emits script this server never sees.\n\nThe two settings are mutually exclusive in the browser, not merely different: a policy\ncarrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch\nhere rather than two independent ones.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "true",
+        "default_value": true,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "csp.cloudflare.script_nonce",
+        "env": "PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE",
+        "env_file": "PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE_FILE",
+        "secrets_file": "csp__cloudflare__script_nonce",
+        "docs": "Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge.\n\nOn by default, because this site is delivered through a Cloudflare Tunnel with the bot\nproducts active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`\nchallenge cookies, which is the observable half of the same feature. Those products inject\nan inline `<script>` into the HTML *after* it leaves this process, so no hash this server\ncomputes can cover it; `script-src` refuses it and the detection silently never runs.\nCloudflare's documented answer is to parse the `Content-Security-Policy` response header\nand copy the nonce onto what it injects, so nothing has to be stamped into the document.\n\nIt carries one obligation the server discharges (`Cache-Control: no-cache` on every\ndocument, so a nonce is never shared between readers) and one it cannot: **no Cloudflare\nCache Rule may cache the shell**. A \"Cache Everything\" rule overrides the origin's\n`Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing\ninside this process can see that.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "true",
+        "default_value": true,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "csp.cloudflare.turnstile",
+        "env": "PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE",
+        "env_file": "PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE_FILE",
+        "secrets_file": "csp__cloudflare__turnstile",
+        "docs": "Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile\nwidget.\n\nOff: this site has no form behind a challenge. A managed-challenge interstitial needs\nnothing here either — that is a Cloudflare-served document carrying its own policy.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "csp.cloudflare.web_analytics",
+        "env": "PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS",
+        "env_file": "PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS_FILE",
+        "secrets_file": "csp__cloudflare__web_analytics",
+        "docs": "Admit the Cloudflare Web Analytics beacon and the endpoint it reports to.\n\nOff: this site measures nothing, which the privacy page states. Only for the *manual*\nsnippet — the automatic edge injection is an inline script and needs `script_nonce`\ninstead.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "isr.cache_dir",
+        "env": "PORTFOLIO_ISR__CACHE_DIR",
+        "env_file": "PORTFOLIO_ISR__CACHE_DIR_FILE",
+        "secrets_file": "isr__cache_dir",
+        "docs": "Writable directory rendered HTML is cached into. Unset or empty disables ISR.\n\nKeep it *outside* the bundled `public/` asset tree so those content-hashed assets stay\nimmutable. The image points it at a sub-directory of `/tmp`, which the deployment already\nprovides as a writable mount even under a read-only root filesystem.",
+        "ty": "PathBuf",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": "ISR off; the image sets `/tmp/isr`",
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "isr.ttl_secs",
+        "env": "PORTFOLIO_ISR__TTL_SECS",
+        "env_file": "PORTFOLIO_ISR__TTL_SECS_FILE",
+        "secrets_file": "isr__ttl_secs",
+        "docs": "Revalidation interval in seconds. Zero means a permanent cache.\n\nEvery page renders from compile-time data, so the only thing that changes the output is a\nnew build, which starts from an empty cache anyway. A positive value opts into a finite,\ntime-based TTL, which is useful only when a *persistent* cache volume is shared across\ndeploys.",
+        "ty": "u64",
+        "values": [],
+        "constraint": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*\\+?[0-9]+\\s*$",
+          "type": "string"
+        },
+        "text_form": "integer",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "0",
+        "default_value": 0,
+        "note": "permanent",
+        "required": false,
+        "secret": false,
+        "reserved": false
+      }
+    ]
+  },
+  "json_schema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": false,
+    "properties": {
+      "assets": {
+        "additionalProperties": false,
+        "properties": {
+          "dist_dir": {
+            "default": "public",
+            "description": "Directory holding the `dx bundle` output, relative to the working directory.\n\nThe image runs from `/app`, next to `public/`, so the default resolves without anything\nbeing set.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "csp": {
+        "additionalProperties": false,
+        "properties": {
+          "cloudflare": {
+            "additionalProperties": false,
+            "properties": {
+              "script_nonce": {
+                "default": true,
+                "description": "Reserve a per-response nonce in `script-src` for the script Cloudflare injects at the edge.\n\nOn by default, because this site is delivered through a Cloudflare Tunnel with the bot\nproducts active — the privacy page lists `_cf_bm`, `cf_clearance` and the `cf_chl_rc_*`\nchallenge cookies, which is the observable half of the same feature. Those products inject\nan inline `<script>` into the HTML *after* it leaves this process, so no hash this server\ncomputes can cover it; `script-src` refuses it and the detection silently never runs.\nCloudflare's documented answer is to parse the `Content-Security-Policy` response header\nand copy the nonce onto what it injects, so nothing has to be stamped into the document.\n\nIt carries one obligation the server discharges (`Cache-Control: no-cache` on every\ndocument, so a nonce is never shared between readers) and one it cannot: **no Cloudflare\nCache Rule may cache the shell**. A \"Cache Everything\" rule overrides the origin's\n`Cache-Control`, satisfying the obligation here and violating it at the edge, and nothing\ninside this process can see that.",
+                "type": "boolean"
+              },
+              "turnstile": {
+                "default": false,
+                "description": "Admit `https://challenges.cloudflare.com` in `script-src` and `frame-src`, for a Turnstile\nwidget.\n\nOff: this site has no form behind a challenge. A managed-challenge interstitial needs\nnothing here either — that is a Cloudflare-served document carrying its own policy.",
+                "type": "boolean"
+              },
+              "web_analytics": {
+                "default": false,
+                "description": "Admit the Cloudflare Web Analytics beacon and the endpoint it reports to.\n\nOff: this site measures nothing, which the privacy page states. Only for the *manual*\nsnippet — the automatic edge injection is an inline script and needs `script_nonce`\ninstead.",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "hash_inline_scripts": {
+            "default": true,
+            "description": "Hash every inline `<script>` in the document being served instead of admitting all inline\nscript with `'unsafe-inline'`.\n\nOn — the default — the server hashes the response body it is about to send, so the only\ninline scripts that run are the ones it rendered itself. That is the whole point of the\nexercise: `'unsafe-inline'` admits an injected `<script>` just as readily as the Dioxus\nhydration bootstrap.\n\nOff is the escape hatch, and it exists because the failure mode is silent: an inline\nscript the scanner does not see is refused by the browser, and the evidence is a blank\npage and a console message nobody is watching. Turning it off restores `'unsafe-inline'`\nthrough an environment variable and a restart rather than a redeploy. Known cases: a\ndevelopment server that injects its own live-reload script downstream of this process,\nand any future renderer change that emits script this server never sees.\n\nThe two settings are mutually exclusive in the browser, not merely different: a policy\ncarrying any hash or nonce makes `'unsafe-inline'` inert, which is why there is one switch\nhere rather than two independent ones.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "isr": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_dir": {
+            "description": "Writable directory rendered HTML is cached into. Unset or empty disables ISR.\n\nKeep it *outside* the bundled `public/` asset tree so those content-hashed assets stay\nimmutable. The image points it at a sub-directory of `/tmp`, which the deployment already\nprovides as a writable mount even under a read-only root filesystem.\n\nDefault: ISR off; the image sets `/tmp/isr`.",
+            "type": "string"
+          },
+          "ttl_secs": {
+            "default": 0,
+            "description": "Revalidation interval in seconds. Zero means a permanent cache.\n\nEvery page renders from compile-time data, so the only thing that changes the output is a\nnew build, which starts from an empty cache anyway. A positive value opts into a finite,\ntime-based TTL, which is useful only when a *persistent* cache volume is shared across\ndeploys.\n\nDefault: permanent.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "title": "portfolio configuration",
+    "type": "object"
+  },
+  "external": {
+    "env": [
+      {
+        "name": "PORT",
+        "owner": "dioxus",
+        "docs": "Bind port. Read by the Dioxus toolchain, not by this loader.",
+        "ty": "u16",
+        "values": [],
+        "constraint": {
+          "maximum": 65535,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*\\+?[0-9]+\\s*$",
+          "type": "string"
+        },
+        "text_form": "integer",
+        "default": "8080",
+        "required": false,
+        "secret": false
+      },
+      {
+        "name": "IP",
+        "owner": "dioxus",
+        "docs": "Bind address. Read by the Dioxus toolchain, not by this loader.",
+        "ty": "IpAddr",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "unknown",
+        "default": "0.0.0.0",
+        "required": false,
+        "secret": false
+      },
+      {
+        "name": "RUST_LOG",
+        "owner": "tracing",
+        "docs": "Verbosity, as `tracing` directives — `info`, `web=debug,info`.",
+        "ty": "String",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "default": "info",
+        "required": false,
+        "secret": false
+      }
+    ],
+    "ignore": [
+      "KUBERNETES_*",
+      "HOSTNAME"
+    ],
+    "unknown": "reject"
+  }
+}


### PR DESCRIPTION
## Why

A deployment pipeline holds an image digest and a `config.toml` it rendered itself, and no way to check the two agree.

Concretely, in `TimSchoenle/helm-charts`: `charts/portfolio` renders `isr.ttl_secs` into a ConfigMap. The day this service renames that key, `serde` ignores what it does not recognise and every existing gate passes — `values.schema.json` describes the chart's values rather than this app's configuration, `kubeconform` sees a valid ConfigMap holding arbitrary text, and `helm lint`, `kube-linter`, `helm unittest` and the e2e install all render and install cleanly. The pod starts, reports healthy, and runs on a compiled default nobody chose.

The same hole exists on the three other surfaces the chart writes: the `PORTFOLIO_*` variables it emits, the key-named files it mounts in `$PORTFOLIO_SECRETS_DIR`, and the env/secrets-file pairs that `ShadowPolicy::Reject` turns into a CrashLoopBackOff. All four are knowable at render time from data `crates/config` already computes.

## What changed

**terrace-config v0.5.0 → v0.6.0**, for `Schema::into_contract`.

**`--format contract`** in `examples/config-schema.rs` — one envelope carrying every key in every spelling it can be supplied by, the same keys as a draft-07 JSON Schema, and the surface no derive can see:

```json
{
  "terrace_contract": 1,
  "app": { "name": "portfolio", "version": "v2.5.0", "source": "…" },
  "schema":      { "dialect": {…}, "loader": […], "keys": […] },
  "json_schema": { "$schema": "http://json-schema.org/draft-07/schema#", … },
  "external":    { "env": […], "ignore": ["KUBERNETES_*", "HOSTNAME"], "unknown": "reject" }
}
```

It takes the **server** scope, not `all`. `github.*` belongs to `update-repos`, which lists repositories and exits during the build; publishing it would tell a chart's CI that a deployment needs a build-time credential — the false requirement the scopes exist to avoid. `--scope` is refused alongside it for the same reason a slice would be wrong.

**`External`** declares `PORT`, `IP` and `RUST_LOG`. The Dioxus toolchain and `tracing` read them before any layer of this loader exists and they carry no prefix, so nothing in the types can report them. Declared, they are checked like any key: a chart passing `PORT: "http"` fails the same gate a chart passing `PORTFOLIO_ISR__TTL_SECS: "soon"` fails. `KUBERNETES_*` and `HOSTNAME` are *ignored* rather than declared — nobody here owns them. Service links are neither and cannot be: their names are built from the release name, which an image cannot know, so a deployment sets `enableServiceLinks: false`.

**The image carries it three ways.** A `contract-builder` stage writes the document; the runtime stage copies it to `/config/contract.json`, so the image is self-describing with no registry at all; and three labels make it findable without pulling a layer.

**`examples/verify-labels.rs`** is the check the `LABEL` block needs and a source diff cannot give. All three values are constants, so the block is hand-written — which means the ways it goes wrong are invisible to the repository: a line dropped on a branch nobody read, a base image contributing its own.

```bash
docker inspect -f '{{json .Config.Labels}}' image:test | cargo run -p portfolio-config --features config-schema --example verify-labels
```

**`docs/config.contract.json`** is committed, and a new `Config Contract` job gates it. A configuration change is then visible in the pull request that makes it: a removed key shows up in the diff, beside the chart it is about to break. The job also diffs the Dockerfile's label block against `--format dockerfile`.

## Notes for review

- **A gate, not a render-and-commit.** The README and `config.example.toml` are auto-committed because a stale one is a stale page. This document is consumed by another repository's CI, where a copy that lands one commit late is a gate passing against the wrong document.
- **`--revision` and `--created` are not passed by the gate.** They move between builds of the same source, so the committed copy carries neither and a published one carries both; the configuration half is what the diff is about.
- **`app.version` is `v`-prefixed.** The field exists to be compared against an image tag and this repository tags `v2.5.0`; `CARGO_PKG_VERSION` yields the bare form.
- **No new dependencies, and nothing reaches the shipped binary.** `config-schema` stays off by default, so `serde_json`, `syn` and the derive reach the generator and never `apps/web`. The `contract-builder` stage sits on `generate` and depends on `crates/config` alone, so it rebuilds when a configuration type changes and stays cached across every change to the site.
- **The document is byte-stable**, which is what lets it be committed and diffed. Nothing in the generator reads a clock, a hash seed or the environment.
- Phase 0 of the design lives in `terrace-config`'s `docs/config-contract-plan.md`; this is Phase 1, and nothing in `helm-charts` is touched.

## Gates

```
cargo fmt --all --check
cargo clippy --workspace --all-targets                       # clean
cargo clippy -p portfolio-config --features config-schema --all-targets   # clean
cargo test --workspace                                       # all green
docker buildx build --check                                  # no warnings
--format contract, twice                                     # byte-identical, matches the committed copy
--format dockerfile                                          # matches the Dockerfile's LABEL block
```
