### PR TITLE
feat(config): take terrace-config v0.9.0, the shared check and a justfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@ Dockerfile.*
 docker-compose*.yml
 cst.yaml
 goss.yaml
+justfile
 hadolint*.yaml
 .trivyignore
 image.tar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,9 +45,11 @@ jobs:
   # observable — which is also why it belongs in the repository's required checks and not only
   # in the run list.
   #
-  # `--revision` and `--created` are deliberately not passed here. They move between builds of the
-  # same source, so the committed copy carries neither and the published one carries both — the
-  # configuration half is what this diff is about.
+  # Both halves of it are now one step. Six repositories carried a hand-written variant of this
+  # check and disagreed on the thing that matters most — how to cut the generated `LABEL` block
+  # back out of a Dockerfile — so the checking lives in `rust/config-contract` and `justfile`
+  # holds the writing. The two cannot drift apart, because neither one is a second opinion about
+  # the other: the action renders and compares, `just regenerate` renders and writes.
   contract:
     name: Config Contract
     runs-on: ubuntu-latest
@@ -67,40 +69,17 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
-      - name: Check the committed contract against the types
-        run: |
-          set -euo pipefail
-          cargo run -q -p portfolio-config --features config-schema \
-            --example config-schema -- --format contract > docs/config.contract.json
-          if ! git diff --exit-code -- docs/config.contract.json; then
-            echo "::error file=docs/config.contract.json::The configuration surface changed and the committed contract did not. The Update Files workflow regenerates and commits it; wait for its push, or run the command in this step and commit the result yourself." >&2
-            exit 1
-          fi
-
-      # The block sits in the Dockerfile as literal text, because a `LABEL` key cannot be
-      # interpolated from a generator. This is the half a source diff can see;
-      # `examples/verify-labels.rs` is the half it cannot, and runs against the built image.
-      #
-      # Cut at the `terrace-config:labels` markers rather than at a fixed line count, so the
-      # comparison covers whatever the region currently holds — and it is the same region
-      # `update-files.yaml` rewrites, which is what stops the check and the fix from disagreeing
-      # about where the block ends. An empty slice means the markers are gone, which `diff`
-      # would otherwise report as three deleted lines rather than as the missing region it is.
-      #
-      # The blank line `println!` leaves after the block is dropped, so the comparison is about
-      # the labels and not about how each side was captured.
-      - name: Check the Dockerfile's label block against the contract
-        run: |
-          set -euo pipefail
-          cargo run -q -p portfolio-config --features config-schema \
-            --example config-schema -- --format dockerfile | sed '/^$/d' > /tmp/labels.expected
-          sed -n '/^# terrace-config:labels:begin$/,/^# terrace-config:labels:end$/p' Dockerfile \
-            | sed '1d;$d' > /tmp/labels.actual
-          if [ ! -s /tmp/labels.actual ]; then
-            echo "::error file=Dockerfile::the terrace-config:labels region is missing or empty; the generated label block has nowhere to go" >&2
-            exit 1
-          fi
-          diff -u /tmp/labels.expected /tmp/labels.actual
+      # One render, both comparisons: the committed `docs/config.contract.json` and the
+      # Dockerfile's `terrace-config:labels` region, cut at the markers rather than by line
+      # count. `image` is empty, so the two checks that need a built image are skipped and this
+      # job stays the cheap half — the labels an image actually carries are a question for a job
+      # that has one.
+      - name: Verify the configuration contract
+        uses: TimSchoenle/actions/actions/rust/config-contract@99c83581b3486a8a9f28e43226b8f02025fcdf9a # tag=actions-rust-config-contract-v1.1.0
+        with:
+          package: portfolio-config
+          features: config-schema
+          image: ''
 
   test:
     name: Test

--- a/.github/workflows/update-files.yaml
+++ b/.github/workflows/update-files.yaml
@@ -240,46 +240,23 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
+      - name: Install just
+        uses: taiki-e/install-action@288e746965032cfcc232e09af2daf5f23c14d780 # v2.86.1
+        with:
+          tool: just
+
+      # The same two files, written by the same recipe a developer runs before pushing. Thirty
+      # lines of `sed` used to live here, and the region it cut was the one thing this workflow
+      # and the gate in `build.yaml` had to agree about — written by hand in one file and read by
+      # hand in another. Neither reads it by hand now: `just regenerate` writes the region and
+      # `rust/config-contract` compares it, and both cut at the markers `--format dockerfile`
+      # itself emits.
+      #
       # `--revision` and `--created` are deliberately not passed, exactly as in the gate: they
       # move between builds of the same source, so the committed copy carries neither and the
       # copy the image publishes carries both. What is committed here is the configuration half.
-      - name: Regenerate the configuration contract
-        run: |
-          set -euo pipefail
-          cargo run -q -p portfolio-config --features config-schema \
-            --example config-schema -- --format contract > docs/config.contract.json
-
-      # Rewritten between the markers the Dockerfile carries, so this replaces the region by name
-      # rather than by line count: `sed '…/q'` prints through the opening marker and stops, the
-      # generated block goes in, and the second `sed` resumes at the closing marker. A block that
-      # grows a fourth key upstream lands the same way the first three do.
-      #
-      # Refuses rather than writes when a marker is missing: with no opening marker the first
-      # `sed` prints the whole file and the result would be a Dockerfile with the block appended
-      # to its end. Only the region is generated, so the file must already say where it is.
-      #
-      # Both intermediates live in `RUNNER_TEMP` rather than beside the Dockerfile, so a step
-      # that dies halfway through leaves the working tree as it found it.
-      - name: Rewrite the Dockerfile's contract labels
-        run: |
-          set -euo pipefail
-          begin='# terrace-config:labels:begin'
-          end='# terrace-config:labels:end'
-          for marker in "$begin" "$end"; do
-            if ! grep -qxF -- "$marker" Dockerfile; then
-              echo "::error file=Dockerfile::no '$marker' line; nothing marks where the generated label block belongs" >&2
-              exit 1
-            fi
-          done
-          cargo run -q -p portfolio-config --features config-schema \
-            --example config-schema -- --format dockerfile \
-            | sed '/^$/d' > "${RUNNER_TEMP}/labels.generated"
-          {
-            sed "/^${begin}\$/q" Dockerfile
-            cat "${RUNNER_TEMP}/labels.generated"
-            sed -n "/^${end}\$/,\$p" Dockerfile
-          } > "${RUNNER_TEMP}/Dockerfile.next"
-          mv "${RUNNER_TEMP}/Dockerfile.next" Dockerfile
+      - name: Regenerate the configuration contract and the Dockerfile's labels
+        run: just regenerate
 
       # Two commits rather than one: a change to the build recipe and a change to a published
       # document are different things to review, and the version bump that motivates most of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,23 @@ A new config block needs no registration. Add it to the aggregate the binary
 loads and it is in the README, because that aggregate is what the generator
 describes.
 
+Two more files come out of the same types and are committed rather than
+rendered on demand: `docs/config.contract.json`, which a chart's CI reads to
+check that what it renders is what this image loads, and the
+`terrace-config:labels` region in the `Dockerfile`, which is what makes that
+document discoverable on the image without pulling a layer. Rewrite both with:
+
+```bash
+just regenerate
+```
+
+That recipe writes and never checks. The checking is
+`TimSchoenle/actions/actions/rust/config-contract`, which the `Config Contract`
+job in **Build** runs on every pull request — so there is exactly one
+implementation of each, and they cannot disagree about where the region ends.
+`just --list` has the rest, including `just render <format>` for reading one
+rendering without redirecting it anywhere.
+
 The `config-schema` feature is off by default and is never enabled by a build
 that ships; `cargo clippy --all-features --all-targets` is what keeps the
 generator compiling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,8 +4764,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config"
-version = "0.6.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.6.0#fb37309b70ad1d47edd4c1fd0fb3bea86f0ce6c8"
+version = "0.9.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.9.0#91cd47fa8beadcd336b34049c9ef7c8499ce0174"
 dependencies = [
  "figment",
  "serde",
@@ -4777,8 +4777,8 @@ dependencies = [
 
 [[package]]
 name = "terrace-config-macros"
-version = "0.6.0"
-source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.6.0#fb37309b70ad1d47edd4c1fd0fb3bea86f0ce6c8"
+version = "0.9.0"
+source = "git+https://github.com/TimSchoenle/terrace-config?tag=v0.9.0#91cd47fa8beadcd336b34049c9ef7c8499ce0174"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ portfolio-data = { path = "crates/data" }
 # update to the loader is a deliberate commit here rather than whatever `main`
 # happened to be at build time.
 #
-# `default-features = false`, then back exactly what is used. The crate is five
+# `default-features = false`, then back exactly what is used. The crate is six
 # features and this workspace takes two of them:
 #
 # - `loader` is the layering above, and the reason the dependency exists.
@@ -45,12 +45,13 @@ portfolio-data = { path = "crates/data" }
 # every consumer for a reload this workspace cannot use — see
 # `crates/config/src/lib.rs` for the two reasons.
 #
-# `schema` is left out here and turned on by `portfolio-config`'s own
-# off-by-default `config-schema` feature, so `serde_json`, `syn` and the derive
-# reach the documentation generator and never a binary this workspace ships.
+# `schema` and `schema-cli` are left out here and turned on together by
+# `portfolio-config`'s own off-by-default `config-schema` feature, so
+# `serde_json`, `syn`, the derive and the generator's argument parser reach the
+# documentation generator and never a binary this workspace ships.
 # `testing` is left out for the same reason and taken as a dev-dependency in
 # `crates/config`, which is the only crate that loads anything.
-terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.6.0", default-features = false, features = [
+terrace-config = { git = "https://github.com/TimSchoenle/terrace-config", tag = "v0.9.0", default-features = false, features = [
     "loader",
     "explain",
 ] }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -4,17 +4,22 @@ version = "2.6.0"
 edition.workspace = true
 publish.workspace = true
 
-# Off by default, and it has to stay that way: `terrace-config/schema` links
+# Off by default, and it has to stay that way: `terrace-config/schema-cli` links
 # `serde_json` and compiles a proc macro, neither of which a running binary has
 # any use for. Only `cargo run --example config-schema` and the `--all-features`
 # CI gates ever turn it on, so nothing it costs reaches the image — the
 # Dockerfile builds no feature flags at all.
 #
+# `schema-cli` rather than `schema`: it is the half of the generator every
+# consumer of `schema` was writing by hand — the `--format` vocabulary, the
+# argument parsing and the dispatch — and it pulls no dependency `schema` did
+# not already. `examples/config-schema.rs` is what is left after taking it.
+#
 # The `#[config(...)]` helper attributes are gated with it rather than left in
 # place: they are the derive's, so a build without the derive fails with
 # `cannot find attribute config` the moment one is unconditional.
 [features]
-config-schema = ["terrace-config/schema"]
+config-schema = ["terrace-config/schema-cli"]
 
 # The generator that renders the configuration reference in `README.md`. Listed
 # so `cargo clippy --all-targets --all-features` compiles it, which is the only

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -11,14 +11,29 @@
 //! is a key renamed in both, in the same commit.
 //!
 //! The same workflow regenerates the two artefacts the image publishes about itself —
-//! `docs/config.contract.json` and the Dockerfile's `dev.terrace.config.*` label block — and the
-//! Config Contract job in `build.yaml` diffs both afterwards. That job is the gate; this is what
-//! keeps a pull request from having to clear it by hand, including the release pull request,
-//! whose only change is the version [`contract`] stamps into the document.
+//! `docs/config.contract.json` and the Dockerfile's `dev.terrace.config.*` label block — through
+//! `just regenerate`, and the Config Contract job in `build.yaml` checks both afterwards. That
+//! job is the gate; this is what keeps a pull request from having to clear it by hand, including
+//! the release pull request, whose only change is the version the contract stamps into the
+//! document.
 //!
 //! Nothing here reads the environment, so the output is the same on a developer's machine and on
 //! a runner where none of the variables it describes are set. That is what makes the render
 //! deterministic enough for the action to skip the commit when nothing changed.
+//!
+//! # What is left here
+//!
+//! The `--format` vocabulary, the dispatch across the renderings, the contract's build stamp and
+//! the argument parsing for all of it are [`Cli`] and [`Request`]. They were the same two hundred
+//! lines in every repository that had a generator, which is how several of them ended up
+//! disagreeing about how to cut a `LABEL` block back out of a Dockerfile.
+//!
+//! What stays is only what no other repository has: [`Scope`], because this workspace ships two
+//! binaries that load two different roots, and `--format variables`, because the payload the
+//! templates read mixes tables from *both* of them and so is not a rendering of any one
+//! [`Schema`]. Both are expressed by choosing what to hand [`Cli::render`] rather than by
+//! re-implementing it — [`Request::parse`] still owns every argument but `--scope`, so a
+//! rendering added upstream arrives here without a line being written.
 //!
 //! # Why there are scopes
 //!
@@ -42,7 +57,7 @@
 //!
 //! # Why the payload is assembled here and not in YAML
 //!
-//! [`Format::Variables`] emits the whole render payload — both tables, the example file, and the
+//! `--format variables` emits the whole render payload — both tables, the example file, and the
 //! spellings the prose in `README.md.hbs` names — as one strict-JSON object. The workflow step
 //! that used to run this binary once per scope and stitch the results together with `jq` now
 //! runs it once and forwards what it printed.
@@ -57,8 +72,9 @@ use std::process::ExitCode;
 
 use portfolio_config::{BuilderConfig, ServerConfig};
 use serde_json::{Map, Value, json};
+use terrace_config::schema::cli::{Cli, Format, Request, USAGE};
 use terrace_config::schema::{
-    App, Column, Contract, DEFAULT_PATH, Docs, External, ExternalVar, Key, Schema, TomlExample,
+    App, Column, Docs, External, ExternalVar, JsonSchema, Key, Schema, TomlExample,
 };
 
 /// The keys `README.md.hbs` names in prose, under the names it reads them by.
@@ -77,6 +93,14 @@ const KEYS: &[(&str, &str)] = &[
     ("githubRepos", "github.repos"),
     ("githubToken", "github.token"),
 ];
+
+/// What this generator adds to the argument list [`USAGE`] describes.
+///
+/// Appended to it rather than replacing it: the format vocabulary belongs to [`Request`], and a
+/// second copy of it here is the copy that goes stale the next time terrace-config grows a
+/// rendering.
+const EXTRA_USAGE: &str =
+    "\n       and here also: [--format variables] [--scope all|server|builder]";
 
 fn main() -> ExitCode {
     let options = match Options::from_args() {
@@ -101,58 +125,30 @@ fn main() -> ExitCode {
 
 /// The schema, rendered as `options` asks for it.
 fn render(options: &Options) -> Result<String, Box<dyn Error>> {
-    if options.format == Format::Variables {
+    let Some(request) = &options.request else {
         return variables();
-    }
-
-    let schema = match options.scope {
-        Scope::All => all()?,
-        Scope::Server => server()?,
-        Scope::Builder => builder()?,
     };
 
-    match options.format {
-        Format::Json => Ok(schema.to_json()?),
-        // The loader variables lead the server table and are absent from every other one. They
-        // apply to both binaries, so a page repeating them above each scope would say the same
-        // thing twice; the server scope is where an operator setting a deployment up will be.
-        Format::Markdown => Ok(match options.scope {
-            Scope::All | Scope::Server => schema.to_markdown(),
-            Scope::Builder => schema.to_markdown_keys(Column::DEFAULT),
-        }),
-        Format::Toml => Ok(example_config(&schema)),
-        // Whole-image renderings, so the scope they take is the one binary the image runs. See
-        // `contract` for why that is the server rather than `all`.
-        Format::Contract => Ok(contract()?.to_json()?),
-        Format::Labels => Ok(contract()?
-            .labels(DEFAULT_PATH)
-            .into_iter()
-            .map(|(name, value)| format!("{name}={value}"))
-            .collect::<Vec<_>>()
-            .join("\n")),
-        // The block the Dockerfile carries verbatim. All three values are constants for this
-        // service, so nothing here is interpolated at build time and nothing has to run on the
-        // host to produce it. `update-files.yaml` writes this between the Dockerfile's
-        // `terrace-config:labels` markers and commits it, and the Config Contract job diffs the
-        // region afterwards; `verify_labels` is still the check that closes the loop, because a
-        // `LABEL` that is right in the source can still be wrong in the image that was built.
-        Format::Dockerfile => Ok(contract()?.to_dockerfile_labels(DEFAULT_PATH)),
-        Format::Variables => unreachable!("returned above"),
-    }
+    Ok(Cli::new(app())
+        // No `$id`: this workspace publishes no schema document at a URL, and an editor told to
+        // resolve one that is not there fails louder than one given nothing to resolve.
+        .json_schema(JsonSchema::new().title("portfolio configuration"))
+        .toml_example(toml_example())
+        .contract_with(&|builder| builder.external(external()))
+        .render(request, schema(options.scope)?)?)
 }
 
-/// The contract the runtime image publishes: every key the *server* loads, and everything else
-/// the container reads.
+/// The image this workspace builds, as the contract names it.
 ///
-/// # Why the server scope and not `all`
-///
-/// A contract is a claim about one image. This workspace builds one — the `scratch` runtime stage
-/// holding the SSR server — and `github.*` is not in it: `update-repos` runs during the build,
-/// lists repositories and exits, and its token is a build secret a deployment never supplies.
-/// Publishing [`all`] would tell a chart's CI that `PORTFOLIO_GITHUB__TOKEN` is a variable this
-/// image reads, which is exactly the false requirement the scopes exist to avoid.
-///
-/// # The part no derive can see
+/// The version is `v`-prefixed, because that is how this repository tags its images and the field
+/// exists to be compared against a tag. `CARGO_PKG_VERSION` yields the bare form.
+fn app() -> App {
+    App::new("portfolio")
+        .version(concat!("v", env!("CARGO_PKG_VERSION")))
+        .source("https://github.com/TimSchoenle/Portfolio")
+}
+
+/// The part of the contract no derive can see.
 ///
 /// `PORT`, `IP` and `RUST_LOG` are read by the Dioxus toolchain and by `tracing`, before any
 /// layer of this loader exists, and they carry no `PORTFOLIO_` prefix — so nothing in the types
@@ -161,47 +157,47 @@ fn render(options: &Options) -> Result<String, Box<dyn Error>> {
 ///
 /// The defaults are the ones the Dockerfile's `ENV` block bakes in, which is where the image's
 /// real behaviour is decided.
-fn contract() -> Result<Contract, Box<dyn Error>> {
-    Ok(server()?
-        .into_contract(
-            // `v`-prefixed, because that is how this repository tags its images and the field
-            // exists to be compared against a tag. `CARGO_PKG_VERSION` yields the bare form.
-            App::new("portfolio")
-                .version(concat!("v", env!("CARGO_PKG_VERSION")))
-                .source("https://github.com/TimSchoenle/Portfolio"),
+fn external() -> External {
+    External::new()
+        .var(
+            ExternalVar::new("PORT")
+                .owner("dioxus")
+                .ty("u16")
+                .default("8080")
+                .docs("Bind port. Read by the Dioxus toolchain, not by this loader."),
         )
-        .external(
-            External::new()
-                .var(
-                    ExternalVar::new("PORT")
-                        .owner("dioxus")
-                        .ty("u16")
-                        .default("8080")
-                        .docs("Bind port. Read by the Dioxus toolchain, not by this loader."),
-                )
-                .var(
-                    ExternalVar::new("IP")
-                        .owner("dioxus")
-                        .ty("IpAddr")
-                        .default("0.0.0.0")
-                        .docs("Bind address. Read by the Dioxus toolchain, not by this loader."),
-                )
-                .var(
-                    ExternalVar::new("RUST_LOG")
-                        .owner("tracing")
-                        .ty("String")
-                        .default("info")
-                        .docs("Verbosity, as `tracing` directives — `info`, `web=debug,info`."),
-                )
-                // What a pod carries that no image asked for, which `Unknown::Reject` names:
-                // the API server's five, and the container runtime's one. An image on `scratch`
-                // contributes none of its own. The third entry on that list — the service links —
-                // is not here and cannot be: their names are built from the release name, so they
-                // belong to `enableServiceLinks: false` on the pod.
-                .ignore("KUBERNETES_*")
-                .ignore("HOSTNAME"),
+        .var(
+            ExternalVar::new("IP")
+                .owner("dioxus")
+                .ty("IpAddr")
+                .default("0.0.0.0")
+                .docs("Bind address. Read by the Dioxus toolchain, not by this loader."),
         )
-        .build()?)
+        .var(
+            ExternalVar::new("RUST_LOG")
+                .owner("tracing")
+                .ty("String")
+                .default("info")
+                .docs("Verbosity, as `tracing` directives — `info`, `web=debug,info`."),
+        )
+        // What a pod carries that no image asked for, which `Unknown::Reject` names: the API
+        // server's five, and the container runtime's one. An image on `scratch` contributes none
+        // of its own. The third entry on that list — the service links — is not here and cannot
+        // be: their names are built from the release name, so they belong to
+        // `enableServiceLinks: false` on the pod.
+        .ignore("KUBERNETES_*")
+        .ignore("HOSTNAME")
+}
+
+/// How `config.example.toml` renders, in the one place both callers read it from.
+///
+/// [`Docs::Full`] rather than the default summary: this is the file an operator edits with no
+/// rustdoc open beside it, and every paragraph the fields carry is a paragraph the hand-written
+/// version of this file used to carry too. No header, because the template supplies one — what
+/// this file is and how to point the loader at it are facts about the repository rather than
+/// about the schema, and the layering itself is documented once, in `README.md`.
+fn toml_example() -> TomlExample {
+    TomlExample::new().header(false).docs(Docs::Full)
 }
 
 /// The whole render payload, as the strict JSON the template action takes.
@@ -209,6 +205,10 @@ fn contract() -> Result<Contract, Box<dyn Error>> {
 /// One object for both templates. An unread name costs a template nothing — strict mode fails on
 /// a reference the payload does not *define*, never on a definition nothing reads — so the
 /// alternative, a payload per template, would only be two ways to get the same schema out.
+///
+/// This is the one rendering [`Cli`] cannot produce, and the reason this generator still has a
+/// `--format` of its own: it mixes a table from each scope with a third built from both, so there
+/// is no single [`Schema`] whose rendering it is.
 ///
 /// # Errors
 /// If a path in [`KEYS`] names no key in the merged schema, which is a rename the prose in
@@ -234,7 +234,7 @@ fn variables() -> Result<String, Box<dyn Error>> {
     let payload = json!({
         "serverConfigTable": server()?.to_markdown().trim_end(),
         "builderConfigTable": builder()?.to_markdown_keys(Column::DEFAULT).trim_end(),
-        "exampleConfig": example_config(&all).trim_end(),
+        "exampleConfig": all.to_toml_example_with(&toml_example()).trim_end(),
         "loader": {
             "envPrefix": all.dialect.prefix,
             "envNesting": all.dialect.nesting_separator,
@@ -258,17 +258,13 @@ fn spellings(key: &Key) -> Value {
     })
 }
 
-/// The body of `config.example.toml`: every key, commented out at its default.
-///
-/// No preamble, because the template supplies one — what this file is and how to point the
-/// loader at it are facts about the repository rather than about the schema, and the layering
-/// itself is documented once, in `README.md`. What is left is what only the types know.
-///
-/// [`Docs::Full`] rather than the default summary: this is the file an operator edits with no
-/// rustdoc open beside it, and every paragraph the fields carry is a paragraph the hand-written
-/// version of this file used to carry too.
-fn example_config(schema: &Schema) -> String {
-    schema.to_toml_example_with(&TomlExample::new().header(false).docs(Docs::Full))
+/// The schema one scope describes.
+fn schema(scope: Scope) -> Result<Schema, portfolio_config::ConfigError> {
+    match scope {
+        Scope::All => all(),
+        Scope::Server => server(),
+        Scope::Builder => builder(),
+    }
 }
 
 /// Every key in the workspace, which is what a machine-readable contract and the example file
@@ -300,27 +296,11 @@ fn builder() -> Result<Schema, portfolio_config::ConfigError> {
 
 /// What to emit, and how much of it.
 struct Options {
-    format: Format,
+    /// What to hand [`Cli::render`], or `None` for `--format variables` — see [`variables`].
+    request: Option<Request>,
+    /// Whose configuration to render. Resolved rather than optional: the whole-image formats fix
+    /// their own scope, and everything else defaults to [`Scope::All`].
     scope: Scope,
-}
-
-/// Which rendering to emit.
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum Format {
-    /// The versioned contract, for a consumer that renders its own tables.
-    Json,
-    /// GitHub-flavoured tables, which is what the README template interpolates.
-    Markdown,
-    /// A commented `config.toml` holding every key at its default.
-    Toml,
-    /// Everything the templates interpolate, as one strict-JSON object.
-    Variables,
-    /// The versioned contract a container build attaches to its image.
-    Contract,
-    /// The image labels that make that contract discoverable, one `NAME=value` per line.
-    Labels,
-    /// The same three as a `LABEL` instruction, for the Dockerfile to carry.
-    Dockerfile,
 }
 
 /// Whose configuration to report.
@@ -335,66 +315,101 @@ enum Scope {
 }
 
 impl Options {
-    /// Everything, as JSON: the output that loses nothing.
+    /// Take `--scope` and `--format variables`, and let [`Request::parse`] have the rest.
+    ///
+    /// Forwarding rather than parsing is what keeps this file from owning a copy of the format
+    /// vocabulary: `--only`, `--path`, `--version`, `--revision`, `--created` and every rendering
+    /// terrace-config ships are handled by the crate that defines them, with its messages, and a
+    /// rendering added upstream needs no change here.
     fn from_args() -> Result<Self, String> {
-        let mut format = Format::Json;
         let mut scope = None;
+        let mut variables = false;
+        let mut forwarded = Vec::new();
+
         let mut args = std::env::args().skip(1);
         while let Some(flag) = args.next() {
             match flag.as_str() {
-                "--format" => {
-                    format = match args.next().as_deref() {
-                        Some("json") => Format::Json,
-                        Some("markdown" | "md") => Format::Markdown,
-                        Some("toml") => Format::Toml,
-                        Some("variables") => Format::Variables,
-                        Some("contract") => Format::Contract,
-                        Some("labels") => Format::Labels,
-                        Some("dockerfile") => Format::Dockerfile,
-                        Some(other) => return Err(format!("unknown format `{other}`; {USAGE}")),
-                        None => return Err(format!("--format takes a value; {USAGE}")),
-                    };
-                }
                 "--scope" => {
                     scope = match args.next().as_deref() {
                         Some("all") => Some(Scope::All),
                         Some("server") => Some(Scope::Server),
                         Some("builder") => Some(Scope::Builder),
-                        Some(other) => return Err(format!("unknown scope `{other}`; {USAGE}")),
-                        None => return Err(format!("--scope takes a value; {USAGE}")),
+                        Some(other) => return Err(usage(&format!("unknown scope `{other}`"))),
+                        None => return Err(usage("`--scope` takes a value")),
                     };
                 }
-                other => return Err(format!("unknown argument `{other}`; {USAGE}")),
+                // The one rendering that is this repository's own. Every other spelling —
+                // including one neither side knows — travels on to `Request::parse`, which is
+                // where the "unknown format" message belongs and stays correct.
+                "--format" => {
+                    let value = args.next();
+                    if value.as_deref() == Some("variables") {
+                        variables = true;
+                    } else {
+                        forwarded.push(flag);
+                        forwarded.extend(value);
+                    }
+                }
+                _ => forwarded.push(flag),
             }
         }
 
-        // Refused rather than ignored: the payload carries a table *per* scope, so a caller
-        // asking for one scope of it is asking for something this cannot give, and silently
-        // handing back all of it would be found much later by whoever read the rendered page.
-        if format == Format::Variables && scope.is_some() {
-            return Err(format!("--format variables covers every scope; {USAGE}"));
+        if variables {
+            // Refused rather than ignored: the payload carries a table *per* scope, so a caller
+            // asking for one scope of it is asking for something this cannot give, and silently
+            // handing back all of it would be found much later by whoever read the rendered page.
+            if scope.is_some() {
+                return Err(usage("`--format variables` covers every scope"));
+            }
+            // Same reasoning for the rest of the argument list: `--only` slices and `--version`
+            // stamps a rendering this does not produce, so anything passed alongside would have
+            // been quietly dropped.
+            if let Some(other) = forwarded.first() {
+                return Err(usage(&format!(
+                    "`--format variables` takes no other argument, and got `{other}`"
+                )));
+            }
+            return Ok(Self {
+                request: None,
+                scope: Scope::All,
+            });
         }
 
-        // Same reasoning, one step further: a contract names the image it belongs to, and this
-        // workspace ships one. Its scope is decided by `contract`, not by a caller who could
-        // otherwise publish a document claiming the server reads a build-time credential.
-        if matches!(
-            format,
-            Format::Contract | Format::Labels | Format::Dockerfile
-        ) && scope.is_some()
-        {
-            return Err(format!(
-                "--format contract and --format labels describe the runtime image and fix their \
-                 own scope; {USAGE}"
-            ));
-        }
+        let request = Request::parse(forwarded).map_err(|error| usage(error.message()))?;
+
+        // A contract names the image it belongs to, and this workspace ships one: the `scratch`
+        // runtime stage holding the SSR server. Its scope is decided here, not by a caller who
+        // could otherwise publish a document claiming the server reads a build-time credential —
+        // `github.*` belongs to `update-repos`, which runs during the build and then exits.
+        let scope = if request.format().whole_image() {
+            if scope.is_some() {
+                return Err(usage(&format!(
+                    "`--format {}` describes the runtime image and fixes its own scope",
+                    request.format()
+                )));
+            }
+            Scope::Server
+        } else {
+            scope.unwrap_or(Scope::All)
+        };
+
+        // The loader variables lead the server table and are absent from every other one. They
+        // apply to both binaries, so a page repeating them above each scope would say the same
+        // thing twice; the server scope is where an operator setting a deployment up will be.
+        let request = if scope == Scope::Builder && request.format() == Format::Markdown {
+            request.with_format(Format::MarkdownKeys)
+        } else {
+            request
+        };
 
         Ok(Self {
-            format,
-            scope: scope.unwrap_or(Scope::All),
+            request: Some(request),
+            scope,
         })
     }
 }
 
-const USAGE: &str = "usage: config-schema \
-     [--format json|markdown|toml|variables|contract|labels|dockerfile]      [--scope all|server|builder]";
+/// A refusal, with both usage lines under it.
+fn usage(message: &str) -> String {
+    format!("{message}; {USAGE}{EXTRA_USAGE}")
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,101 @@
+# Local tooling. `just` with no arguments lists what there is.
+#
+# Everything a contributor has to run by hand lives here rather than in a script under
+# `.github/scripts/`, so that the command a README quotes, the command CI runs and the command a
+# developer types are one string. Recipes that only wrap `cargo` are here for the same reason:
+# the flags are the part people get wrong.
+#
+#     https://github.com/casey/just
+#
+# There is deliberately no recipe that *checks* the generated artefacts. Checking is
+# `TimSchoenle/actions/actions/rust/config-contract`, which does it in three places this file
+# cannot reach — against the Dockerfile, against the committed document, and against the labels a
+# built image actually carries. A second implementation here would be a second opinion, and the
+# whole point of the shared action is that there is only one.
+
+# The generator, and where its output belongs. These five lines are the only per-repository part
+# of this file.
+example := "config-schema"
+features := "config-schema"
+package := "portfolio-config"
+contract := "docs/config.contract.json"
+dockerfile := "Dockerfile"
+
+# The markers `--format dockerfile` emits around the LABEL block. Defined by terrace-config, not
+# by this repository: cutting the region by line count reads correctly right up until a fourth
+# label is added, and then compares two of three lines and passes.
+begin := "# terrace-config:labels:begin"
+end := "# terrace-config:labels:end"
+
+[private]
+default:
+    @just --list --unsorted
+
+[doc('Rewrite everything generated from src/config.rs')]
+regenerate: contract-json dockerfile-labels
+
+[doc('Print one rendering: json|markdown|markdown-loader|markdown-keys|toml|json-schema|contract|labels|dockerfile')]
+[group('generate')]
+render format:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=(run --quiet --example "{{ example }}")
+    [ -n "{{ package }}" ] && args+=(-p "{{ package }}")
+    [ -n "{{ features }}" ] && args+=(--features "{{ features }}")
+    cargo "${args[@]}" -- --format "{{ format }}"
+
+# Rendered without `--version`, `--revision` or `--created`, so it is byte-reproducible across
+# rebuilds and releases: the committed copy describes the configuration surface, and the copy
+# inside an image additionally names the build it came from.
+
+[doc('Rewrite the committed contract document')]
+[group('generate')]
+contract-json:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p "$(dirname "{{ contract }}")"
+    just render contract > "{{ contract }}"
+    echo "wrote {{ contract }}"
+
+# The file is rebuilt around the markers rather than substituted in place: `sed` cannot replace a
+# multi-line block portably, and `--format dockerfile` emits both markers along with the block
+# between them.
+
+[doc('Rewrite the LABEL region in the Dockerfile')]
+[group('generate')]
+dockerfile-labels:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! grep -qF '{{ begin }}' "{{ dockerfile }}" || ! grep -qF '{{ end }}' "{{ dockerfile }}"; then
+        echo "error: {{ dockerfile }} carries no '{{ begin }}' … '{{ end }}' region, so the" >&2
+        echo "       generated LABEL block has nowhere to go. Paste 'just render dockerfile'" >&2
+        echo "       into it once, markers included." >&2
+        exit 1
+    fi
+    block="$(mktemp)"
+    rewritten="$(mktemp)"
+    trap 'rm -f "$block" "$rewritten"' EXIT
+    just render dockerfile > "$block"
+    {
+        sed -n "1,/^{{ begin }}\$/p" "{{ dockerfile }}" | sed '$d'
+        cat "$block"
+        sed -n "/^{{ end }}\$/,\$p" "{{ dockerfile }}" | sed '1d'
+    } > "$rewritten"
+    mv "$rewritten" "{{ dockerfile }}"
+    echo "wrote the LABEL region in {{ dockerfile }}"
+
+[doc('Format, lint and test — what a pull request is going to run anyway')]
+[group('check')]
+verify: fmt lint test
+
+[group('check')]
+fmt:
+    cargo fmt --all
+
+[group('check')]
+lint:
+    cargo clippy --all-features --all-targets -- -D warnings
+
+[group('check')]
+test:
+    cargo test --all-features


### PR DESCRIPTION
Moves onto terrace-config v0.9.0, delegates the generator's dispatch to `terrace_config::schema::cli`, replaces the inline label-checking YAML with the shared `rust/config-contract` action, and moves local tooling to `just`.

This repo keeps more of its own program than the others, for two reasons that are real rather than gaps:

- **`--scope all|server|builder`** picks which of two schemas to describe. `Cli` renders one `Schema`; choosing between them is this repo's business.
- **`--format variables`** mixes `server()`'s markdown table, `builder()`'s key table and a TOML example built from `all()` into one JSON object. That is not a rendering of any single `Schema`.

So it drops to the `Request` layer rather than `Cli::main`: `--scope` is stripped from argv and the remainder handed to `Request::parse`, so a rendering added upstream needs no line here. Everything else is delegated — the format vocabulary, `--only`/`--path`/`--version`/`--revision`/`--created`, the seven-arm dispatch, contract assembly, label joining, error messages. The two scope-specific behaviours became request choices: `markdown --scope builder` is now `Format::MarkdownKeys`, and the whole-image formats fix the scope to `server` via `whole_image()`.

## Behaviour is unchanged, and this was checked properly

27 invocations captured before the change and re-run after — every `--format` × `--scope` pair, every refusal, the `md` alias. **Every stdout and every exit status is byte-identical**, with one deliberate exception: `--format dockerfile` now emits the `terrace-config:labels` markers around the block, which is what the shared check cuts on. Three previously-erroring formats now work (`markdown-loader`, `markdown-keys`, `json-schema`); no refusal became an acceptance otherwise.

## Verified locally

`cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets` and `cargo clippy -p portfolio-config --all-targets --features config-schema -- -D warnings` both 0 warnings (the examples are `required-features`-gated, so the workspace command alone does not compile them); `cargo test --workspace` passes, `cargo test -p portfolio-config --features config-schema` 18 pass; all 6 workflows parse; `just regenerate` wrote no change twice over and both artefacts are byte-identical to the parent commit; `just --fmt --check` clean.

No job gained a Rust toolchain, so no `cache: false` was needed — the jobs that run the generator already had one and publish no image.

zizmor: 0 findings before and after as invoked — but **5 of 6 workflow files carry a UTF-8 BOM and zizmor 1.29.0 skips them silently**, so only `security.yml` is really audited. On BOM-stripped copies the count is 1 high before → 1 high after (the pre-existing `github-app` finding). Flagged separately; it affects four repositories.

## Two follow-ups worth knowing about

1. **`crates/config/examples/verify-labels.rs` is dead code.** Nothing invokes it, and it carries a second, silently diverging copy of the external surface (its `ExternalVar`s lack the `.docs(...)` the generator's have). It was already unused before this change; v0.9.0's `schema::cli::verify` and the action's `image:` input now make it redundant twice over. The Dockerfile comments around lines 196–200 still tell a reader to run it.
2. `justfile` was added to `.dockerignore` — the Dockerfile does `COPY . .`, so editing it would otherwise bust the build cache.