### PR TITLE
chore(deps): update h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Why

```
Crate:     h2
Version:   0.4.15
Title:     h2 unbounded empty DATA frames
Date:      2026-08-17
ID:        RUSTSEC-2026-0258
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0258
Solution:  Upgrade to >=0.4.16
```

`h2` before 0.4.16 accepts an unbounded stream of empty DATA frames, letting a peer hold a connection open and burn CPU without ever advancing the stream. The SSR server reaches it through `hyper`, so this is on the request path of every deployed instance rather than a build-time dependency.

The advisory was published 2026-08-17, so `Cargo Audit` has been failing on `main` and on every open PR since.

## What changed

The lockfile, and only the `h2` entry. `h2` is transitive — no manifest in this workspace names it — so there is nothing else to bump.

Edited in place rather than through `cargo update -p h2 --precise 0.4.16`, which on this machine also re-resolved five unrelated `windows-sys` references down from `0.61.2` to `0.52.0`. The advisory is about one crate and the diff should be about one crate; a dependency downgrade smuggled into a security bump is the kind of thing nobody reads twice.

```diff
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
```

## Gates

```
cargo check --workspace --locked   # the lockfile is consistent, not just edited
cargo audit                        # exit 0; the 6 remaining warnings are the pre-existing
                                   # unmaintained ones CI already allows
```

Kept separate from #1115, which is a feature branch that does not touch `h2` — that one can rebase onto this.
