### PR TITLE
docs: bring the README onto the shared standard

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -1,474 +1,261 @@
 <!--
-Template for the repository README. CI renders it on every pull request and commits the result
-to README.md, so edit this file — never README.md itself.
+Generated from .github/templates/README.md.hbs. Edit that file, never this one.
 
-Every variable comes from one command:
+Two payloads are merged into one render. The repository's own facts — name, description, version,
+licence, toolchain and the docs/ index — come from
+TimSchoenle/actions/actions/common/readme-variables, which reads the root Cargo.toml and walks
+docs/. It deliberately does not read the description from the GitHub API: one edited in the web UI
+would change this file with no commit behind it, and the next unrelated pull request would fail the
+drift gate for a reason absent from its own diff.
 
-    cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format variables
+The configuration half comes from one command:
 
-which walks the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
-binaries actually load — and prints the whole payload as strict JSON:
+    cargo run -q -p portfolio-config --features config-schema \
+      --example config-schema -- --format variables
 
-  - `serverConfigTable` and `builderConfigTable`, one Markdown table per binary, each key with
-    its TOML path, type, environment spelling, default and purpose. The server scope leads with
-    the variables the loader reads before any layer exists; the builder scope renders keys alone,
-    because they would be the same two variables. Both go through a triple-stash, being Markdown
-    to emit as-is rather than escape.
-  - `loader`, the dialect: the prefix, the nesting separator, the indirection suffix and the two
-    variables naming the layers.
-  - `keys`, the spellings of the handful of keys the prose below names — `keys.githubToken.env`,
-    `keys.githubToken.envFile`, and so on.
-
-Prefer an injected value to a typed one anywhere the two would say the same thing. A rename in
-`crates/config` then reaches the sentences as well as the tables, and a key the prose names and
-the types no longer have fails the generator instead of rendering a blank. `KEYS` in
-`crates/config/examples/config-schema.rs` is where a key joins that set.
-
-Neither table has a `_FILE` column: it is the environment spelling plus a constant suffix, which
-the layer list above the tables already states once.
-
-They are two tables and not one on purpose. A single list of every key reads as though a
-deployment needs a GitHub token; it does not, because `github.*` belongs to a build-time tool
+which walks the `Describe` derives on `ServerConfig` and `BuilderConfig`, the aggregates the two
+binaries actually load, and prints both tables, the example configuration and the spellings the
+prose below names. The two tables are two on purpose: one list of every key reads as though a
+deployment needs a GitHub token, and it does not, because `github.*` belongs to a build-time tool
 that exits during the image build.
 
-That is what keeps the configuration reference honest across a rename: the key table is not a
-copy of the types, it is the types, and a pull request that renames a field arrives with the
-README already saying so. `.github/workflows/update-files.yaml` is the job that does it.
+The Update Files workflow renders this on every pull request and commits the result back to the
+branch. The README job in Build re-renders with `check: true` and fails when the committed file
+does not match it, so a README edited by hand does not merge.
 
-This is an HTML comment, not a template one, so Handlebars parses it like any other line and it
-survives into README.md — which is the point, since that is where someone about to edit the
-wrong file will be. Nothing in it may contain a mustache that is not a real reference.
+Prefer an injected value to a typed one anywhere the two would say the same thing. A rename in
+`crates/config` then reaches the sentences as well as the tables, and a key the prose names and the
+types no longer have fails the generator instead of rendering a blank. `KEYS` in
+`crates/config/examples/config-schema.rs` is where a key joins that set.
+
+Nothing in this comment may contain a mustache that is not a real reference.
 -->
-# Portfolio
 
-Personal portfolio at [tim-schoenle.de](https://tim-schoenle.de).
+# {{ repo.name }}
 
-A **Rust + Dioxus** fullstack application (server-side rendered with WASM
-hydration) styled with **Tailwind CSS**, served by an **Axum** server running from
-a distroless container.
+{{ repo.description }}
 
-## Table of Contents
+[![Release](https://img.shields.io/github/v/release/{{ repo.slug }}?sort=semver)]({{ repo.url }}/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/{{ repo.slug }}/build.yaml?branch={{ repo.branch }})]({{ repo.url }}/actions/workflows/build.yaml)
+[![License](https://img.shields.io/badge/license-{{ replace repo.license "-" "--" }}-blue)](LICENSE)
+[![Rust](https://img.shields.io/badge/rust-{{ toolchain.msrv }}-orange)](https://www.rust-lang.org)
 
-- [Architecture](#architecture)
-- [Technology Stack](#technology-stack)
+## What this is
+
+The source of <{{ repo.homepage }}>, as one Rust workspace.
+
+`apps/web` is a single crate with two feature-selected builds. The `server` build is a native Axum
+binary that renders every route. The `web` build is a WASM bundle that hydrates it in the browser.
+The Dioxus CLI produces both.
+
+The configuration tables below are generated, not written. They come out of the Rust types that
+load the configuration, as do `config.example.toml` and the contract document the image publishes
+about itself, so renaming a field corrects all three in the commit that renames it.
+
+## Quick start
+
+```bash
+docker run --rm -p 8080:8080 timschoenle/portfolio:{{ release.tag }}
+```
+
+Then open <http://localhost:8080>. The runtime image is `FROM scratch`: one statically linked
+binary, the client bundle beside it, and the configuration contract at `/config/contract.json`. It
+runs as `1001:1001` and needs nothing writable.
+
+## Table of contents
+
 - [Features](#features)
-- [Getting Started](#getting-started)
-  - [Prerequisites](#prerequisites)
-  - [Development](#development)
-  - [Production Build](#production-build)
-  - [Container](#container)
+- [Installation](#installation)
+- [Usage](#usage)
 - [Configuration](#configuration)
-- [Deployment](#deployment)
-  - [Probe Endpoints](#probe-endpoints)
-  - [Read-only and Security Posture](#read-only-and-security-posture)
-  - [Content-Security-Policy](#content-security-policy)
-  - [Reproducible Builds](#reproducible-builds)
-- [Project Data (`repos.json`)](#project-data-reposjson)
-- [Third-Party Licenses](#third-party-licenses)
+- [Operations](#operations)
+- [Compatibility](#compatibility)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 - [Security](#security)
 - [License](#license)
 
-## Architecture
-
-The project is a Cargo workspace composed of one shared library crate and three
-applications.
-
-| Crate | Purpose |
-| --- | --- |
-| `crates/config` | The typed configuration blocks every binary reads, plus the Portfolio dialect of the [terrace-config](https://github.com/TimSchoenle/terrace-config) layered loader (see [Configuration](#configuration)) |
-| `crates/data` | Shared, language-neutral data (config, skills, experience, repos schema) plus embedded `i18n/{en,de}.json` translations |
-| `apps/web` | Dioxus 0.7 fullstack app: a single crate that compiles to both the WASM client (`web` feature) and the native Axum SSR server (`server` feature), with the JSON API, SEO documents, security headers, and probe endpoints |
-| `apps/resume-generator` | Generates `resume/{en,de}.pdf` and `resume-fingerprint.json` (Typst, embedded subset of Liberation Sans) |
-| `apps/update-repos` | Builder that fetches the user's active GitHub repositories (skipping archived, blacklisted, and >1-year-stale ones) and refreshes `apps/web/repos.json` using the shared `Repo`/`ReposFile` models |
-
-## Technology Stack
-
-- **App:** Rust, [Dioxus](https://dioxuslabs.com) 0.7 fullstack (Axum SSR + WASM
-  hydration) with the built-in Dioxus router
-- **Internationalization:** EN/DE via [i18nrs](https://crates.io/crates/i18nrs).
-  Translations live in `crates/data/i18n/`; the active language is persisted in
-  `localStorage` (`lang`) and detected from the browser language on first visit.
-  A unit test in `crates/data` enforces key parity between both languages.
-- **Styling:** Tailwind CSS v4 with custom design tokens
-- **Build:** the [Dioxus CLI](https://dioxuslabs.com) (`dx`)
-- **Data:** `apps/web/repos.json` is regenerated at build time from the GitHub
-  API (all active repositories — archived, blacklisted, and >1-year-stale ones
-  excluded) and embedded into the binary by `apps/web/build.rs`
-
 ## Features
 
-- Routes: `/` (single-page sections `s1`-`s5`), `/imprint`, `/privacy`, `/licenses`, and a 404 page
-- Hero with a two-line display name, scroll parallax, and a live meta card
-- Fixed chapter rail with scroll tracking and staggered reveal-on-scroll blocks
-- Stack section: an interactive skill radar (per-skill hover tooltips, category
-  filtering/dimming) and a chip matrix with confidence bars
-- Projects: a GitHub statistics strip, language filter, and loading skeletons fed
-  by `repos.json`
-- Experience accordion with year badges and animated bodies (real career data)
-- Contact: a terminal with a type-in `ssh` animation, oversized email, and action buttons
-- Command palette (Cmd+K / Ctrl+K) with fuzzy search and keyboard navigation
-- Language switcher (EN/DE) — every visible string is translated
-- Localized, single-page, ATS-readable resume PDFs with SHA-256 fingerprints on the contact card. The
-  generator scales typography down until the content fits one A4 page.
-- Legal pages (imprint, privacy policy) localized and rendered from the translation files
-- Third-party licences page generated at build time by cargo-about: every crate
-  the client and the server link, the licence it ships under, and the verbatim
-  text of every licence file found
-- Server-side rendering with WASM hydration; per-route `<head>` metadata, JSON-LD,
-  and server-negotiated locale for the first paint
-- SEO: meta/OG tags, JSON-LD, `robots.txt`, `sitemap.xml`, and a web manifest
-- Security headers set by the server: HSTS, `Referrer-Policy`, `Permissions-Policy`,
-  and a Content-Security-Policy built per document from the inline scripts it
-  actually carries, with a per-response nonce for Cloudflare's edge injection
-- WASM client tuned for size: `opt-level = "z"`, LTO, and a single codegen unit
+- Every route renders on the server and then hydrates. Per-route `<head>` metadata and JSON-LD ship
+  in the first response, and the locale is negotiated from request headers before the document is
+  serialised, so nothing arrives in the wrong language and gets swapped a moment later.
+- EN and DE throughout, including both legal pages and both resumes. `translation_key_sets_match`
+  in `crates/data` fails the build when the two translation files disagree on a key, which
+  otherwise shows up as one English string in a German page rather than as an error.
+- **The resumes are typeset during the build.** Typst lays out one A4 page per language, scaling
+  the type down and re-typesetting until the content fits, and each PDF carries a SHA-256
+  fingerprint that the contact card shows.
+- **The Content-Security-Policy is built per response.** The server hashes the inline scripts that
+  document actually carries and reserves a nonce for the script Cloudflare injects at the edge, so
+  `script-src` needs no `'unsafe-inline'`.
+- `/licenses` lists every crate the client and the server link, the licence it ships under, and the
+  verbatim text of every licence file found. cargo-about produces it during the image build, and an
+  unlisted licence fails that build.
+- The project list is fetched from the GitHub API at build time, with archived, blacklisted and
+  year-stale repositories dropped, then embedded into the binary by `build.rs`.
+- Cmd+K opens a command palette with fuzzy search and keyboard navigation. The stack section is a
+  skill radar with per-skill tooltips and category filtering.
 
-## Getting Started
+## Installation
 
-### Prerequisites
-
-- Rust (stable) with the `wasm32-unknown-unknown` target:
-  `rustup target add wasm32-unknown-unknown`
-- [Dioxus CLI](https://dioxuslabs.com) (`dx`): `cargo install dioxus-cli`
-  (or `cargo binstall dioxus-cli`)
-- [cargo-about](https://github.com/EmbarkStudios/cargo-about) (only to render the
-  third-party licences page): `cargo install --locked cargo-about`
-- Node.js (required only for the Tailwind CSS build step)
-- Docker (optional, for containerized builds)
-
-### Development
+### Docker
 
 ```bash
-# Resume PDFs + resume-fingerprint.json. Run BEFORE the web build so the
-# fingerprint is embedded (build.rs) and the PDFs are served from public/resume/.
-cargo run -p resume-generator -- apps/web/generated
-
-# Third-party licence inventory for the /licenses page (build.rs embeds it).
-# Optional: without it the page renders its "nothing to show" state.
-just licenses
-
-# Web dev server (SSR + hydration, http://localhost:8080)
-cd apps/web
-npm ci && npm run build:css
-dx serve --platform web
-
-# Tests (including i18n key parity)
-cargo test -p portfolio-data
-cargo test -p web --no-default-features --features server
+docker pull timschoenle/portfolio:{{ release.tag }}
 ```
 
-### Production Build
+Both architectures are pushed as one manifest list, so `docker pull` resolves the right image per
+node. The push carries an SBOM and max-mode provenance and is signed with cosign. Pin by digest in
+production. The Helm chart does.
+
+### Helm
 
 ```bash
-cargo run --release -p resume-generator -- apps/web/generated
-cd apps/web && npm ci && npm run build:css && dx bundle --platform web --release
+helm repo add timschoenle https://timschoenle.github.io/helm-charts
+helm install portfolio timschoenle/portfolio
 ```
 
-### Container
+The chart is in
+[TimSchoenle/helm-charts](https://github.com/TimSchoenle/helm-charts/tree/main/charts/portfolio) and
+each release bumps it to the new image digest.
 
-The container performs all of the above and serves the result on port 8080:
+### From source
 
 ```bash
-docker build -t portfolio .
+rustup target add wasm32-unknown-unknown
+cargo install --locked dioxus-cli cargo-about
+git clone {{ repo.url }}.git
+cd {{ repo.name }}
 ```
+
+Node.js is needed for the Tailwind step, and `just` runs every recipe CI runs.
+
+## Usage
+
+Two artefacts have to exist before the web build, because `apps/web/build.rs` embeds both. Without
+them it substitutes empty defaults and the pages render their empty state.
+
+```bash
+cargo run -p resume-generator -- apps/web/generated   # resume PDFs, fingerprints, social card
+just licenses                                         # third-party inventory for /licenses
+cd apps/web && npm ci && npm run build:css
+dx serve --platform web                               # SSR + hydration on http://localhost:8080
+```
+
+Run the checks CI runs, in one recipe:
+
+```bash
+just verify   # fmt, lint, test
+```
+
+Refresh the project list from the GitHub API:
+
+```bash
+{{ keys.githubToken.envFile }}=/run/secrets/gh_token \
+  cargo run --release -p update-repos -- apps/web/repos.json
+```
+
+Without a token the run still works, against the anonymous rate limit.
+[docs/PROJECT_DATA.md](docs/PROJECT_DATA.md) has the filtering rules and the caching.
 
 ## Configuration
 
-Configuration is **layered and file-first**, via
-[terrace-config](https://github.com/TimSchoenle/terrace-config). `crates/config`
-owns the typed blocks and the `{{ loader.envPrefix }}` dialect; each binary declares the
-aggregate it actually reads. Sources are merged in this order, lowest precedence
-first:
+Values are resolved in five layers, each overriding the one above it. The last three are mutually
+exclusive per key: a key supplied by two of them fails the boot rather than letting one win,
+because a stale environment variable shadowing a rotated mounted secret keeps the process running
+on the old credential.
 
-1. **Struct defaults** — the `serde` defaults in `crates/config`.
-2. **TOML** at `${{ loader.configVar }}` — a file, or every `*.toml` inside it when it
-   names a directory (so a `ConfigMap` can be split into fragments).
+1. **Defaults** — the `serde` defaults of each typed block.
+2. **TOML** at `${{ loader.configVar }}` — a file, or every `*.toml` inside it when it names a directory.
 3. **Environment** — `{{ loader.envPrefix }}`-prefixed variables, `{{ loader.envNesting }}` for nesting.
-4. **Secrets directory** at `${{ loader.secretsDirVar }}` — one file per key, named
-   after it (`{{ keys.githubToken.secretsFile }}`); this is what a Kubernetes `Secret` volume mounts.
-5. **File indirection** — `{{ loader.envPrefix }}<KEY>{{ loader.fileSuffix }}=/path` names a file holding the
-   value.
+4. **Secrets directory** at `${{ loader.secretsDirVar }}` — one file per key, named after it
+   (`{{ keys.githubToken.secretsFile }}`). This is what a Kubernetes `Secret` volume mounts.
+5. **File indirection** — `{{ loader.envPrefix }}<KEY>{{ loader.fileSuffix }}=/path` names a file holding the value.
 
-The last three are **mutually exclusive per key**: a key supplied by two of them
-fails the boot instead of one silently winning, because a stale environment
-variable shadowing a rotated mounted secret keeps the process running on the old
-credential.
+An empty value counts as unset in every layer, because container platforms routinely inject `KEY=`
+for a declared-but-unset variable.
 
-The tables below are **generated from the aggregates the binaries load** —
-`ServerConfig` and `BuilderConfig` in `crates/config`. They are split the way the
-binaries are, because the two configurations are not one: what a deployment sets
-and what the image build sets have no overlap at all.
+### Server
 
-Regenerate one on its own with:
+The two variables the loader reads before any layer exists, then every key `apps/web` loads. Each
+environment spelling also accepts a `{{ loader.fileSuffix }}` suffix naming a file that holds the value.
 
-```bash
-cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format markdown --scope server
-```
+{{{ serverConfigTable }}}
 
-#### What the server reads
+### Builder
 
-The two variables the loader itself reads, then every key `apps/web` loads. This
-is the whole surface a **deployment** configures.
+What `update-repos` loads. It runs during the image build and exits. The server never reads these
+keys, so a deployment needs no GitHub token. That is why there are two tables and not one.
 
-{{{serverConfigTable}}}
+{{{ builderConfigTable }}}
 
-#### What the `update-repos` builder reads
+`{{ keys.githubToken.path }}` is the only secret in the workspace, and it should arrive as a file
+rather than as an environment variable. `/proc/<pid>/environ`, a crash dump and `docker inspect` all
+carry the environment, and child processes inherit it. The Docker build mounts it as a BuildKit
+secret and hands `update-repos` the path.
 
-`github.*` is read only by the build-time repository lister, which runs during the
-image build and exits. **The server never loads it**, so a deployment needs no
-GitHub token and no `github` block — the Docker build supplies the token as a
-BuildKit secret and nothing survives into the image.
+`IP`, `PORT` and `RUST_LOG` sit outside this namespace deliberately. They are the Dioxus toolchain's
+contract with the binary, and it keeps reading them itself.
 
-{{{builderConfigTable}}}
+[`config.example.toml`](config.example.toml) carries every key at its default, commented out, and is
+rendered from the same payload as these tables.
 
-The `config-schema` feature is off in every build that ships, so the derive and
-the `serde_json` it pulls stay out of the image; CI's `--all-features` gates are
-what keep the generator compiling.
+## Operations
 
-An empty value counts as unset everywhere, because container platforms routinely
-inject `KEY=` for a declared-but-unset variable.
-[`config.example.toml`](./config.example.toml) is a commented starting point, and
-is generated from the same types as the tables above — every key at its default,
-commented out, so a copy of it and an empty file mean the same thing to the
-loader:
-
-```bash
-cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format toml
-```
-
-`IP`, `PORT` and `RUST_LOG` are deliberately **outside** this namespace: they are
-the Dioxus toolchain's contract with the binary (`dx serve` sets them to tell a
-development build which port it is proxied on), so the framework keeps reading
-them itself. `CI` likewise belongs to the CI provider.
-
-### Secrets
-
-`{{ keys.githubToken.path }}` is the only secret in the workspace, and it should arrive as a
-**file**, never as an environment variable — `/proc/<pid>/environ`, a crash dump
-and `docker inspect` all carry the environment, and child processes inherit it:
-
-```bash
-{{ keys.githubToken.envFile }}=/run/secrets/gh_token cargo run --release -p update-repos
-```
-
-The Docker build already does this: the `gh_token` BuildKit secret is mounted as
-a file and handed to `update-repos` by path. In the process it is a
-`secrecy::SecretString`, so it has no `Debug` or `Display` and the one place it
-becomes a `&str` is the `Authorization` header.
-
-Only the loader half of `terrace-config` is used; its hot-reload supervisor is
-not. The reasoning — the server holds no secrets, and `dioxus::serve` owns an
-accept loop with no shutdown handle — is recorded in `crates/config/src/lib.rs`.
-
-## Deployment
-
-The image is built on a `distroless/cc` base holding the dynamically linked
-`server` binary plus its sibling read-only `public/` assets under `/app` — no
-shell, package manager, or writable system paths. The Helm chart lives in a
-separate repository; the application and image here are prepared to run under a
-hardened pod spec out of the box.
-
-### Probe Endpoints
+### Probes
 
 | Endpoint | Alias | Purpose |
 | --- | --- | --- |
-| `GET /api/health` | — | General health report with the current UTC time |
-| `GET /api/health/live` | `GET /livez` | **Liveness** — process is running; failure restarts the container |
-| `GET /api/health/ready` | `GET /readyz` | **Readiness** — the client bundle (`index.html` under `{{ keys.assetsDistDir.path }}`, default `{{ keys.assetsDistDir.default }}/`) is present and servable; failure removes the pod from the Service endpoints |
+| `GET /api/health` | — | Health report with the current UTC time |
+| `GET /api/health/live` | `GET /livez` | **Liveness** — the process is running; failure restarts the container |
+| `GET /api/health/ready` | `GET /readyz` | **Readiness** — `index.html` under `{{ keys.assetsDistDir.path }}` (default `{{ keys.assetsDistDir.default }}/`) is present and servable; failure removes the pod from the Service endpoints |
 
-All probe responses are `no-store` (never cached). Readiness returns `503` until
-the assets are present.
+All probe responses are `no-store`. Readiness returns `503` until the assets are there.
 
-### Read-only and Security Posture
+### Runtime posture
 
-The server only reads from its bundle directory (the sibling `public/` dir) and
-writes logs to stdout, so it runs unchanged with a fully read-only root
-filesystem (no
-writable volume, not even `/tmp`). It is built to satisfy the restricted Pod
-Security Standard:
+The server reads its bundle directory and writes to stdout. It runs as numeric non-root
+`1001:1001`, so `runAsNonRoot` verifies statically, and it satisfies the restricted Pod Security
+Standard with a read-only root filesystem, no privilege escalation, every capability dropped and
+`seccompProfile: RuntimeDefault`.
 
-- runs as numeric non-root `1001:1001` (so `runAsNonRoot` verifies statically)
-- `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`
-- all Linux capabilities dropped, `seccompProfile: RuntimeDefault`
-- HTTP security headers (CSP, HSTS, `X-Content-Type-Options`, `X-Frame-Options`,
-  `Referrer-Policy`, `Permissions-Policy`) set on every response — see
-  [Content-Security-Policy](#content-security-policy)
-- listens on `:$PORT` (default `8080`); graceful shutdown on `SIGTERM`
+Incremental static regeneration is the one thing that wants a writable path. The image points the
+cache at `/tmp/isr` and bakes an empty one owned by the runtime user; where that path is not
+writable, every request is rendered fresh instead.
 
-Everything else the server reads comes from the layered configuration described
-under [Configuration](#configuration), so a `ConfigMap` fragment or a `Secret`
-volume is a first-class source rather than something a chart has to flatten into
-environment variables.
+## Compatibility
 
-### Content-Security-Policy
+| | Supported |
+| --- | --- |
+| Rust | {{ toolchain.msrv }} (edition {{ toolchain.edition }}) |
+| Platforms | `linux/amd64`, `linux/arm64` |
+| Pod Security Standard | restricted |
 
-Built with [csp-shell](https://github.com/TimSchoenle/csp-shell) rather than
-written out as a string, in `apps/web/src/server/csp.rs`. Two policies leave the
-server:
+## Documentation
 
-- **Documents** get one derived from the bytes they carry. Dioxus renders its
-  hydration data inline (`window.initial_dioxus_hydration_data="…"`), so its text
-  is only known per response — the body is buffered anyway to stamp `<html lang>`,
-  and each inline script is hashed out of that same string. `'unsafe-inline'` is
-  therefore gone from `script-src`: an injected `<script>` no longer runs just
-  because the hydration bootstrap has to.
-- **Everything else** — assets, the JSON API, the SEO documents — gets a policy
-  that admits no inline script at all, because none of them has any.
-
-`'unsafe-eval'` remains, and only for the one reason it has ever been here:
-`dioxus-web`'s document provider applies `document::Title`, `document::Stylesheet`
-and friends through `new Function(…)`, which throws an uncaught `EvalError`
-without it and freezes client-side navigation.
-
-**Cloudflare.** The bot products in front of this origin (Bot Fight Mode,
-JavaScript Detections, the challenge platform — the `_cf_bm`, `cf_clearance` and
-`cf_chl_rc_*` cookies the privacy page lists) inject an inline `<script>` at the
-edge, after this server has hashed what it rendered. No hash can cover it; a
-nonce can, because Cloudflare parses the `Content-Security-Policy` response
-header and copies the nonce onto what it injects. That is
-`{{ keys.cspScriptNonce.path }}`, on by default, and it brings one obligation the
-server discharges — every document is `Cache-Control: no-cache`, so a nonce is
-never shared between readers — and one it cannot:
-
-> **Deployment checklist:** no Cloudflare Cache Rule may cache the shell. A
-> "Cache Everything" rule overrides the origin's `Cache-Control`, pinning one
-> nonce across every reader for the lifetime of the cache entry, and nothing
-> inside this process can see that happening.
-
-Turnstile and Web Analytics are off; switching either on admits its origins in
-the directives that product actually needs them in (Turnstile in `script-src`
-**and** `frame-src` — admitting only the first renders an empty box).
-
-**If a page ever renders blank**, that is the failure mode this design has:
-`{{ keys.cspHashInlineScripts.env }}=false` together with
-`{{ keys.cspScriptNonce.env }}=false` restores `'unsafe-inline'` on a
-restart rather than a redeploy. The two must move together — a browser ignores
-`'unsafe-inline'` as soon as the policy carries a nonce — and supplying one
-without the other fails the boot with a message saying so.
-
-### Reproducible Builds
-
-The build is pinned end-to-end so the image is reproducible:
-
-- base images pinned by digest; Rust toolchain pinned via the base image
-- the Dioxus CLI (`dx`) is pinned to an exact version (build arg
-  `DIOXUS_CLI_VERSION`)
-- `cargo` / `dx bundle` build `--locked` against the committed `Cargo.lock`; the
-  Tailwind toolchain uses `npm ci` against `package-lock.json`
-- pass `SOURCE_DATE_EPOCH` (and the OCI metadata build args `VCS_REF`, `VERSION`,
-  `CREATED`, `SOURCE_URL`) for deterministic, self-describing images:
-
-```bash
-docker build \
-  --build-arg SOURCE_DATE_EPOCH=$(git log -1 --format=%ct) \
-  --build-arg VCS_REF=$(git rev-parse HEAD) \
-  --build-arg VERSION=$(git describe --tags --always) \
-  -t portfolio .
-```
-
-## Project Data (`repos.json`)
-
-The projects section reads `repos.json`, which is embedded into the binary at
-build time via `include_str!` (see `apps/web/build.rs`). The file is **generated
-during the build**: the `update-repos` builder runs before the web build and
-refreshes `apps/web/repos.json`. When it is absent (dev builds, `cargo check`),
-`build.rs` substitutes an empty default so the `include_str!` always resolves.
-
-To avoid hitting the GitHub API on every rebuild (and its rate limits), the
-builder reuses the existing file while it is still fresh, deciding from its own
-`generated_at` timestamp: the fetch is skipped when the file is younger than the
-cache TTL — **10 hours on CI** (when the `CI` environment variable is set) and
-**60 minutes** otherwise. CI additionally persists the file across runs with
-`actions/cache` (keyed by a ~10-hour window) so a fresh copy is restored before
-the build.
-
-When it does run, the builder lists every repository the user owns
-(`GET /users/{user}/repos`, paginated), drops the archived ones, the repositories
-blacklisted in `CONFIG.blacklisted_repos`, and any repository with no update in
-the last 365 days. It deserializes the rest directly into the shared
-`portfolio_data::Repo`/`ReposFile` models and writes the pretty-printed JSON,
-surfacing failures through a dedicated `UpdateReposError` model. An explicit
-repository set can be requested via `{{ keys.githubRepos.path }}`, in which case each named
-repository is fetched directly (without filtering):
-
-```bash
-# Defaults: user = CONFIG.github_username, repos = all active repos
-#           (archived/blacklisted/>1y-stale excluded),
-#           output = apps/web/repos.json
-{{ keys.githubToken.envFile }}=/run/secrets/gh_token \
-  cargo run --release -p update-repos -- apps/web/repos.json
-
-# Override the repo set for a one-off run (figment's bracketed array syntax,
-# so the environment and the TOML spelling stay the same shape)
-{{ keys.githubRepos.env }}='[Portfolio,actions]' cargo run --release -p update-repos
-```
-
-## Third-Party Licenses
-
-`/licenses` lists every third-party dependency the shipped artefacts link, the
-licence each is distributed under, and the verbatim text of every licence file
-found. One row per dependency, and the row is the disclosure control: opening it
-shows that dependency's licence text and a link to its repository. There is no
-separate list of texts, because such a list could only repeat these same names to
-say which text belonged to which.
-
-It is a Dioxus route like any other — inside the app shell, translated,
-server-side rendered, reachable from the footer and the command palette — and it
-reads a document compiled into the binary rather than anything fetched at
-runtime. That document stays normalised, one entry per distinct licence file
-rather than one per dependency; the join happens while rendering
-(`LicensesFile::dependencies`), which is what keeps it to 340 KB in the binary.
-
-That document is produced by
-[cargo-about](https://github.com/EmbarkStudios/cargo-about) during the image
-build, from [`apps/web/about.toml`](./apps/web/about.toml) (which licences are
-acceptable, which targets are built) and
-[`apps/web/about.hbs`](./apps/web/about.hbs) (the JSON it writes).
-`apps/web/build.rs` embeds the result the same way it embeds `repos.json`, and
-substitutes an empty default when it is absent — so a `cargo check` outside the
-image build still compiles, and the page simply says it has nothing to show.
-
-Running it against `apps/web/Cargo.toml` rather than the workspace is deliberate:
-what it reports is the dependency set a visitor actually receives — the wasm
-client and the SSR server — and not the resume generator's typst tree or the
-repo-list builder's HTTP client, neither of which is shipped. `--all-features`
-covers both halves of the fullstack crate in one pass, since the client's
-`web-sys` and the server's axum sit behind its platform features.
-
-The `accepted` list in `about.toml` is a gate, not a description: `cargo about`
-exits non-zero on a licence that is not on it, and that fails the image build. A
-dependency arriving under terms this site cannot ship stops the build rather than
-being published under a licences page that does not mention it — and adding an
-entry to that list is a deliberate decision to ship under those terms.
-
-```bash
-# Render the inventory locally; the image build runs the same command.
-just licenses
-
-# …which is:
-cargo about generate --locked --all-features   --manifest-path apps/web/Cargo.toml   --output-file apps/web/generated/licenses.json   apps/web/about.hbs
-```
+| Document | Purpose |
+| --- | --- |
+{{#each docs}}| [{{ title }}]({{ path }}) | {{ default (mdCell summary) "—" }} |
+{{/each}}
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the
-development setup and the checks that must pass before opening a pull request.
+[CONTRIBUTING.md](CONTRIBUTING.md) has the development setup, the commit convention and the checks
+a pull request has to pass. Note what the licence grants before you fork: reading the source and
+running it locally, and nothing about redistributing or deploying it.
 
-**This file is generated**, as is
-[`config.example.toml`](./config.example.toml). Edit the templates under
-[`.github/templates/`](./.github/templates) instead — CI renders both on every
-pull request and commits the results back to the branch, so there is no toolchain
-to install locally.
+Several files here are generated, this one included. Each says so in its opening lines, and an edit
+made to the output instead of to the template is replaced by the next render.
 
 ## Security
 
-To report a vulnerability, please follow the process described in
-[SECURITY.md](./SECURITY.md).
+Do not open a public issue for a vulnerability. [SECURITY.md](SECURITY.md) has the reporting route
+and the supported versions.
 
 ## License
 
-Proprietary. See [LICENSE](./LICENSE). The bundled Liberation Sans fonts are
-licensed under the SIL OFL (see `apps/resume-generator/fonts/LICENSE`).
+`{{ repo.license }}`. Viewing the source and running it locally for personal, non-commercial
+evaluation is granted. Copying, modifying, redistributing, deploying and training on it are not.
+[LICENSE](LICENSE) has the terms. The bundled fonts keep their own: Inter and Liberation Sans are
+both under the SIL Open Font License, in `apps/resume-generator/fonts/`.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,6 +81,59 @@ jobs:
           features: config-schema
           image: ''
 
+  # The same arrangement as `contract` above, for the other generated document. Update Files
+  # renders `README.md` on a pull request and commits it back to the branch; this re-renders it
+  # from the same two payloads and fails when the committed file differs, so a README edited by
+  # hand cannot merge and a template change cannot merge without its output.
+  #
+  # It lives here rather than in Update Files because that workflow only runs on `pull_request`,
+  # and a gate that never sees `main` is not a gate. The convergence and the refusal are two jobs
+  # on purpose: that one makes the branch right, this one declines to let it merge before it is.
+  readme:
+    name: README
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the code
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      # The two steps Update Files runs, with the same inputs. `branch` is the default branch in
+      # both places: left at its `github.ref_name` default it would be `<number>/merge` on a pull
+      # request and `main` here, and the badge URLs alone would then fail every merge.
+      - name: Generate the configuration payload
+        id: config-schema
+        run: |
+          set -euo pipefail
+          variables="$(cargo run -q -p portfolio-config --features config-schema \
+            --example config-schema -- --format variables)"
+          echo "variables=${variables}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect the README payload
+        id: readme-variables
+        uses: TimSchoenle/actions/actions/common/readme-variables@b5b5c9e047f00ffa00b7772536c8bdb4f158f706 # tag=actions-common-readme-variables-v1.1.0
+        with:
+          branch: ${{ github.event.repository.default_branch }}
+          extra: ${{ steps.config-schema.outputs.variables }}
+
+      - name: Verify README.md is current
+        uses: TimSchoenle/actions/actions/common/render-template@3b7d152374ee63e720e7c16bed8b088b40554911 # tag=actions-common-render-template-v1.1.1
+        with:
+          template: .github/templates/README.md.hbs
+          output: README.md
+          variables: ${{ steps.readme-variables.outputs.variables }}
+          check: 'true'
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/update-files.yaml
+++ b/.github/workflows/update-files.yaml
@@ -135,15 +135,35 @@ jobs:
             --example config-schema -- --format variables)"
           echo "variables=${variables}" >> "$GITHUB_OUTPUT"
 
+      # The other half of the README's payload: name, description, version, licence, toolchain and
+      # the `docs/` index, read out of the root `Cargo.toml` and a walk of `docs/`. The
+      # configuration payload above is handed to it as `extra` and deep-merged over what it
+      # derived, which is safe here because the generator emits no key this action also emits —
+      # `serverConfigTable`, `builderConfigTable`, `exampleConfig`, `loader` and `keys` against
+      # `repo`, `release`, `toolchain` and `docs`. A same-named key would replace, not merge, so
+      # adding one to the generator means checking that list first.
+      #
+      # `branch` is pinned to the default branch rather than left at its `github.ref_name` default,
+      # which on a pull_request event is `<number>/merge`: the badge and permalink URLs would then
+      # differ between this render and the gate that re-renders on `main`, and every merge would
+      # fail that gate for a reason absent from its diff.
+      - name: Collect the README payload
+        id: readme-variables
+        uses: TimSchoenle/actions/actions/common/readme-variables@b5b5c9e047f00ffa00b7772536c8bdb4f158f706 # tag=actions-common-readme-variables-v1.1.0
+        with:
+          branch: ${{ github.event.repository.default_branch }}
+          extra: ${{ steps.config-schema.outputs.variables }}
+
       # Each render commits only its own output — `file_pattern` defaults to it — so a document
-      # that did not change produces no commit, and neither can carry the other along.
+      # that did not change produces no commit, and neither can carry the other along. The example
+      # configuration stays on the raw generator payload: it interpolates nothing the merge adds.
       - name: Render and commit the README
         id: readme
         uses: TimSchoenle/actions/actions/common/render-template-and-commit@15d83f02081c9dc8a844646199c63792dcccdfa8 # tag=actions-common-render-template-and-commit-v1.1.3
         with:
           template: .github/templates/README.md.hbs
           output: README.md
-          variables: ${{ steps.config-schema.outputs.variables }}
+          variables: ${{ steps.readme-variables.outputs.variables }}
           token: ${{ steps.generate_token.outputs.token }}
           commit_message: 'docs: render README from its template'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,25 @@ version = "2.1.0"
 edition = "2024"
 publish = false
 
+# The five fields below `name` are what the README payload action
+# (`TimSchoenle/actions/actions/common/readme-variables`) reads. It refuses to
+# take the description from the GitHub API on purpose: one edited in the web UI
+# would change the rendered README with no commit behind it, and the next
+# unrelated pull request would then fail the README drift gate for a reason
+# absent from its own diff. The description, the homepage and the licence are
+# the same three strings the image's OCI labels carry.
+#
+# `rust-version` is the toolchain the image is built with — `rust:1.97-slim` in
+# the Dockerfile — and not a floor anything tests below.
 [package]
 name = "portfolio-platform"
 version = "2.7.1"
 publish = false
 edition = "2024"
+rust-version = "1.97"
+description = "Dioxus fullstack (SSR + hydration) portfolio served by Axum."
+homepage = "https://tim-schoenle.de"
+license = "LicenseRef-Proprietary"
 
 [workspace.dependencies]
 portfolio-config = { path = "crates/config" }

--- a/README.md
+++ b/README.md
@@ -1,216 +1,185 @@
 <!--
-Template for the repository README. CI renders it on every pull request and commits the result
-to README.md, so edit this file — never README.md itself.
+Generated from .github/templates/README.md.hbs. Edit that file, never this one.
 
-Every variable comes from one command:
+Two payloads are merged into one render. The repository's own facts — name, description, version,
+licence, toolchain and the docs/ index — come from
+TimSchoenle/actions/actions/common/readme-variables, which reads the root Cargo.toml and walks
+docs/. It deliberately does not read the description from the GitHub API: one edited in the web UI
+would change this file with no commit behind it, and the next unrelated pull request would fail the
+drift gate for a reason absent from its own diff.
 
-    cargo run -p portfolio-config --features config-schema --example config-schema \
-      -- --format variables
+The configuration half comes from one command:
 
-which walks the `Describe` derives on `ServerConfig` and `BuilderConfig` — the aggregates the two
-binaries actually load — and prints the whole payload as strict JSON:
+    cargo run -q -p portfolio-config --features config-schema \
+      --example config-schema -- --format variables
 
-  - `serverConfigTable` and `builderConfigTable`, one Markdown table per binary, each key with
-    its TOML path, type, environment spelling, default and purpose. The server scope leads with
-    the variables the loader reads before any layer exists; the builder scope renders keys alone,
-    because they would be the same two variables. Both go through a triple-stash, being Markdown
-    to emit as-is rather than escape.
-  - `loader`, the dialect: the prefix, the nesting separator, the indirection suffix and the two
-    variables naming the layers.
-  - `keys`, the spellings of the handful of keys the prose below names — `keys.githubToken.env`,
-    `keys.githubToken.envFile`, and so on.
-
-Prefer an injected value to a typed one anywhere the two would say the same thing. A rename in
-`crates/config` then reaches the sentences as well as the tables, and a key the prose names and
-the types no longer have fails the generator instead of rendering a blank. `KEYS` in
-`crates/config/examples/config-schema.rs` is where a key joins that set.
-
-Neither table has a `_FILE` column: it is the environment spelling plus a constant suffix, which
-the layer list above the tables already states once.
-
-They are two tables and not one on purpose. A single list of every key reads as though a
-deployment needs a GitHub token; it does not, because `github.*` belongs to a build-time tool
+which walks the `Describe` derives on `ServerConfig` and `BuilderConfig`, the aggregates the two
+binaries actually load, and prints both tables, the example configuration and the spellings the
+prose below names. The two tables are two on purpose: one list of every key reads as though a
+deployment needs a GitHub token, and it does not, because `github.*` belongs to a build-time tool
 that exits during the image build.
 
-That is what keeps the configuration reference honest across a rename: the key table is not a
-copy of the types, it is the types, and a pull request that renames a field arrives with the
-README already saying so. `.github/workflows/update-files.yaml` is the job that does it.
+The Update Files workflow renders this on every pull request and commits the result back to the
+branch. The README job in Build re-renders with `check: true` and fails when the committed file
+does not match it, so a README edited by hand does not merge.
 
-This is an HTML comment, not a template one, so Handlebars parses it like any other line and it
-survives into README.md — which is the point, since that is where someone about to edit the
-wrong file will be. Nothing in it may contain a mustache that is not a real reference.
+Prefer an injected value to a typed one anywhere the two would say the same thing. A rename in
+`crates/config` then reaches the sentences as well as the tables, and a key the prose names and the
+types no longer have fails the generator instead of rendering a blank. `KEYS` in
+`crates/config/examples/config-schema.rs` is where a key joins that set.
+
+Nothing in this comment may contain a mustache that is not a real reference.
 -->
+
 # Portfolio
 
-Personal portfolio at [tim-schoenle.de](https://tim-schoenle.de).
+Dioxus fullstack (SSR + hydration) portfolio served by Axum.
 
-A **Rust + Dioxus** fullstack application (server-side rendered with WASM
-hydration) styled with **Tailwind CSS**, served by an **Axum** server running from
-a distroless container.
+[![Release](https://img.shields.io/github/v/release/TimSchoenle/Portfolio?sort=semver)](https://github.com/TimSchoenle/Portfolio/releases)
+[![Build](https://img.shields.io/github/actions/workflow/status/TimSchoenle/Portfolio/build.yaml?branch=main)](https://github.com/TimSchoenle/Portfolio/actions/workflows/build.yaml)
+[![License](https://img.shields.io/badge/license-LicenseRef--Proprietary-blue)](LICENSE)
+[![Rust](https://img.shields.io/badge/rust-1.97-orange)](https://www.rust-lang.org)
 
-## Table of Contents
+## What this is
 
-- [Architecture](#architecture)
-- [Technology Stack](#technology-stack)
+The source of <https://tim-schoenle.de>, as one Rust workspace.
+
+`apps/web` is a single crate with two feature-selected builds. The `server` build is a native Axum
+binary that renders every route. The `web` build is a WASM bundle that hydrates it in the browser.
+The Dioxus CLI produces both.
+
+The configuration tables below are generated, not written. They come out of the Rust types that
+load the configuration, as do `config.example.toml` and the contract document the image publishes
+about itself, so renaming a field corrects all three in the commit that renames it.
+
+## Quick start
+
+```bash
+docker run --rm -p 8080:8080 timschoenle/portfolio:v2.7.1
+```
+
+Then open <http://localhost:8080>. The runtime image is `FROM scratch`: one statically linked
+binary, the client bundle beside it, and the configuration contract at `/config/contract.json`. It
+runs as `1001:1001` and needs nothing writable.
+
+## Table of contents
+
 - [Features](#features)
-- [Getting Started](#getting-started)
-  - [Prerequisites](#prerequisites)
-  - [Development](#development)
-  - [Production Build](#production-build)
-  - [Container](#container)
+- [Installation](#installation)
+- [Usage](#usage)
 - [Configuration](#configuration)
-- [Deployment](#deployment)
-  - [Probe Endpoints](#probe-endpoints)
-  - [Read-only and Security Posture](#read-only-and-security-posture)
-  - [Content-Security-Policy](#content-security-policy)
-  - [Reproducible Builds](#reproducible-builds)
-- [Project Data (`repos.json`)](#project-data-reposjson)
-- [Third-Party Licenses](#third-party-licenses)
+- [Operations](#operations)
+- [Compatibility](#compatibility)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 - [Security](#security)
 - [License](#license)
 
-## Architecture
-
-The project is a Cargo workspace composed of one shared library crate and three
-applications.
-
-| Crate | Purpose |
-| --- | --- |
-| `crates/config` | The typed configuration blocks every binary reads, plus the Portfolio dialect of the [terrace-config](https://github.com/TimSchoenle/terrace-config) layered loader (see [Configuration](#configuration)) |
-| `crates/data` | Shared, language-neutral data (config, skills, experience, repos schema) plus embedded `i18n/{en,de}.json` translations |
-| `apps/web` | Dioxus 0.7 fullstack app: a single crate that compiles to both the WASM client (`web` feature) and the native Axum SSR server (`server` feature), with the JSON API, SEO documents, security headers, and probe endpoints |
-| `apps/resume-generator` | Generates `resume/{en,de}.pdf` and `resume-fingerprint.json` (Typst, embedded subset of Liberation Sans) |
-| `apps/update-repos` | Builder that fetches the user's active GitHub repositories (skipping archived, blacklisted, and >1-year-stale ones) and refreshes `apps/web/repos.json` using the shared `Repo`/`ReposFile` models |
-
-## Technology Stack
-
-- **App:** Rust, [Dioxus](https://dioxuslabs.com) 0.7 fullstack (Axum SSR + WASM
-  hydration) with the built-in Dioxus router
-- **Internationalization:** EN/DE via [i18nrs](https://crates.io/crates/i18nrs).
-  Translations live in `crates/data/i18n/`; the active language is persisted in
-  `localStorage` (`lang`) and detected from the browser language on first visit.
-  A unit test in `crates/data` enforces key parity between both languages.
-- **Styling:** Tailwind CSS v4 with custom design tokens
-- **Build:** the [Dioxus CLI](https://dioxuslabs.com) (`dx`)
-- **Data:** `apps/web/repos.json` is regenerated at build time from the GitHub
-  API (all active repositories — archived, blacklisted, and >1-year-stale ones
-  excluded) and embedded into the binary by `apps/web/build.rs`
-
 ## Features
 
-- Routes: `/` (single-page sections `s1`-`s5`), `/imprint`, `/privacy`, `/licenses`, and a 404 page
-- Hero with a two-line display name, scroll parallax, and a live meta card
-- Fixed chapter rail with scroll tracking and staggered reveal-on-scroll blocks
-- Stack section: an interactive skill radar (per-skill hover tooltips, category
-  filtering/dimming) and a chip matrix with confidence bars
-- Projects: a GitHub statistics strip, language filter, and loading skeletons fed
-  by `repos.json`
-- Experience accordion with year badges and animated bodies (real career data)
-- Contact: a terminal with a type-in `ssh` animation, oversized email, and action buttons
-- Command palette (Cmd+K / Ctrl+K) with fuzzy search and keyboard navigation
-- Language switcher (EN/DE) — every visible string is translated
-- Localized, single-page, ATS-readable resume PDFs with SHA-256 fingerprints on the contact card. The
-  generator scales typography down until the content fits one A4 page.
-- Legal pages (imprint, privacy policy) localized and rendered from the translation files
-- Third-party licences page generated at build time by cargo-about: every crate
-  the client and the server link, the licence it ships under, and the verbatim
-  text of every licence file found
-- Server-side rendering with WASM hydration; per-route `<head>` metadata, JSON-LD,
-  and server-negotiated locale for the first paint
-- SEO: meta/OG tags, JSON-LD, `robots.txt`, `sitemap.xml`, and a web manifest
-- Security headers set by the server: HSTS, `Referrer-Policy`, `Permissions-Policy`,
-  and a Content-Security-Policy built per document from the inline scripts it
-  actually carries, with a per-response nonce for Cloudflare's edge injection
-- WASM client tuned for size: `opt-level = "z"`, LTO, and a single codegen unit
+- Every route renders on the server and then hydrates. Per-route `<head>` metadata and JSON-LD ship
+  in the first response, and the locale is negotiated from request headers before the document is
+  serialised, so nothing arrives in the wrong language and gets swapped a moment later.
+- EN and DE throughout, including both legal pages and both resumes. `translation_key_sets_match`
+  in `crates/data` fails the build when the two translation files disagree on a key, which
+  otherwise shows up as one English string in a German page rather than as an error.
+- **The resumes are typeset during the build.** Typst lays out one A4 page per language, scaling
+  the type down and re-typesetting until the content fits, and each PDF carries a SHA-256
+  fingerprint that the contact card shows.
+- **The Content-Security-Policy is built per response.** The server hashes the inline scripts that
+  document actually carries and reserves a nonce for the script Cloudflare injects at the edge, so
+  `script-src` needs no `'unsafe-inline'`.
+- `/licenses` lists every crate the client and the server link, the licence it ships under, and the
+  verbatim text of every licence file found. cargo-about produces it during the image build, and an
+  unlisted licence fails that build.
+- The project list is fetched from the GitHub API at build time, with archived, blacklisted and
+  year-stale repositories dropped, then embedded into the binary by `build.rs`.
+- Cmd+K opens a command palette with fuzzy search and keyboard navigation. The stack section is a
+  skill radar with per-skill tooltips and category filtering.
 
-## Getting Started
+## Installation
 
-### Prerequisites
-
-- Rust (stable) with the `wasm32-unknown-unknown` target:
-  `rustup target add wasm32-unknown-unknown`
-- [Dioxus CLI](https://dioxuslabs.com) (`dx`): `cargo install dioxus-cli`
-  (or `cargo binstall dioxus-cli`)
-- [cargo-about](https://github.com/EmbarkStudios/cargo-about) (only to render the
-  third-party licences page): `cargo install --locked cargo-about`
-- Node.js (required only for the Tailwind CSS build step)
-- Docker (optional, for containerized builds)
-
-### Development
+### Docker
 
 ```bash
-# Resume PDFs + resume-fingerprint.json. Run BEFORE the web build so the
-# fingerprint is embedded (build.rs) and the PDFs are served from public/resume/.
-cargo run -p resume-generator -- apps/web/generated
-
-# Third-party licence inventory for the /licenses page (build.rs embeds it).
-# Optional: without it the page renders its "nothing to show" state.
-just licenses
-
-# Web dev server (SSR + hydration, http://localhost:8080)
-cd apps/web
-npm ci && npm run build:css
-dx serve --platform web
-
-# Tests (including i18n key parity)
-cargo test -p portfolio-data
-cargo test -p web --no-default-features --features server
+docker pull timschoenle/portfolio:v2.7.1
 ```
 
-### Production Build
+Both architectures are pushed as one manifest list, so `docker pull` resolves the right image per
+node. The push carries an SBOM and max-mode provenance and is signed with cosign. Pin by digest in
+production. The Helm chart does.
+
+### Helm
 
 ```bash
-cargo run --release -p resume-generator -- apps/web/generated
-cd apps/web && npm ci && npm run build:css && dx bundle --platform web --release
+helm repo add timschoenle https://timschoenle.github.io/helm-charts
+helm install portfolio timschoenle/portfolio
 ```
 
-### Container
+The chart is in
+[TimSchoenle/helm-charts](https://github.com/TimSchoenle/helm-charts/tree/main/charts/portfolio) and
+each release bumps it to the new image digest.
 
-The container performs all of the above and serves the result on port 8080:
+### From source
 
 ```bash
-docker build -t portfolio .
+rustup target add wasm32-unknown-unknown
+cargo install --locked dioxus-cli cargo-about
+git clone https://github.com/TimSchoenle/Portfolio.git
+cd Portfolio
 ```
+
+Node.js is needed for the Tailwind step, and `just` runs every recipe CI runs.
+
+## Usage
+
+Two artefacts have to exist before the web build, because `apps/web/build.rs` embeds both. Without
+them it substitutes empty defaults and the pages render their empty state.
+
+```bash
+cargo run -p resume-generator -- apps/web/generated   # resume PDFs, fingerprints, social card
+just licenses                                         # third-party inventory for /licenses
+cd apps/web && npm ci && npm run build:css
+dx serve --platform web                               # SSR + hydration on http://localhost:8080
+```
+
+Run the checks CI runs, in one recipe:
+
+```bash
+just verify   # fmt, lint, test
+```
+
+Refresh the project list from the GitHub API:
+
+```bash
+PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token \
+  cargo run --release -p update-repos -- apps/web/repos.json
+```
+
+Without a token the run still works, against the anonymous rate limit.
+[docs/PROJECT_DATA.md](docs/PROJECT_DATA.md) has the filtering rules and the caching.
 
 ## Configuration
 
-Configuration is **layered and file-first**, via
-[terrace-config](https://github.com/TimSchoenle/terrace-config). `crates/config`
-owns the typed blocks and the `PORTFOLIO_` dialect; each binary declares the
-aggregate it actually reads. Sources are merged in this order, lowest precedence
-first:
+Values are resolved in five layers, each overriding the one above it. The last three are mutually
+exclusive per key: a key supplied by two of them fails the boot rather than letting one win,
+because a stale environment variable shadowing a rotated mounted secret keeps the process running
+on the old credential.
 
-1. **Struct defaults** — the `serde` defaults in `crates/config`.
-2. **TOML** at `$PORTFOLIO_CONFIG` — a file, or every `*.toml` inside it when it
-   names a directory (so a `ConfigMap` can be split into fragments).
+1. **Defaults** — the `serde` defaults of each typed block.
+2. **TOML** at `$PORTFOLIO_CONFIG` — a file, or every `*.toml` inside it when it names a directory.
 3. **Environment** — `PORTFOLIO_`-prefixed variables, `__` for nesting.
-4. **Secrets directory** at `$PORTFOLIO_SECRETS_DIR` — one file per key, named
-   after it (`github__token`); this is what a Kubernetes `Secret` volume mounts.
-5. **File indirection** — `PORTFOLIO_<KEY>_FILE=/path` names a file holding the
-   value.
+4. **Secrets directory** at `$PORTFOLIO_SECRETS_DIR` — one file per key, named after it
+   (`github__token`). This is what a Kubernetes `Secret` volume mounts.
+5. **File indirection** — `PORTFOLIO_<KEY>_FILE=/path` names a file holding the value.
 
-The last three are **mutually exclusive per key**: a key supplied by two of them
-fails the boot instead of one silently winning, because a stale environment
-variable shadowing a rotated mounted secret keeps the process running on the old
-credential.
+An empty value counts as unset in every layer, because container platforms routinely inject `KEY=`
+for a declared-but-unset variable.
 
-The tables below are **generated from the aggregates the binaries load** —
-`ServerConfig` and `BuilderConfig` in `crates/config`. They are split the way the
-binaries are, because the two configurations are not one: what a deployment sets
-and what the image build sets have no overlap at all.
+### Server
 
-Regenerate one on its own with:
-
-```bash
-cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format markdown --scope server
-```
-
-#### What the server reads
-
-The two variables the loader itself reads, then every key `apps/web` loads. This
-is the whole surface a **deployment** configures.
+The two variables the loader reads before any layer exists, then every key `apps/web` loads. Each
+environment spelling also accepts a `_FILE` suffix naming a file that holds the value.
 
 | Variable | Role | Default | Purpose |
 |---|---|---|---|
@@ -227,12 +196,10 @@ is the whole surface a **deployment** configures.
 | `isr.cache_dir` | `PathBuf` | `PORTFOLIO_ISR__CACHE_DIR` | unset (ISR off; the image sets `/tmp/isr`) | — | Writable directory rendered HTML is cached into. Unset or empty disables ISR. |
 | `isr.ttl_secs` | `u64` | `PORTFOLIO_ISR__TTL_SECS` | `0` (permanent) | — | Revalidation interval in seconds. Zero means a permanent cache. |
 
-#### What the `update-repos` builder reads
+### Builder
 
-`github.*` is read only by the build-time repository lister, which runs during the
-image build and exits. **The server never loads it**, so a deployment needs no
-GitHub token and no `github` block — the Docker build supplies the token as a
-BuildKit secret and nothing survives into the image.
+What `update-repos` loads. It runs during the image build and exits. The server never reads these
+keys, so a deployment needs no GitHub token. That is why there are two tables and not one.
 
 | TOML | Type | Environment | Default | Flags | Purpose |
 |---|---|---|---|---|---|
@@ -240,252 +207,75 @@ BuildKit secret and nothing survives into the image.
 | `github.token` | `SecretString` | `PORTFOLIO_GITHUB__TOKEN` | unset | secret | Bearer token lifting the GitHub API rate limit. |
 | `github.repos` | `Vec<String>` | `PORTFOLIO_GITHUB__REPOS` | `[]` (every active repository the user owns) | — | Explicit repository set, bypassing the "every active repository" listing and its filtering. |
 
-The `config-schema` feature is off in every build that ships, so the derive and
-the `serde_json` it pulls stay out of the image; CI's `--all-features` gates are
-what keep the generator compiling.
+`github.token` is the only secret in the workspace, and it should arrive as a file
+rather than as an environment variable. `/proc/<pid>/environ`, a crash dump and `docker inspect` all
+carry the environment, and child processes inherit it. The Docker build mounts it as a BuildKit
+secret and hands `update-repos` the path.
 
-An empty value counts as unset everywhere, because container platforms routinely
-inject `KEY=` for a declared-but-unset variable.
-[`config.example.toml`](./config.example.toml) is a commented starting point, and
-is generated from the same types as the tables above — every key at its default,
-commented out, so a copy of it and an empty file mean the same thing to the
-loader:
+`IP`, `PORT` and `RUST_LOG` sit outside this namespace deliberately. They are the Dioxus toolchain's
+contract with the binary, and it keeps reading them itself.
 
-```bash
-cargo run -p portfolio-config --features config-schema --example config-schema \
-  -- --format toml
-```
+[`config.example.toml`](config.example.toml) carries every key at its default, commented out, and is
+rendered from the same payload as these tables.
 
-`IP`, `PORT` and `RUST_LOG` are deliberately **outside** this namespace: they are
-the Dioxus toolchain's contract with the binary (`dx serve` sets them to tell a
-development build which port it is proxied on), so the framework keeps reading
-them itself. `CI` likewise belongs to the CI provider.
+## Operations
 
-### Secrets
-
-`github.token` is the only secret in the workspace, and it should arrive as a
-**file**, never as an environment variable — `/proc/<pid>/environ`, a crash dump
-and `docker inspect` all carry the environment, and child processes inherit it:
-
-```bash
-PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token cargo run --release -p update-repos
-```
-
-The Docker build already does this: the `gh_token` BuildKit secret is mounted as
-a file and handed to `update-repos` by path. In the process it is a
-`secrecy::SecretString`, so it has no `Debug` or `Display` and the one place it
-becomes a `&str` is the `Authorization` header.
-
-Only the loader half of `terrace-config` is used; its hot-reload supervisor is
-not. The reasoning — the server holds no secrets, and `dioxus::serve` owns an
-accept loop with no shutdown handle — is recorded in `crates/config/src/lib.rs`.
-
-## Deployment
-
-The image is built on a `distroless/cc` base holding the dynamically linked
-`server` binary plus its sibling read-only `public/` assets under `/app` — no
-shell, package manager, or writable system paths. The Helm chart lives in a
-separate repository; the application and image here are prepared to run under a
-hardened pod spec out of the box.
-
-### Probe Endpoints
+### Probes
 
 | Endpoint | Alias | Purpose |
 | --- | --- | --- |
-| `GET /api/health` | — | General health report with the current UTC time |
-| `GET /api/health/live` | `GET /livez` | **Liveness** — process is running; failure restarts the container |
-| `GET /api/health/ready` | `GET /readyz` | **Readiness** — the client bundle (`index.html` under `assets.dist_dir`, default `public/`) is present and servable; failure removes the pod from the Service endpoints |
+| `GET /api/health` | — | Health report with the current UTC time |
+| `GET /api/health/live` | `GET /livez` | **Liveness** — the process is running; failure restarts the container |
+| `GET /api/health/ready` | `GET /readyz` | **Readiness** — `index.html` under `assets.dist_dir` (default `public/`) is present and servable; failure removes the pod from the Service endpoints |
 
-All probe responses are `no-store` (never cached). Readiness returns `503` until
-the assets are present.
+All probe responses are `no-store`. Readiness returns `503` until the assets are there.
 
-### Read-only and Security Posture
+### Runtime posture
 
-The server only reads from its bundle directory (the sibling `public/` dir) and
-writes logs to stdout, so it runs unchanged with a fully read-only root
-filesystem (no
-writable volume, not even `/tmp`). It is built to satisfy the restricted Pod
-Security Standard:
+The server reads its bundle directory and writes to stdout. It runs as numeric non-root
+`1001:1001`, so `runAsNonRoot` verifies statically, and it satisfies the restricted Pod Security
+Standard with a read-only root filesystem, no privilege escalation, every capability dropped and
+`seccompProfile: RuntimeDefault`.
 
-- runs as numeric non-root `1001:1001` (so `runAsNonRoot` verifies statically)
-- `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`
-- all Linux capabilities dropped, `seccompProfile: RuntimeDefault`
-- HTTP security headers (CSP, HSTS, `X-Content-Type-Options`, `X-Frame-Options`,
-  `Referrer-Policy`, `Permissions-Policy`) set on every response — see
-  [Content-Security-Policy](#content-security-policy)
-- listens on `:$PORT` (default `8080`); graceful shutdown on `SIGTERM`
+Incremental static regeneration is the one thing that wants a writable path. The image points the
+cache at `/tmp/isr` and bakes an empty one owned by the runtime user; where that path is not
+writable, every request is rendered fresh instead.
 
-Everything else the server reads comes from the layered configuration described
-under [Configuration](#configuration), so a `ConfigMap` fragment or a `Secret`
-volume is a first-class source rather than something a chart has to flatten into
-environment variables.
+## Compatibility
 
-### Content-Security-Policy
+| | Supported |
+| --- | --- |
+| Rust | 1.97 (edition 2024) |
+| Platforms | `linux/amd64`, `linux/arm64` |
+| Pod Security Standard | restricted |
 
-Built with [csp-shell](https://github.com/TimSchoenle/csp-shell) rather than
-written out as a string, in `apps/web/src/server/csp.rs`. Two policies leave the
-server:
+## Documentation
 
-- **Documents** get one derived from the bytes they carry. Dioxus renders its
-  hydration data inline (`window.initial_dioxus_hydration_data="…"`), so its text
-  is only known per response — the body is buffered anyway to stamp `<html lang>`,
-  and each inline script is hashed out of that same string. `'unsafe-inline'` is
-  therefore gone from `script-src`: an injected `<script>` no longer runs just
-  because the hydration bootstrap has to.
-- **Everything else** — assets, the JSON API, the SEO documents — gets a policy
-  that admits no inline script at all, because none of them has any.
-
-`'unsafe-eval'` remains, and only for the one reason it has ever been here:
-`dioxus-web`'s document provider applies `document::Title`, `document::Stylesheet`
-and friends through `new Function(…)`, which throws an uncaught `EvalError`
-without it and freezes client-side navigation.
-
-**Cloudflare.** The bot products in front of this origin (Bot Fight Mode,
-JavaScript Detections, the challenge platform — the `_cf_bm`, `cf_clearance` and
-`cf_chl_rc_*` cookies the privacy page lists) inject an inline `<script>` at the
-edge, after this server has hashed what it rendered. No hash can cover it; a
-nonce can, because Cloudflare parses the `Content-Security-Policy` response
-header and copies the nonce onto what it injects. That is
-`csp.cloudflare.script_nonce`, on by default, and it brings one obligation the
-server discharges — every document is `Cache-Control: no-cache`, so a nonce is
-never shared between readers — and one it cannot:
-
-> **Deployment checklist:** no Cloudflare Cache Rule may cache the shell. A
-> "Cache Everything" rule overrides the origin's `Cache-Control`, pinning one
-> nonce across every reader for the lifetime of the cache entry, and nothing
-> inside this process can see that happening.
-
-Turnstile and Web Analytics are off; switching either on admits its origins in
-the directives that product actually needs them in (Turnstile in `script-src`
-**and** `frame-src` — admitting only the first renders an empty box).
-
-**If a page ever renders blank**, that is the failure mode this design has:
-`PORTFOLIO_CSP__HASH_INLINE_SCRIPTS=false` together with
-`PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE=false` restores `'unsafe-inline'` on a
-restart rather than a redeploy. The two must move together — a browser ignores
-`'unsafe-inline'` as soon as the policy carries a nonce — and supplying one
-without the other fails the boot with a message saying so.
-
-### Reproducible Builds
-
-The build is pinned end-to-end so the image is reproducible:
-
-- base images pinned by digest; Rust toolchain pinned via the base image
-- the Dioxus CLI (`dx`) is pinned to an exact version (build arg
-  `DIOXUS_CLI_VERSION`)
-- `cargo` / `dx bundle` build `--locked` against the committed `Cargo.lock`; the
-  Tailwind toolchain uses `npm ci` against `package-lock.json`
-- pass `SOURCE_DATE_EPOCH` (and the OCI metadata build args `VCS_REF`, `VERSION`,
-  `CREATED`, `SOURCE_URL`) for deterministic, self-describing images:
-
-```bash
-docker build \
-  --build-arg SOURCE_DATE_EPOCH=$(git log -1 --format=%ct) \
-  --build-arg VCS_REF=$(git rev-parse HEAD) \
-  --build-arg VERSION=$(git describe --tags --always) \
-  -t portfolio .
-```
-
-## Project Data (`repos.json`)
-
-The projects section reads `repos.json`, which is embedded into the binary at
-build time via `include_str!` (see `apps/web/build.rs`). The file is **generated
-during the build**: the `update-repos` builder runs before the web build and
-refreshes `apps/web/repos.json`. When it is absent (dev builds, `cargo check`),
-`build.rs` substitutes an empty default so the `include_str!` always resolves.
-
-To avoid hitting the GitHub API on every rebuild (and its rate limits), the
-builder reuses the existing file while it is still fresh, deciding from its own
-`generated_at` timestamp: the fetch is skipped when the file is younger than the
-cache TTL — **10 hours on CI** (when the `CI` environment variable is set) and
-**60 minutes** otherwise. CI additionally persists the file across runs with
-`actions/cache` (keyed by a ~10-hour window) so a fresh copy is restored before
-the build.
-
-When it does run, the builder lists every repository the user owns
-(`GET /users/{user}/repos`, paginated), drops the archived ones, the repositories
-blacklisted in `CONFIG.blacklisted_repos`, and any repository with no update in
-the last 365 days. It deserializes the rest directly into the shared
-`portfolio_data::Repo`/`ReposFile` models and writes the pretty-printed JSON,
-surfacing failures through a dedicated `UpdateReposError` model. An explicit
-repository set can be requested via `github.repos`, in which case each named
-repository is fetched directly (without filtering):
-
-```bash
-# Defaults: user = CONFIG.github_username, repos = all active repos
-#           (archived/blacklisted/>1y-stale excluded),
-#           output = apps/web/repos.json
-PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token \
-  cargo run --release -p update-repos -- apps/web/repos.json
-
-# Override the repo set for a one-off run (figment's bracketed array syntax,
-# so the environment and the TOML spelling stay the same shape)
-PORTFOLIO_GITHUB__REPOS='[Portfolio,actions]' cargo run --release -p update-repos
-```
-
-## Third-Party Licenses
-
-`/licenses` lists every third-party dependency the shipped artefacts link, the
-licence each is distributed under, and the verbatim text of every licence file
-found. One row per dependency, and the row is the disclosure control: opening it
-shows that dependency's licence text and a link to its repository. There is no
-separate list of texts, because such a list could only repeat these same names to
-say which text belonged to which.
-
-It is a Dioxus route like any other — inside the app shell, translated,
-server-side rendered, reachable from the footer and the command palette — and it
-reads a document compiled into the binary rather than anything fetched at
-runtime. That document stays normalised, one entry per distinct licence file
-rather than one per dependency; the join happens while rendering
-(`LicensesFile::dependencies`), which is what keeps it to 340 KB in the binary.
-
-That document is produced by
-[cargo-about](https://github.com/EmbarkStudios/cargo-about) during the image
-build, from [`apps/web/about.toml`](./apps/web/about.toml) (which licences are
-acceptable, which targets are built) and
-[`apps/web/about.hbs`](./apps/web/about.hbs) (the JSON it writes).
-`apps/web/build.rs` embeds the result the same way it embeds `repos.json`, and
-substitutes an empty default when it is absent — so a `cargo check` outside the
-image build still compiles, and the page simply says it has nothing to show.
-
-Running it against `apps/web/Cargo.toml` rather than the workspace is deliberate:
-what it reports is the dependency set a visitor actually receives — the wasm
-client and the SSR server — and not the resume generator's typst tree or the
-repo-list builder's HTTP client, neither of which is shipped. `--all-features`
-covers both halves of the fullstack crate in one pass, since the client's
-`web-sys` and the server's axum sit behind its platform features.
-
-The `accepted` list in `about.toml` is a gate, not a description: `cargo about`
-exits non-zero on a licence that is not on it, and that fails the image build. A
-dependency arriving under terms this site cannot ship stops the build rather than
-being published under a licences page that does not mention it — and adding an
-entry to that list is a deliberate decision to ship under those terms.
-
-```bash
-# Render the inventory locally; the image build runs the same command.
-just licenses
-
-# …which is:
-cargo about generate --locked --all-features   --manifest-path apps/web/Cargo.toml   --output-file apps/web/generated/licenses.json   apps/web/about.hbs
-```
+| Document | Purpose |
+| --- | --- |
+| [Architecture](docs/ARCHITECTURE.md) | Six packages in one Cargo workspace: two libraries every binary reads, three binaries, and a placeholder at the root that exists so release-please has a version to move. |
+| [Deployment](docs/DEPLOYMENT.md) | What the image contains, how it is built reproducibly, what it publishes about its own configuration, and where the chart that runs it lives. |
+| [Project data](docs/PROJECT_DATA.md) | How apps/web/repos.json is fetched, filtered, cached and embedded, and what the projects section reads out of it. |
+| [Security posture](docs/SECURITY_POSTURE.md) | The Content-Security-Policy the server builds per response, the headers around it, and what the process needs from the filesystem it runs on. |
+| [docs/config.contract.json](docs/config.contract.json) | — |
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the
-development setup and the checks that must pass before opening a pull request.
+[CONTRIBUTING.md](CONTRIBUTING.md) has the development setup, the commit convention and the checks
+a pull request has to pass. Note what the licence grants before you fork: reading the source and
+running it locally, and nothing about redistributing or deploying it.
 
-**This file is generated**, as is
-[`config.example.toml`](./config.example.toml). Edit the templates under
-[`.github/templates/`](./.github/templates) instead — CI renders both on every
-pull request and commits the results back to the branch, so there is no toolchain
-to install locally.
+Several files here are generated, this one included. Each says so in its opening lines, and an edit
+made to the output instead of to the template is replaced by the next render.
 
 ## Security
 
-To report a vulnerability, please follow the process described in
-[SECURITY.md](./SECURITY.md).
+Do not open a public issue for a vulnerability. [SECURITY.md](SECURITY.md) has the reporting route
+and the supported versions.
 
 ## License
 
-Proprietary. See [LICENSE](./LICENSE). The bundled Liberation Sans fonts are
-licensed under the SIL OFL (see `apps/resume-generator/fonts/LICENSE`).
+`LicenseRef-Proprietary`. Viewing the source and running it locally for personal, non-commercial
+evaluation is granted. Copying, modifying, redistributing, deploying and training on it are not.
+[LICENSE](LICENSE) has the terms. The bundled fonts keep their own: Inter and Liberation Sans are
+both under the SIL Open Font License, in `apps/resume-generator/fonts/`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,79 @@
+# Architecture
+
+Six packages in one Cargo workspace: two libraries every binary reads, three binaries, and a placeholder at the root that exists so release-please has a version to move.
+
+## The packages
+
+| Package | Purpose |
+| --- | --- |
+| `crates/config` | The typed configuration blocks each binary reads, plus the Portfolio dialect of the [terrace-config](https://github.com/TimSchoenle/terrace-config) layered loader |
+| `crates/data` | Language-neutral data — site config, skills, experience, the `repos.json` schema — and the embedded `i18n/{en,de}.json` translations |
+| `apps/web` | The site. One crate that builds twice: a WASM client under the `web` feature and a native Axum SSR server under `server`, carrying the JSON API, the SEO documents, the security headers and the probes |
+| `apps/resume-generator` | Typesets one resume PDF per language, writes `resume-fingerprint.json`, and rasterises the 1200×630 social card, with its fonts embedded |
+| `apps/update-repos` | Lists the owner's active GitHub repositories and rewrites `apps/web/repos.json` through the shared `Repo`/`ReposFile` models |
+| `.` (`portfolio-platform`) | `src/lib.rs` is a placeholder. release-please's Rust strategy needs a root package to bump, and the version it writes there is the one the README payload and the image's contract document both read |
+
+## One crate, two builds
+
+`apps/web` selects its renderer with a feature rather than splitting into two crates, because the
+route table, the page components and the `<head>` metadata are shared and would otherwise be a
+third crate that both depend on. `web` pulls `dioxus-web` and `web-sys`; `server` pulls axum,
+`tower-http` and `csp-shell`. The Dioxus CLI (`dx`) drives both halves.
+
+Server-side rendering is not a fallback here. The locale is negotiated from request headers in
+`apps/web/src/i18n.rs` and applied before the document is serialised, so nothing arrives in the
+wrong language and gets swapped once hydration runs. The `<html lang>` attribute is stamped into
+the buffered body, which is also where the Content-Security-Policy gets the inline scripts it
+hashes — see [SECURITY_POSTURE.md](SECURITY_POSTURE.md).
+
+## Internationalization
+
+EN and DE, through [i18nrs](https://crates.io/crates/i18nrs) with only its `dio` component set
+enabled. `dio-ssr` is left out: it negotiates the locale through a `#[server]` round-trip whose
+`get_cookie` result is discarded upstream, so this workspace negotiates on the server from request
+headers and reads `document.cookie` directly on the client instead.
+
+`translation_key_sets_match` in `crates/data` compares the key sets of both translation files and
+fails the build when they differ. i18nrs falls back to an arbitrary language for a missing key,
+which shows up as one English string in a German page rather than as an error, so the test is the
+only thing that catches it.
+
+## What the client ships
+
+The WASM bundle is built under the `release` profile: `opt-level = "z"`, fat LTO, one codegen unit.
+The profile sets `panic = "unwind"` even so, because it also builds the SSR server, where a panic
+in one handler has to fail that request rather than the process. The wasm target has no unwinding,
+so the client keeps its size either way.
+
+Tailwind CSS v4 is compiled by `@tailwindcss/cli` through npm, which is the only reason Node.js is
+a prerequisite.
+
+## Generated artefacts
+
+Three things reach the binary from outside the source tree, and `apps/web/build.rs` embeds all
+three with `include_str!`. Each has an empty default it falls back to, so a bare `cargo check`
+outside the image build still compiles and the affected page renders its empty state.
+
+| Artefact | Written by | Read by |
+| --- | --- | --- |
+| `apps/web/repos.json` | `apps/update-repos` | the projects section — see [PROJECT_DATA.md](PROJECT_DATA.md) |
+| `apps/web/generated/licenses.json` | `cargo about`, through `just licenses` | `/licenses` — see [DEPLOYMENT.md](DEPLOYMENT.md) |
+| `resume-fingerprint.json` | `apps/resume-generator` | the contact card, which shows each PDF's SHA-256 |
+
+The resume generator is a Typst document builder rather than a PDF library. It embeds Inter, with
+Liberation Sans as a metric-compatible last resort, and emits a tagged PDF 1.7 with live link
+annotations. `fit` is the part worth knowing about: it scales the type down and re-typesets until
+the content lands on one A4 page, because a resume that runs to a second page is a resume an ATS
+truncates. The main column is emitted before the sidebar so a text extractor reads identity,
+summary and experience in that order despite the sidebar sitting on the left.
+
+The same run rasterises `og-image.png` at 1200×630. Every link unfurler refuses SVG, and Typst is
+already here with the brand font and a layout engine, so the social card is a second small document
+rather than a second toolchain.
+
+## Routes
+
+`/` is a single page of sections `s1`–`s5`. `/imprint`, `/privacy` and `/licenses` are routes in
+the same shell, translated and server-rendered like any other, with a 404 page under the catch-all.
+Beside them the server registers `/api/v1/profile` and its JSON schema, the probes documented in
+the README, and `robots.txt`, `sitemap.xml` and `site.webmanifest`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,123 @@
+# Deployment
+
+What the image contains, how it is built reproducibly, what it publishes about its own configuration, and where the chart that runs it lives.
+
+## The image
+
+The runtime stage is `FROM scratch`. There is no shell, no package manager, no CA bundle, no
+tzdata and no `/etc/passwd` — a numeric `USER` needs no passwd entry. What gets copied in is the
+`server` binary, the `public/` bundle beside it, and `/config/contract.json`.
+
+That works because the server is linked against musl and is fully static. Every build stage runs
+natively on `$BUILDPLATFORM` and cross-compiles the binary to `$TARGETPLATFORM`; the mapping from
+Docker's `TARGETARCH` to the Rust triple is resolved once into `/etc/rust-target`, and an
+architecture that is not `amd64` or `arm64` fails there rather than building the wrong thing
+further down. Nothing else in the build is architecture-dependent: the client is WASM, and
+`repos.json`, the resume PDFs and the Tailwind CSS are data.
+
+`WORKDIR` is `/app` and the server resolves `public/` relative to itself, so the two have to stay
+together.
+
+### Incremental static regeneration
+
+The image sets the ISR cache directory to `/tmp/isr` and bakes an empty one owned by the runtime
+user, because a non-root process on a `scratch` root cannot create it. Under
+`readOnlyRootFilesystem: true` the chart mounts a writable volume there; a plain `docker run` uses
+the baked-in copy. Where the path is not writable at all, the server renders every request fresh
+instead of failing.
+
+The cache is permanent by default. The only thing that changes a page is a new build, and a new
+build starts from an empty cache. A positive TTL is for a persistent cache volume shared across
+deploys. Each entry is keyed by the negotiated locale, so the German and English renders of a page
+do not overwrite each other.
+
+## The configuration contract
+
+The image describes its own configuration surface twice, so a consumer can find it with or without
+a registry.
+
+`/config/contract.json` is the offline copy — a few kilobytes, readable from an exported tarball,
+an air-gapped mirror or an init container. The canonical copy is the OCI referrer attached to the
+pushed digest. Three labels make either one discoverable without pulling a layer:
+
+```dockerfile
+LABEL dev.terrace.config.contract.version="1" \
+      dev.terrace.config.contract.path="/config/contract.json" \
+      dev.terrace.config.prefix="PORTFOLIO_"
+```
+
+That block is generated, not typed. `config-schema --format dockerfile` emits it between two
+markers, `just regenerate` rewrites the region between them, and the `Config Contract` job in
+**Build** compares the Dockerfile, the committed `docs/config.contract.json` and the labels a built
+image actually carries. Delimiting by marker rather than by line count is what makes a fourth label
+added upstream get rewritten instead of falling outside the slice.
+
+The committed contract is rendered without `--version`, `--revision` or `--created`. Those move
+between builds of the same source, so the committed copy describes the configuration surface and
+the copy inside an image additionally names the build it came from.
+
+## Reproducible builds
+
+Every input is pinned:
+
+- Base images by digest, which is also what pins the Rust toolchain.
+- The Dioxus CLI and cargo-about to exact versions, through the `DIOXUS_CLI_VERSION` and
+  `CARGO_ABOUT_VERSION` build args.
+- `cargo` and `dx bundle` run `--locked` against the committed `Cargo.lock`, and the Tailwind
+  toolchain runs `npm ci` against `package-lock.json`.
+
+Pass `SOURCE_DATE_EPOCH` for deterministic timestamps, and the four OCI metadata args to make the
+image self-describing:
+
+```bash
+docker build \
+  --build-arg SOURCE_DATE_EPOCH="$(git log -1 --format=%ct)" \
+  --build-arg VCS_REF="$(git rev-parse HEAD)" \
+  --build-arg VERSION="$(git describe --tags --always)" \
+  --build-arg SOURCE_URL=https://github.com/TimSchoenle/Portfolio \
+  -t portfolio .
+```
+
+`update-repos` runs inside the build and needs the GitHub token. It arrives as a BuildKit secret
+mounted as a file, so nothing survives into a layer:
+
+```bash
+docker build --secret id=gh_token,src=./gh_token -t portfolio .
+```
+
+## Publishing
+
+A release pushes both architectures as one manifest list, so `docker pull` resolves the right image
+per node. The push carries max-mode provenance and an SBOM, and `cosign sign --recursive` signs the
+index and each per-architecture child manifest — verification then still succeeds for a consumer or
+an admission controller that resolved the index down to one architecture before checking.
+
+The chart lives in
+[TimSchoenle/helm-charts](https://github.com/TimSchoenle/helm-charts/tree/main/charts/portfolio) and
+is bumped by the release workflow with the image **digest** alongside the tag, so a deployment is
+pinned to bytes rather than to a moving name.
+
+## Third-party licence inventory
+
+`/licenses` renders a document produced by [cargo-about](https://github.com/EmbarkStudios/cargo-about)
+during the image build, from `apps/web/about.toml` (which licences are acceptable, which targets are
+built) and `apps/web/about.hbs` (the JSON it writes).
+
+It runs against `apps/web/Cargo.toml` rather than the workspace, because what the page has to report
+is the dependency set a visitor actually receives — the WASM client and the SSR server — and not the
+resume generator's Typst tree or the repository lister's HTTP client, neither of which ships.
+`--all-features` covers both halves of the fullstack crate in one pass, since the client's `web-sys`
+and the server's axum sit behind its platform features.
+
+```bash
+just licenses
+```
+
+The document stays normalised, one entry per distinct licence file rather than one per dependency,
+and the join happens while rendering. That is what keeps it to 340 KB inside the binary.
+
+The `accepted` list in `about.toml` is a gate rather than a description. `cargo about` exits
+non-zero on a licence that is not on it and the image build fails, so a dependency arriving under
+terms this site cannot ship stops the build instead of being published under a licences page that
+does not mention it. Adding an entry to that list is a deliberate decision to ship under those
+terms.

--- a/docs/PROJECT_DATA.md
+++ b/docs/PROJECT_DATA.md
@@ -1,0 +1,53 @@
+# Project data
+
+How `apps/web/repos.json` is fetched, filtered, cached and embedded, and what the projects section reads out of it.
+
+## Where the file comes from
+
+`apps/update-repos` writes it and `apps/web/build.rs` embeds it with `include_str!`. The builder
+runs before the web build — inside the image build, and by hand during development. When the file
+is absent, `build.rs` substitutes an empty default so the `include_str!` always resolves and the
+projects section renders its empty state.
+
+```bash
+PORTFOLIO_GITHUB__TOKEN_FILE=/run/secrets/gh_token \
+  cargo run --release -p update-repos -- apps/web/repos.json
+```
+
+Without a token it still runs, against the anonymous rate limit. The token exists only to lift that
+limit; the server never loads it. See the configuration tables in the [README](../README.md).
+
+## What it keeps
+
+The builder lists every repository the owner has (`GET /users/{user}/repos`, paginated) and drops
+three kinds:
+
+- Archived repositories.
+- Repositories named in `CONFIG.blacklisted_repos`.
+- Repositories with no update in the last 365 days (`MAX_AGE_DAYS` in `builder.rs`).
+
+What survives is deserialized straight into the shared `portfolio_data::Repo` and `ReposFile`
+models and written as pretty-printed JSON, with failures surfaced through a dedicated
+`UpdateReposError`. Sharing the models with `crates/data` is what stops the writer and the reader
+from disagreeing about a field name.
+
+An explicit set bypasses the listing and its filtering, and each named repository is fetched
+directly:
+
+```bash
+PORTFOLIO_GITHUB__REPOS='[Portfolio,actions]' cargo run --release -p update-repos
+```
+
+The bracketed array is figment's syntax, so the environment spelling and the TOML spelling stay the
+same shape.
+
+## Freshness
+
+A rebuild does not mean a fetch. The builder reads the `generated_at` timestamp out of the existing
+file and skips the fetch while the file is younger than the cache TTL: 10 hours when the `CI`
+environment variable is set to a non-empty value, 60 minutes otherwise. Deriving freshness from the
+file's own timestamp rather than from a marker means it works the same whether the file was written
+locally or restored from a CI cache.
+
+CI additionally persists the file across runs with `actions/cache`, keyed by a roughly ten-hour
+window, so a fresh copy is usually restored before the build even asks.

--- a/docs/SECURITY_POSTURE.md
+++ b/docs/SECURITY_POSTURE.md
@@ -1,0 +1,96 @@
+# Security posture
+
+The Content-Security-Policy the server builds per response, the headers around it, and what the process needs from the filesystem it runs on.
+
+## Runtime
+
+The server reads its bundle directory and writes to stdout. Nothing else. It runs with a read-only
+root filesystem and no writable volume, apart from the ISR cache described in
+[DEPLOYMENT.md](DEPLOYMENT.md), which it does without when the path is not writable.
+
+It is built to satisfy the restricted Pod Security Standard:
+
+- Numeric non-root `1001:1001`, so `runAsNonRoot` verifies statically without a passwd lookup.
+- `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false`.
+- Every Linux capability dropped, `seccompProfile: RuntimeDefault`.
+- Listens on `:$PORT`, default `8080`.
+
+Everything else it reads comes from the layered configuration, so a `ConfigMap` fragment or a
+`Secret` volume is a first-class source rather than something the chart has to flatten into
+environment variables.
+
+## Headers
+
+Five headers are set on every response, overriding whatever a handler produced:
+
+| Header | Value |
+| --- | --- |
+| `X-Content-Type-Options` | `nosniff` |
+| `X-Frame-Options` | `DENY` |
+| `Referrer-Policy` | `no-referrer` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), interest-cohort=()` |
+
+`Content-Security-Policy` is the exception. The subresource policy is set only when the document
+middleware has not already set a stricter one, which is what the section below is about.
+
+## Content-Security-Policy
+
+Built with [csp-shell](https://github.com/TimSchoenle/csp-shell) in `apps/web/src/server/csp.rs`,
+from the bytes of the document being served rather than written out as a string. Two policies leave
+the server.
+
+**Documents** get one derived from what they carry. Dioxus renders its hydration data inline as
+`window.initial_dioxus_hydration_data="…"`, so the text of that script is only known per response.
+The body is buffered anyway, to stamp `<html lang>`, and each inline script is hashed out of that
+same string. `'unsafe-inline'` is therefore absent from `script-src`, and an injected `<script>` no
+longer runs merely because the hydration bootstrap has to.
+
+**Everything else** — assets, the JSON API, the SEO documents — gets a policy admitting no inline
+script at all, because none of them has any.
+
+`'unsafe-eval'` remains, for the one reason it has ever been here: `dioxus-web`'s document provider
+applies `document::Title`, `document::Stylesheet` and friends through `new Function(…)`, which
+throws an uncaught `EvalError` without it and freezes client-side navigation.
+
+### Cloudflare
+
+The bot products in front of this origin inject an inline `<script>` at the edge, after this server
+has hashed what it rendered. No hash can cover it. A nonce can, because Cloudflare parses the
+`Content-Security-Policy` response header and copies the nonce onto what it injects. That is what
+`csp.cloudflare.script_nonce` reserves, on by default.
+
+It brings one obligation the server discharges and one it cannot. Every document is served
+`Cache-Control: no-cache`, so a nonce is never shared between readers. The other:
+
+> **Deployment checklist.** No Cloudflare Cache Rule may cache the shell. A "Cache Everything" rule
+> overrides the origin's `Cache-Control` and pins one nonce across every reader for the lifetime of
+> the cache entry, and nothing inside this process can see that happening.
+
+The ISR cache is unaffected. It stores the body, and the nonce lives only in the response header,
+minted after the cached render is read.
+
+Turnstile and Web Analytics are off. Switching either on admits its origins in the directives that
+product actually needs them in — Turnstile in `script-src` **and** `frame-src`, since admitting only
+the first renders an empty box.
+
+### If a page renders blank
+
+That is the failure mode this design has. Setting both `csp.hash_inline_scripts` and
+`csp.cloudflare.script_nonce` to false restores `'unsafe-inline'` on a restart rather than a
+redeploy. The two must move together: a browser ignores `'unsafe-inline'` as soon as the policy
+carries a nonce, and supplying one without the other fails the boot with a message saying so.
+
+## The one secret
+
+`github.token` is the only secret in the workspace, and the server never loads it — it belongs to
+the build-time repository lister. In the process it is a `secrecy::SecretString`, which has no
+`Debug` and no `Display`, and the single place it becomes a `&str` is the `Authorization` header.
+
+Supply it as a file. `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry the
+environment, and child processes inherit it. The Docker build already does this, mounting the
+BuildKit secret and handing `update-repos` the path.
+
+Only the loader half of `terrace-config` is used; its hot-reload supervisor is not. The reasoning —
+the server holds no secrets, and `dioxus::serve` owns an accept loop with no shutdown handle — is
+recorded in `crates/config/src/lib.rs`.


### PR DESCRIPTION
## What changed

The README is now rendered from `.github/templates/README.md.hbs` against two merged payloads, and
a job in **Build** refuses a stale one.

**The payload.** `TimSchoenle/actions/actions/common/readme-variables@b5b5c9e` supplies `repo`,
`release`, `toolchain` and a `docs` index built by walking `docs/`. The existing
`config-schema --format variables` generator is unchanged and its output is handed to the action as
`extra`, where it is deep-merged over the derived half. The two key sets do not overlap — the
generator emits `serverConfigTable`, `builderConfigTable`, `exampleConfig`, `loader` and `keys` —
so nothing the action derived is replaced. A same-named key **would** replace rather than merge, so
adding one to the generator means checking that list first; the workflow comment says so.

`branch` is pinned to `${{ github.event.repository.default_branch }}` in both callers. Left at its
`github.ref_name` default it is `<number>/merge` on a pull request and `main` on the gate, and the
badge URL alone would then fail every merge for a reason absent from the diff.

**The gate.** `build.yaml` gains a `readme` job (`name: README`) beside `Config Contract`, running
the same two payload steps and then `render-template` with `check: 'true'`. It is there rather than
in Update Files because Update Files only triggers on `pull_request`, and a gate that never sees
`main` is not a gate. This mirrors what the repository already does for the configuration contract:
Update Files makes the branch converge, Build declines to let it merge before it has.

**The page.** 491 lines to 281, in the canonical order: banner, H1, description, four badges, what
this is, quick start, contents, features, installation, usage, configuration, operations,
compatibility, documentation, contributing, security, licence. Both generated configuration tables
carry over unchanged. Four reference sections moved into `docs/`, where the same action indexes
them into the documentation table.

**The manifest.** `Cargo.toml` gains `description`, `homepage`, `license` and `rust-version`. The
payload reads all four from the manifest and deliberately refuses to read the first three from the
GitHub API. The first three are byte-identical to the strings the image's OCI labels already carry.

## Rendered locally, not hand-written

I ran the pinned `readme-variables` and `render-template` dist bundles under node against this
checkout, then re-ran `render-template` with `check: true`, which reported the committed file up to
date. CI's render step should therefore commit nothing on top of this.

Prose checks from the contract, both against the rendered file: em dashes **2** (budget 5),
`**Bold** —` bullets **0** (budget 3). Sentence distribution: n=67, mean 13.9, median 13, stdev 8.2.

## What a reviewer should check

1. **`rust-version = "1.97"`.** This is a judgement, not a fact I read. Nothing in the tree declared
   an MSRV. 1.97 is the toolchain the image builds with (`rust:1.97-slim` in the Dockerfile) and it
   is what my local cargo reports, but nothing tests below it. It renders into the Rust badge and
   the Compatibility row. Drop it and both go, along with `toolchain.msrv`.
2. **Two facts the old README had wrong, now corrected in `docs/`.** The runtime stage is
   `FROM scratch` with a statically linked musl binary, not a `distroless/cc` base. The resume
   generator embeds Inter with Liberation Sans as a metric-compatible fallback, not a subset of
   Liberation Sans. Both read off the Dockerfile and `apps/resume-generator/src/world.rs`.
3. **A claim I removed rather than moved.** The old page said the server shuts down gracefully on
   `SIGTERM`. Nothing in the workspace installs a signal handler, so it is gone rather than
   restated.
4. **The image name `timschoenle/portfolio` is typed in the template.** It lives in
   `release-please.yaml`, not in a manifest, and the payload has no field for it. The tag beside it
   is `{{ release.tag }}`. Emitting it from the generator would single-source it at the cost of
   putting a publishing constant in a configuration schema.
5. **Badges.** Four, all links: release, build, licence, Rust. No coverage badge, because there is
   no coverage. I dropped the website badge the worked example carried, because the spec says to
   drop an inapplicable badge rather than substitute a decorative one. The licence badge escapes the
   SPDX id's hyphen with the `replace` helper, so `LicenseRef-Proprietary` renders whole instead of
   splitting into two shields fields.
6. **Compatibility has no Helm chart row and no Kubernetes version.** Both live in
   `TimSchoenle/helm-charts` and neither is in this payload; typing them would be a version that
   goes stale silently. The chart is linked from Installation instead.
7. **Claims about the Pod Security Standard.** `readOnlyRootFilesystem`, dropped capabilities and
   `seccompProfile` are chart settings this repository does not contain. The wording says the image
   is built to satisfy them, which is what the old README claimed too, but only the numeric
   `USER 1001:1001` is verifiable here.
8. **`docs/*.md` spell environment variables literally**, unlike the README. They are not rendered
   from a template, so a key rename in `crates/config` does not reach them. The README's mustaches
   still catch it, and the generator still fails on a `KEYS` path that no longer exists.

## Not touched

`crates/config/examples/config-schema.rs`, `just regenerate`, `docs/config.contract.json`, the
Dockerfile's label region and the `Config Contract` job. I re-rendered the contract and the label
block after the `Cargo.toml` change; both are byte-identical. `config.example.toml` verifies clean
against its own template.
