### PR TITLE
ci: regenerate the config contract and its labels instead of only gating them

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,9 +38,12 @@ jobs:
   # diffing makes a configuration change visible in the pull request that makes it: a removed key
   # shows up in the diff, next to the chart it is about to break.
   #
-  # A gate rather than a render-and-commit like the README and the example file. Those two are
-  # documentation and a stale one is a stale page; this one is consumed by another repository's
-  # CI, and a copy that arrives one commit late is a gate passing against the wrong document.
+  # The gate stays now that `update-files.yaml` regenerates both artefacts and commits them: the
+  # two answer different questions. That workflow makes a pull request converge on the contract
+  # its types produce; this one refuses to let one merge before it has. A copy that arrives a
+  # commit late is a gate passing against the wrong document, and this job is what makes "late"
+  # observable — which is also why it belongs in the repository's required checks and not only
+  # in the run list.
   #
   # `--revision` and `--created` are deliberately not passed here. They move between builds of the
   # same source, so the committed copy carries neither and the published one carries both — the
@@ -70,22 +73,33 @@ jobs:
           cargo run -q -p portfolio-config --features config-schema \
             --example config-schema -- --format contract > docs/config.contract.json
           if ! git diff --exit-code -- docs/config.contract.json; then
-            echo "::error file=docs/config.contract.json::The configuration surface changed and the committed contract did not. Regenerate it with the command in this step and commit the result." >&2
+            echo "::error file=docs/config.contract.json::The configuration surface changed and the committed contract did not. The Update Files workflow regenerates and commits it; wait for its push, or run the command in this step and commit the result yourself." >&2
             exit 1
           fi
 
-      # The block is hand-carried, because a `LABEL` key cannot be interpolated from a generator.
-      # This is the half a source diff can see; `examples/verify-labels.rs` is the half it cannot,
-      # and runs against the built image.
+      # The block sits in the Dockerfile as literal text, because a `LABEL` key cannot be
+      # interpolated from a generator. This is the half a source diff can see;
+      # `examples/verify-labels.rs` is the half it cannot, and runs against the built image.
+      #
+      # Cut at the `terrace-config:labels` markers rather than at a fixed line count, so the
+      # comparison covers whatever the region currently holds — and it is the same region
+      # `update-files.yaml` rewrites, which is what stops the check and the fix from disagreeing
+      # about where the block ends. An empty slice means the markers are gone, which `diff`
+      # would otherwise report as three deleted lines rather than as the missing region it is.
       #
       # The blank line `println!` leaves after the block is dropped, so the comparison is about
-      # the three labels and not about how each side was captured.
+      # the labels and not about how each side was captured.
       - name: Check the Dockerfile's label block against the contract
         run: |
           set -euo pipefail
           cargo run -q -p portfolio-config --features config-schema \
             --example config-schema -- --format dockerfile | sed '/^$/d' > /tmp/labels.expected
-          grep -A2 'LABEL dev.terrace.config' Dockerfile > /tmp/labels.actual
+          sed -n '/^# terrace-config:labels:begin$/,/^# terrace-config:labels:end$/p' Dockerfile \
+            | sed '1d;$d' > /tmp/labels.actual
+          if [ ! -s /tmp/labels.actual ]; then
+            echo "::error file=Dockerfile::the terrace-config:labels region is missing or empty; the generated label block has nowhere to go" >&2
+            exit 1
+          fi
           diff -u /tmp/labels.expected /tmp/labels.actual
 
   test:

--- a/.github/workflows/update-files.yaml
+++ b/.github/workflows/update-files.yaml
@@ -185,3 +185,143 @@ jobs:
               issue_number: context.issue.number,
               body: `Re-rendered from the configuration types in \`crates/config\`:\n\n${rendered}`
             })
+
+  # The two artefacts the image publishes about its own configuration: `docs/config.contract.json`,
+  # which a chart's CI reads to check that what it renders is what this image loads, and the
+  # `LABEL` block that makes that document discoverable on the image without pulling a layer.
+  #
+  # Both were gate-only, and the gate had a case it could not clear on its own. `app.version` in
+  # the contract is `CARGO_PKG_VERSION`, so a release pull request — which moves the version and
+  # nothing else — makes the committed contract stale by construction, and release-please has no
+  # step that would regenerate it. Every release was therefore red on Config Contract until
+  # someone pushed the regenerated file by hand, and the check is not a required one, so the
+  # alternative outcome was worse: a release merging with a contract naming the previous version,
+  # published to the chart repository as the description of an image that does not match it.
+  #
+  # Regenerating here fixes the general case as well as that one, and on the same terms as the
+  # documents above: the generator reads nothing from the environment, so a pull request that did
+  # not touch the configuration surface produces no commit.
+  #
+  # A job of its own, after `render-generated-files`, for the reason given there — one pusher on
+  # the head ref at a time. The gate in `build.yaml` stays: this makes the branch converge, that
+  # refuses to let it merge before it has.
+  sync-config-contract:
+    name: Ensure the Config Contract and its Labels Match the Types
+    needs: render-generated-files
+    environment:
+      name: ci
+      deployment: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push the regenerated contract and label block
+      pull-requests: write # to comment on PRs
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Generate Bot Token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ACTIONS_MAINTENANCE_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_MAINTENANCE_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      # `--revision` and `--created` are deliberately not passed, exactly as in the gate: they
+      # move between builds of the same source, so the committed copy carries neither and the
+      # copy the image publishes carries both. What is committed here is the configuration half.
+      - name: Regenerate the configuration contract
+        run: |
+          set -euo pipefail
+          cargo run -q -p portfolio-config --features config-schema \
+            --example config-schema -- --format contract > docs/config.contract.json
+
+      # Rewritten between the markers the Dockerfile carries, so this replaces the region by name
+      # rather than by line count: `sed '…/q'` prints through the opening marker and stops, the
+      # generated block goes in, and the second `sed` resumes at the closing marker. A block that
+      # grows a fourth key upstream lands the same way the first three do.
+      #
+      # Refuses rather than writes when a marker is missing: with no opening marker the first
+      # `sed` prints the whole file and the result would be a Dockerfile with the block appended
+      # to its end. Only the region is generated, so the file must already say where it is.
+      #
+      # Both intermediates live in `RUNNER_TEMP` rather than beside the Dockerfile, so a step
+      # that dies halfway through leaves the working tree as it found it.
+      - name: Rewrite the Dockerfile's contract labels
+        run: |
+          set -euo pipefail
+          begin='# terrace-config:labels:begin'
+          end='# terrace-config:labels:end'
+          for marker in "$begin" "$end"; do
+            if ! grep -qxF -- "$marker" Dockerfile; then
+              echo "::error file=Dockerfile::no '$marker' line; nothing marks where the generated label block belongs" >&2
+              exit 1
+            fi
+          done
+          cargo run -q -p portfolio-config --features config-schema \
+            --example config-schema -- --format dockerfile \
+            | sed '/^$/d' > "${RUNNER_TEMP}/labels.generated"
+          {
+            sed "/^${begin}\$/q" Dockerfile
+            cat "${RUNNER_TEMP}/labels.generated"
+            sed -n "/^${end}\$/,\$p" Dockerfile
+          } > "${RUNNER_TEMP}/Dockerfile.next"
+          mv "${RUNNER_TEMP}/Dockerfile.next" Dockerfile
+
+      # Two commits rather than one: a change to the build recipe and a change to a published
+      # document are different things to review, and the version bump that motivates most of
+      # these touches only the contract. `file_pattern` keeps each commit to its own file.
+      - name: Commit the regenerated contract
+        id: contract
+        uses: TimSchoenle/actions/actions/common/commit-changes@0a6ad3014d13b1baa2e6ab1966603fe88ed5887b # tag=actions-common-commit-changes-v1.3.1
+        with:
+          commit_message: 'docs: regenerate the configuration contract'
+          file_pattern: 'docs/config.contract.json'
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Commit the Dockerfile's contract labels
+        id: labels
+        uses: TimSchoenle/actions/actions/common/commit-changes@0a6ad3014d13b1baa2e6ab1966603fe88ed5887b # tag=actions-common-commit-changes-v1.3.1
+        with:
+          commit_message: 'build: sync the Dockerfile contract labels'
+          file_pattern: 'Dockerfile'
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Comment on PR
+        if: >-
+          github.event_name == 'pull_request'
+          && (steps.contract.outputs.changes_detected == 'true'
+          || steps.labels.outputs.changes_detected == 'true')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          CONTRACT_CHANGED: ${{ steps.contract.outputs.changes_detected }}
+          LABELS_CHANGED: ${{ steps.labels.outputs.changes_detected }}
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            const regenerated = [
+              ['docs/config.contract.json', '--format contract', process.env.CONTRACT_CHANGED],
+              ['Dockerfile', '--format dockerfile', process.env.LABELS_CHANGED],
+            ]
+              .filter(([, , changed]) => changed === 'true')
+              .map(([output, format]) => `- \`${output}\`, from \`config-schema ${format}\``)
+              .join('\n');
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Regenerated from the configuration types in \`crates/config\`:\n\n${regenerated}\n\nThe \`Config Contract\` job in **Build** gates these, and runs again on this push.`
+            })

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,17 +193,25 @@ ARG SOURCE_URL
 # interpolated, and no ARG and no host-side generator run stands between the
 # source and the image.
 #
-# Hand-carried means it can be wrong in ways a source diff cannot see, so the
-# check is on the built image instead:
+# Literal text can be wrong in ways a source diff alone cannot see, so the built
+# image is checked too:
 #
 #   docker inspect -f '{{json .Config.Labels}}' "$image" |
 #     cargo run -p portfolio-config --features config-schema --example verify-labels
 #
-# `--format dockerfile` emits this block, and the Config Contract job diffs the
-# two so the copy here cannot drift from the document it points at.
+# `--format dockerfile` emits the block between the markers below. The Update
+# Files workflow rewrites that region from the generator and commits the result;
+# the Config Contract job diffs it afterwards, so the copy here cannot drift from
+# the document it points at. Edit the types, not these three lines.
+#
+# The markers are what make the region machine-writable: they delimit it by name
+# rather than by line count, so a fourth label added upstream is rewritten like
+# the first three instead of falling silently outside the slice.
+# terrace-config:labels:begin
 LABEL dev.terrace.config.contract.version="1" \
       dev.terrace.config.contract.path="/config/contract.json" \
       dev.terrace.config.prefix="PORTFOLIO_"
+# terrace-config:labels:end
 LABEL org.opencontainers.image.title="portfolio" \
       org.opencontainers.image.description="Dioxus fullstack (SSR + hydration) portfolio served by Axum." \
       org.opencontainers.image.url="https://tim-schoenle.de" \

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -10,6 +10,12 @@
 //! the pull request. Neither document can drift from the types: a key renamed in `crates/config`
 //! is a key renamed in both, in the same commit.
 //!
+//! The same workflow regenerates the two artefacts the image publishes about itself —
+//! `docs/config.contract.json` and the Dockerfile's `dev.terrace.config.*` label block — and the
+//! Config Contract job in `build.yaml` diffs both afterwards. That job is the gate; this is what
+//! keeps a pull request from having to clear it by hand, including the release pull request,
+//! whose only change is the version [`contract`] stamps into the document.
+//!
 //! Nothing here reads the environment, so the output is the same on a developer's machine and on
 //! a runner where none of the variables it describes are set. That is what makes the render
 //! deterministic enough for the action to skip the commit when nothing changed.
@@ -126,8 +132,10 @@ fn render(options: &Options) -> Result<String, Box<dyn Error>> {
             .join("\n")),
         // The block the Dockerfile carries verbatim. All three values are constants for this
         // service, so nothing here is interpolated at build time and nothing has to run on the
-        // host to produce it — which is what makes `verify_labels` the check that matters: the
-        // block is hand-carried, so the only place to catch a wrong one is the built image.
+        // host to produce it. `update-files.yaml` writes this between the Dockerfile's
+        // `terrace-config:labels` markers and commits it, and the Config Contract job diffs the
+        // region afterwards; `verify_labels` is still the check that closes the loop, because a
+        // `LABEL` that is right in the source can still be wrong in the image that was built.
         Format::Dockerfile => Ok(contract()?.to_dockerfile_labels(DEFAULT_PATH)),
         Format::Variables => unreachable!("returned above"),
     }


### PR DESCRIPTION
## The failure

[The Config Contract job on #1110](https://github.com/TimSchoenle/Portfolio/actions/runs/32171370574/job/95823073665?pr=1110) is red, and no push to that branch can turn it green.

`app.version` in `docs/config.contract.json` is `CARGO_PKG_VERSION`. A release pull request moves the version and nothing else, so the committed contract goes stale by construction — and release-please has no step that would regenerate it:

```diff
   "app": {
     "name": "portfolio",
-    "version": "v2.5.0",
+    "version": "v2.6.0",
```

So every release is red on Config Contract until someone regenerates the file by hand. And `Config Contract` is not in the repository's required checks, which makes the likelier outcome the worse one: the release merges anyway, `main` ships a contract naming the previous version, and the release workflow publishes it to the chart repository as the description of an image it does not match. That is exactly the "gate passing against the wrong document" the job's own comment was written to prevent, arriving through the back door.

The same is true in general, not just for releases: any pull request touching the configuration surface had to carry a hand-regenerated contract.

## The fix

`update-files.yaml` gets a third job, `Ensure the Config Contract and its Labels Match the Types`, which regenerates both artefacts and commits them — the same treatment `README.md` and `config.example.toml` already get:

| Artefact | Generated from | Commit |
| --- | --- | --- |
| `docs/config.contract.json` | `config-schema --format contract` | `docs: regenerate the configuration contract` |
| `Dockerfile` label block | `config-schema --format dockerfile` | `build: sync the Dockerfile contract labels` |

Two commits rather than one: a change to the build recipe and a change to a published document are different things to review, and the version bump that motivates most of these touches only the contract.

It runs after `render-generated-files` rather than beside it, for the reason that job already documents — one pusher on the head ref at a time. The generator reads nothing from the environment, so a pull request that did not touch the configuration surface produces no commit, and the job posts a comment only when something actually moved.

**The gate stays.** The two answer different questions: the new job makes a branch converge on the contract its types produce, the gate refuses to let it merge before it has.

## Markers around the Dockerfile's label block

```dockerfile
# terrace-config:labels:begin
LABEL dev.terrace.config.contract.version="1" \
      dev.terrace.config.contract.path="/config/contract.json" \
      dev.terrace.config.prefix="PORTFOLIO_"
# terrace-config:labels:end
```

The block still cannot be interpolated at build time — a `LABEL` key is not an `ARG` — so it stays literal text in the file; it is now written there by CI rather than by hand.

The markers are what make that safe, and they fix a latent bug on the way: the gate used `grep -A2`, which hard-codes the block at three lines. Both sides now cut at the markers, so a fourth label added upstream in `terrace-config` is checked and rewritten like the first three instead of falling silently outside the slice. Both the fix step and the gate refuse to run rather than guess when a marker is missing — without that, the rewrite would append the block to the end of the Dockerfile.

## Why not teach release-please to do it

`extra-files` with the `json` updater can write a version into `docs/config.contract.json`, but it writes the bare `2.6.0`; the contract carries `v2.6.0`, because that is how this repository tags its images and the field exists to be compared against a tag. There is no prefix option. It would also only fix the release case, not the general one.

## Verified

- The rewrite is idempotent against the current tree, and restores a deliberately mangled block byte-for-byte.
- The gate still fails on a mangled block, and both missing-marker guards fire.
- Simulated the release bump (`crates/config` to `2.6.0`): the gate fails on the contract exactly as in the linked run, and passes once the regeneration step has written it.
- Ran the new step's shell verbatim as parsed out of the YAML; it leaves no files behind in the working tree.
- `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.

## Follow-up, not in this PR

`Config Contract` should be added to the required status checks on `main`. It is the backstop, and right now nothing stops a merge that skips it. That is a repository settings change, so I have left it to you.
