### PR TITLE
docs: bring the crates onto the estate doc-comment standard

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,6 +134,47 @@ jobs:
           variables: ${{ steps.readme-variables.outputs.variables }}
           check: 'true'
 
+  # The documentation gate. `missing_docs` and the clippy doc lints are compiled by `check` and
+  # `clippy` already; the rustdoc lints in `[workspace.lints.rustdoc]` are not, because rustdoc is
+  # the only thing that runs them. A broken intra-doc link renders as the literal text on the page,
+  # so it is invisible to the reader and visible only to whoever no longer needs it. That is why it
+  # is denied, and why this job exists as its own step rather than as a flag on an existing one.
+  #
+  # `--workspace` matters: the workspace root is a package too, so the default member set is that
+  # placeholder alone and every crate this repository actually ships would go unchecked.
+  doc:
+    name: Docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the code
+    env:
+      RUSTDOCFLAGS: '-D warnings'
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Build the documentation
+        run: cargo doc --workspace --all-features --no-deps
+
+      # `apps/web` compiles under two mutually exclusive platform features and `--all-features`
+      # renders both, so a link that only resolves when the server feature is on never fails the
+      # run above. This is the shape the wasm client is actually built in.
+      - name: Build the documentation without the server feature
+        run: cargo doc -p web --no-default-features --features web --no-deps
+
+      - name: Run the doctests
+        run: cargo test --workspace --doc --all-features
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,42 @@ description = "Dioxus fullstack (SSR + hydration) portfolio served by Axum."
 homepage = "https://tim-schoenle.de"
 license = "LicenseRef-Proprietary"
 
+# Inherited by every member with `[lints] workspace = true`.
+#
+# `missing_docs` only fires on an effectively-exported item, so it reaches
+# `crates/config` and `crates/data` and nothing in `apps/`: all three binaries
+# declare their modules privately, which makes every item in them unexported as
+# far as the lint is concerned. The rustdoc link lints below do fire inside a
+# private module, so the `doc` job still gates the binaries; what is not linted
+# there is coverage, and that is a review criterion.
+#
+# `clippy::missing_docs_in_private_items` is deliberately absent. A private
+# helper whose body is six obvious lines has nothing to say; the private
+# constant whose value came out of a rate limit has everything to say, and no
+# lint tells those apart.
+[workspace.lints.rust]
+missing_docs = "warn"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# Already inside `pedantic`. Named again so the next reader can see they are
+# deliberate rather than swept in with the group.
+missing_errors_doc = "warn"
+missing_panics_doc = "warn"
+doc_markdown = "warn"
+too_long_first_doc_paragraph = "warn"
+doc_link_with_quotes = "warn"
+doc_broken_link = "warn"
+doc_include_without_cfg = "warn"
+
+# Denied rather than warned: a broken link renders as the literal text
+# ``[`Foo`]`` on the page, so it is invisible to the person reading the rendered
+# output and visible only to the person who no longer needs it.
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+private_intra_doc_links = "warn"
+unescaped_backticks = "warn"
+
 [workspace.dependencies]
 portfolio-config = { path = "crates/config" }
 portfolio-data = { path = "crates/data" }
@@ -212,3 +248,6 @@ opt-level = 1
 lto = false
 codegen-units = 16
 strip = true
+
+[lints]
+workspace = true

--- a/apps/resume-generator/Cargo.toml
+++ b/apps/resume-generator/Cargo.toml
@@ -13,3 +13,6 @@ typst-render.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 time.workspace = true
+
+[lints]
+workspace = true

--- a/apps/resume-generator/src/fit.rs
+++ b/apps/resume-generator/src/fit.rs
@@ -3,7 +3,7 @@
 //! readable sizes. The order is: prefer detail, then tighten density
 //! (Comfortable → Compact), and only then ease the type scale.
 //!
-//! Page count comes straight from Typst's compiled [`PagedDocument`]
+//! Page count comes straight from Typst's compiled [`typst_layout::PagedDocument`]
 //! (`pages.len()`), so fitting needs no PDF parsing; the PDF is exported only
 //! for the scale that actually fits.
 
@@ -32,6 +32,14 @@ pub(crate) enum Detail {
 }
 
 impl Detail {
+    /// How many bullets the entry at `entry_index` of the sorted work history renders at this
+    /// detail level.
+    ///
+    /// `entry_index` is the position in [`portfolio_data::experiences_sorted`], so "recent" means
+    /// the first two of that order rather than the two most recent by date.
+    ///
+    /// [`Experience::resume_bullet_cap`](portfolio_data::Experience::resume_bullet_cap) is applied
+    /// last and only ever lowers the result, so a capped entry stays capped at every level.
     pub(crate) fn bullet_count(self, entry_index: usize, e: &portfolio_data::Experience) -> u8 {
         let recent = entry_index < 2;
         let ongoing = e.end.is_none();
@@ -47,6 +55,7 @@ impl Detail {
         n.min(e.resume_bullet_cap.unwrap_or(u8::MAX))
     }
 
+    /// The phrase the generator prints for this level, for the line naming what it took to fit.
     pub(crate) fn describe(self) -> &'static str {
         match self {
             Detail::Full => "full detail",
@@ -56,10 +65,15 @@ impl Detail {
     }
 }
 
+/// A resume that fit on one page, and what it cost to get there.
 pub(crate) struct Fitted {
+    /// The exported PDF.
     pub(crate) bytes: Vec<u8>,
+    /// The type scale it fit at, between [`ABSOLUTE_MIN_SCALE`] and `1.0`.
     pub(crate) scale: f64,
+    /// Whether the Compact spacing preset was needed.
     pub(crate) dense: bool,
+    /// How much of the experience section survived.
     pub(crate) detail: Detail,
 }
 

--- a/apps/resume-generator/src/translations.rs
+++ b/apps/resume-generator/src/translations.rs
@@ -1,9 +1,15 @@
 //! Read-only view over one embedded translation file.
+//!
+//! A missing key panics instead of returning an `Option` nobody would have anything useful to do
+//! with, so a drifted translation file fails the image build rather than emitting a resume with a
+//! blank heading on it. `portfolio_data`'s `translation_key_sets_match` holds the two files to one
+//! key set, so a key missing here is missing from both languages rather than one.
 
 use std::error::Error;
 
 use portfolio_data::{YearMonth, format_period};
 
+/// One language's translations, with the two lookups the date formatter needs already resolved.
 pub(crate) struct Translations {
     root: serde_json::Value,
     months: Vec<String>,
@@ -11,6 +17,11 @@ pub(crate) struct Translations {
 }
 
 impl Translations {
+    /// Parses a translation document and resolves the twelve month names and the "present"
+    /// label out of it.
+    ///
+    /// Errors on malformed JSON. Panics if any of those thirteen keys is missing, for the reason
+    /// in the module comment.
     pub(crate) fn parse(json: &str) -> Result<Self, Box<dyn Error>> {
         let root: serde_json::Value = serde_json::from_str(json)?;
         let mut t = Translations {
@@ -25,7 +36,7 @@ impl Translations {
         Ok(t)
     }
 
-    /// Looks up a dotted key; the data crate's tests guarantee presence.
+    /// Looks up a dotted key, panicking when it is absent or does not hold a string.
     pub(crate) fn get(&self, key: &str) -> String {
         let mut value = &self.root;
         for part in key.split('.') {
@@ -37,6 +48,8 @@ impl Translations {
             .to_string()
     }
 
+    /// A date range in this language, e.g. `Nov 2018 – Jan 2023`, open-ended when `end` is
+    /// `None`.
     pub(crate) fn period(&self, start: YearMonth, end: Option<YearMonth>) -> String {
         format_period(start, end, &self.months, &self.present)
     }

--- a/apps/update-repos/Cargo.toml
+++ b/apps/update-repos/Cargo.toml
@@ -14,3 +14,6 @@ serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
 ureq.workspace = true
+
+[lints]
+workspace = true

--- a/apps/update-repos/src/builder.rs
+++ b/apps/update-repos/src/builder.rs
@@ -1,15 +1,13 @@
-//! A small builder for fetching a user's GitHub repositories and assembling
-//! them into the shared [`portfolio_data::ReposFile`] model.
+//! The GitHub half of `update-repos`: what is listed, what is kept, and what is thrown away.
 //!
-//! By default it lists every repository the user owns (paginated) and keeps
-//! only the active ones: not archived, not blacklisted and updated within the
-//! last [`MAX_AGE_DAYS`] days. An explicit set of repository names may also be
-//! supplied (via `github.repos`), in which case each is fetched by name without
-//! filtering.
+//! Two modes, and they are not variations of one another. With no explicit names the builder
+//! pages through everything the user owns and then filters: archived, blacklisted, or untouched
+//! for [`MAX_AGE_DAYS`] days is dropped. With names supplied it fetches each one and filters
+//! nothing, because a repository somebody asked for by name is not one that needs judging.
 //!
-//! [`ReposBuilder::fetch`] performs the network calls; [`ReposBuilder::assemble`]
-//! is a pure step (timestamp + user + repos) so it can be unit-tested without
-//! network access.
+//! Only [`ReposBuilder::fetch`] and the two functions under it touch the network. Everything the
+//! tests care about — the filter, the assembly — is reachable without it, which is why
+//! `active_repos` takes `now` as an argument instead of reading the clock.
 
 use std::time::Duration;
 
@@ -42,7 +40,11 @@ pub struct ReposBuilder {
 }
 
 impl ReposBuilder {
-    /// Starts a builder for the given GitHub `user`.
+    /// A builder against the public GitHub API, unauthenticated, with no repository named.
+    ///
+    /// The agent it constructs has a 30-second global timeout covering connect, send and read
+    /// together. `update-repos` runs inside an image build, where a hung socket is a hung build
+    /// and no retry is attempted.
     pub fn new(user: impl Into<String>) -> Self {
         let agent: ureq::Agent = ureq::Agent::config_builder()
             .timeout_global(Some(Duration::from_secs(30)))
@@ -58,20 +60,24 @@ impl ReposBuilder {
         }
     }
 
-    /// Sets the bearer token used to authenticate API requests (lifts the rate
-    /// limit). A `None` or empty token leaves requests unauthenticated, which
-    /// is the normal case on a fork's pull request.
+    /// Authenticates every subsequent request, lifting the API rate limit.
     ///
-    /// Kept wrapped rather than taken as a `String`: the token arrives from a
-    /// mounted file and is never printed, so the only place it becomes a `&str`
-    /// is [`Self::get`], where it goes onto the wire.
+    /// `None` or an all-empty token leaves the requests unauthenticated. That is the normal case
+    /// on a fork's pull request, where there is no secret to pass, rather than a misconfiguration
+    /// worth failing over.
+    ///
+    /// Kept wrapped rather than taken as a `String`: the token arrives from a mounted file and is
+    /// never printed, so the only place it becomes a `&str` is [`Self::get`], where it goes onto
+    /// the wire.
     pub fn token(mut self, token: Option<SecretString>) -> Self {
         self.token = token.filter(|token| !token.expose_secret().is_empty());
         self
     }
 
-    /// Sets the exact list of repository names to fetch (empty names are
-    /// ignored). Their order is preserved in the resulting [`ReposFile`].
+    /// Names the repositories to fetch, in place of listing the account.
+    ///
+    /// Blank names are dropped. The rest keep their order all the way into the [`ReposFile`], and
+    /// none of them are filtered for age, archival or the blacklist.
     pub fn repos<I, S>(mut self, repos: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -85,9 +91,9 @@ impl ReposBuilder {
         self
     }
 
-    /// Sets the list of repository names that must never appear in the result
-    /// when listing all of the user's repositories (empty names are ignored).
-    /// Matched case-insensitively by name.
+    /// Excludes repositories by name, case-insensitively, when the account is listed.
+    ///
+    /// Ignored entirely by [`Self::repos`], which fetches what it was asked for.
     pub fn blacklist<I, S>(mut self, blacklist: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -160,10 +166,11 @@ impl ReposBuilder {
         ))
     }
 
-    /// Pure filter step: drops archived repositories, blacklisted repositories
-    /// (matched case-insensitively by name) and repositories that have not been
-    /// updated within [`MAX_AGE_DAYS`] days of `now`. Keeps API order.
-    /// Exposed for unit testing without network access.
+    /// The active repositories out of `repos`, in the order they arrived.
+    ///
+    /// Archived, blacklisted, and last updated more than [`MAX_AGE_DAYS`] days before `now` are
+    /// each dropped. A repository whose `updated_at` is missing or unparsable is kept. `now` is a
+    /// parameter rather than a clock read so the age boundary is a thing a test can stand on.
     fn active_repos(repos: Vec<Repo>, blacklist: &[String], now: OffsetDateTime) -> Vec<Repo> {
         let cutoff = now - time::Duration::days(MAX_AGE_DAYS);
         repos
@@ -216,8 +223,10 @@ impl ReposBuilder {
         Ok(repo)
     }
 
-    /// Pure assembly step: stamps the current time and wraps the repositories
-    /// in a [`ReposFile`]. Exposed for unit testing without network access.
+    /// The listing, stamped with the current UTC time in RFC 3339.
+    ///
+    /// That stamp is what the next build's freshness check reads, so it is taken after the fetch
+    /// rather than when the builder was created.
     pub fn assemble(&self, repos: Vec<Repo>) -> Result<ReposFile, UpdateReposError> {
         let generated_at = OffsetDateTime::now_utc().format(&Rfc3339)?;
         Ok(ReposFile {

--- a/apps/update-repos/src/cache.rs
+++ b/apps/update-repos/src/cache.rs
@@ -1,12 +1,8 @@
-//! Build-time caching for `repos.json`.
+//! When a `repos.json` already on disk is good enough to skip the API call.
 //!
-//! `repos.json` is generated during the build, so to avoid hitting the GitHub
-//! API (and its rate limits) on every rebuild, a freshly generated file is
-//! reused while it is still "fresh". The freshness window is longer on CI than
-//! on a developer machine.
-//!
-//! Freshness is derived purely from the file's own `generated_at` timestamp, so
-//! it works whether the file was produced locally or restored from a CI cache.
+//! Freshness comes from the file's own `generated_at` stamp and nothing else — not the mtime,
+//! not a marker file — so a listing restored from a CI cache is judged by when it was generated
+//! rather than by when it was unpacked.
 
 use std::fs;
 use std::path::Path;
@@ -16,14 +12,13 @@ use time::Duration;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
-/// How long a generated `repos.json` stays fresh on CI.
+/// How long a generated `repos.json` stays fresh on CI: ten hours, so one listing serves the
+/// image builds of a working day.
 pub const CI_TTL: Duration = Duration::hours(10);
 /// How long a generated `repos.json` stays fresh on a developer machine.
 pub const LOCAL_TTL: Duration = Duration::minutes(60);
 
-/// Returns the cache time-to-live for the current environment: [`CI_TTL`] when
-/// running on CI (the `CI` env var is set to a non-empty value), [`LOCAL_TTL`]
-/// otherwise.
+/// [`CI_TTL`] on CI, [`LOCAL_TTL`] anywhere else.
 pub fn ttl_for_env() -> Duration {
     if is_ci() { CI_TTL } else { LOCAL_TTL }
 }
@@ -34,9 +29,10 @@ fn is_ci() -> bool {
     std::env::var("CI").map(|v| !v.is_empty()).unwrap_or(false)
 }
 
-/// Reads the cached `repos.json` at `path` and reports whether it is still fresh
-/// relative to `now` and `ttl`. A missing or malformed file is treated as stale
-/// (returns `false`) so the caller falls back to fetching.
+/// Whether the `repos.json` at `path` was generated within `ttl` of `now`.
+///
+/// Missing, unreadable and malformed all answer `false`, so every way of having no usable
+/// listing leads to the same fetch.
 pub fn is_cached_fresh(path: &Path, now: OffsetDateTime, ttl: Duration) -> bool {
     let Ok(contents) = fs::read_to_string(path) else {
         return false;
@@ -47,9 +43,13 @@ pub fn is_cached_fresh(path: &Path, now: OffsetDateTime, ttl: Duration) -> bool 
     is_fresh(&file.generated_at, now, ttl)
 }
 
-/// Pure freshness check: `true` when `generated_at` (an RFC 3339 timestamp) is
-/// within `ttl` of `now`. A missing or unparsable timestamp is treated as stale
-/// (returns `false`), forcing a refetch.
+/// Whether `generated_at`, an RFC 3339 timestamp, is less than `ttl` before `now`.
+///
+/// Exactly `ttl` old is stale. A timestamp in the future is fresh, so clock skew between the
+/// machine that wrote the file and the one reading it does not cost an API call.
+///
+/// An unparsable stamp is stale, which is the reading that refetches rather than the one that
+/// trusts a file nothing can date.
 pub fn is_fresh(generated_at: &str, now: OffsetDateTime, ttl: Duration) -> bool {
     match OffsetDateTime::parse(generated_at, &Rfc3339) {
         Ok(generated) => now - generated < ttl,

--- a/apps/web/Cargo.toml
+++ b/apps/web/Cargo.toml
@@ -84,3 +84,6 @@ server = [
     "dep:http",
     "dep:portfolio-config",
 ]
+
+[lints]
+workspace = true

--- a/apps/web/src/app.rs
+++ b/apps/web/src/app.rs
@@ -30,6 +30,10 @@ const PRELOADED_FONTS: [&str; 2] = [
     "/fonts/jetbrains-mono-latin-400-normal.woff2",
 ];
 
+/// Provides the i18n context and the parsed repository listing, then renders the router.
+///
+/// Every component that calls [`crate::i18n::use_i18n`] or reads [`crate::github::ReposState`]
+/// out of context has to sit under this one.
 #[component]
 pub fn App() -> Element {
     let translations = HashMap::from([("en", I18N_EN), ("de", I18N_DE)]);

--- a/apps/web/src/pages/home.rs
+++ b/apps/web/src/pages/home.rs
@@ -11,6 +11,10 @@ use crate::ui::hero::Hero;
 use crate::ui::projects::Projects;
 use crate::ui::skills::Skills;
 
+/// The `/` route: the chapter rail beside the six stacked sections.
+///
+/// Takes the repository listing from context rather than a prop, so it renders only under
+/// [`crate::app::App`].
 #[component]
 pub fn Home() -> Element {
     let repos = use_context::<ReposState>();

--- a/apps/web/src/pages/imprint.rs
+++ b/apps/web/src/pages/imprint.rs
@@ -1,9 +1,15 @@
+//! `/imprint` — the operator disclosure §5 DDG requires of a German site.
+//!
+//! The facts come from [`CONFIG`]`.legal`; the labels and the boilerplate around them come from
+//! the translation files, because the obligation is to state them in the reader's language.
+
 use dioxus::prelude::*;
 use portfolio_data::CONFIG;
 
 use super::legal::{AddressBlock, LegalPage, LegalSection};
 use crate::i18n::use_i18n;
 
+/// Renders the disclosure through [`LegalPage`], dated by `CONFIG.legal.imprint_last_change`.
 #[component]
 pub fn Imprint() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/pages/legal.rs
+++ b/apps/web/src/pages/legal.rs
@@ -11,6 +11,9 @@ use crate::i18n::use_i18n;
 use crate::routes::Route;
 use crate::ui::canonical::Canonical;
 
+/// Frames a legal page: back link, title, last-updated line, then `children` as its sections.
+///
+/// `last_updated` is printed verbatim after the localized label, neither parsed nor reformatted.
 #[component]
 pub fn LegalPage(
     title: String,
@@ -41,6 +44,11 @@ pub fn LegalPage(
     }
 }
 
+/// One numbered section of a legal page.
+///
+/// `body` is a raw translation string, run through the paragraph and list splitting below.
+/// `children` render after it, for the sections that need markup a translation string cannot
+/// carry.
 #[component]
 pub fn LegalSection(
     heading: String,

--- a/apps/web/src/pages/licenses.rs
+++ b/apps/web/src/pages/licenses.rs
@@ -18,6 +18,8 @@ use crate::licenses::load_licenses;
 use crate::routes::Route;
 use crate::ui::canonical::Canonical;
 
+/// Renders the inventory `cargo about` produced for this build, or a localized notice when the
+/// build produced none.
 #[component]
 pub fn Licenses() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/pages/not_found.rs
+++ b/apps/web/src/pages/not_found.rs
@@ -1,8 +1,15 @@
+//! The catch-all page every unrouted URL lands on.
+
 use dioxus::prelude::*;
 
 use crate::i18n::use_i18n;
 use crate::routes::Route;
 
+/// Answers any path no other route claimed.
+///
+/// `segments` is what the catch-all captured, and nothing reads it. The page is deliberately
+/// identical for every unknown URL, which is also what makes it safe to render one that a
+/// visitor did not type.
 #[component]
 pub fn NotFound(segments: Vec<String>) -> Element {
     let _ = segments;

--- a/apps/web/src/pages/privacy.rs
+++ b/apps/web/src/pages/privacy.rs
@@ -17,6 +17,7 @@ const SECTIONS: [(&str, &str); 9] = [
     ("privacy.noTrackingHeading", "privacy.noTrackingBody"),
 ];
 
+/// Renders the privacy notice through [`LegalPage`], dated by `CONFIG.legal.privacy_last_change`.
 #[component]
 pub fn Privacy() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/server/api.rs
+++ b/apps/web/src/server/api.rs
@@ -1,6 +1,11 @@
-//! Public JSON API handlers, mirroring the original Next.js portfolio plus
-//! Kubernetes probe endpoints. Every response derives solely from compile-time
-//! data, so the documents only change on redeploy.
+//! The public JSON API, and the two probes Kubernetes calls.
+//!
+//! The two profile documents are functions of compile-time data, so each is rendered once into a
+//! `&'static str` and changes on redeploy or not at all. The probes carry a live timestamp and
+//! are built per request. Nothing here touches the database this site does not have.
+//!
+//! The profile endpoint's shape is a contract with consumers older than this crate; see
+//! [`portfolio_data::profile`].
 
 use std::path::Path;
 use std::sync::LazyLock;
@@ -72,8 +77,10 @@ struct HealthResponse {
     timestamp: String,
 }
 
-/// ISO 8601 / RFC 3339 timestamp with millisecond precision and a `Z` suffix,
-/// matching the original endpoint's `new Date().toISOString()`.
+/// The current UTC time as `YYYY-MM-DDTHH:MM:SS.sssZ`.
+///
+/// Millisecond precision and a literal `Z`, which is what `Date.prototype.toISOString` emits and
+/// therefore what anything already parsing this endpoint expects.
 fn now_iso8601() -> String {
     let format =
         format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z");

--- a/apps/web/src/server/cache.rs
+++ b/apps/web/src/server/cache.rs
@@ -8,12 +8,15 @@
 //! Implemented as a response middleware that only sets `Cache-Control` when a
 //! handler has not already done so, so the API's own headers win.
 //!
-//! NOTE: `is_content_hashed` recognises the `dx`/`manganis` hash format, in which
-//! the asset filename stem ends in a `dxh`-prefixed hex segment (e.g.
-//! `tailwind-dxh31cffa1cc71c7bb.css`). `dx bundle` puts the whole client bundle
-//! under those names — the loader *and* the wasm binary — so everything in
-//! `public/assets/` is immutable. Nothing is served from `/wasm/`; that path
-//! exists only inside the build tree, before bundling renames and hashes it.
+//! What counts as content-hashed is the `dx`/`manganis` naming: a filename stem ending in a
+//! `dxh`-prefixed hex segment, as in `tailwind-dxh31cffa1cc71c7bb.css`. `dx bundle` puts the
+//! whole client bundle under those names, the loader and the wasm binary alike, so everything
+//! under `public/assets/` is immutable. The hex run is not fixed-width — plain hex comes out
+//! fifteen digits about as often as sixteen — and a rule that assumed sixteen served the two
+//! largest files on the page uncached.
+//!
+//! Nothing is served from `/wasm/`. That path exists inside the build tree only, before
+//! bundling renames and hashes it.
 
 use axum::{
     extract::Request,

--- a/apps/web/src/server/mod.rs
+++ b/apps/web/src/server/mod.rs
@@ -338,18 +338,17 @@ fn cacheable_path(path: &str) -> Option<&'static str> {
 /// (including its serialized hydration route) for a different unknown URL.
 const ISR_UNCACHEABLE_SENTINEL: &str = ".uncacheable";
 
-/// The Dioxus SSR/asset router, with incremental static regeneration enabled
-/// when the configuration names a writable cache directory.
+/// The Dioxus SSR and asset router, and whether it came back with the incremental cache on.
 ///
-/// Dioxus's incremental renderer keys its cache by request path (and query)
-/// only. This site negotiates locale per request (cookie / `Accept-Language`,
-/// see `crate::i18n::detect_locale`), so a naive per-path cache would serve
-/// whichever language rendered a URL first to every visitor. To keep ISR
-/// correct, [`tag_locale_for_isr`] appends the negotiated locale to the request
-/// URI and [`isr_map_path`] nests each render under its locale, giving one cache
-/// entry per language per path.
-/// Returns the Dioxus router and whether ISR is enabled (so the caller can add
-/// the locale-tagging middleware only when the cache is active).
+/// The cache is on only when the configured directory turns out to be writable, so the caller
+/// layers the locale-tagging half of [`localize_page`] onto the returned router only when the
+/// flag is `true`.
+///
+/// Dioxus's incremental renderer keys on the request path and query alone, and this site
+/// negotiates the locale per request, so a per-path cache would serve whichever language
+/// rendered a URL first to everyone who asked for it afterwards.
+/// [`with_locale_query`] puts the negotiated locale on the URI and [`isr_map_path`] nests each
+/// render under it, which is what makes the key one entry per language per path.
 fn dioxus_app_router(isr: &IsrConfig) -> (Router, bool) {
     match incremental_config(isr) {
         Some(cfg) => (

--- a/apps/web/src/server/seo.rs
+++ b/apps/web/src/server/seo.rs
@@ -1,7 +1,9 @@
-//! SEO documents served from `portfolio_data::CONFIG` — the single source of
-//! truth for site facts. Ported from the former build-time `site-meta` crate;
-//! the `<head>` block it also produced is now rendered per-route via Dioxus
-//! `document::` elements in the app, so only these three files remain.
+//! `robots.txt`, `sitemap.xml` and `site.webmanifest`, built from [`CONFIG`].
+//!
+//! Three whole documents a crawler fetches by a fixed path, which is what separates them from
+//! the rest of the site's metadata. Anything a crawler reads *inside* a page — the title, the
+//! canonical link, the Open Graph tags — is a `document::` element in the component that owns
+//! the route, so it is rendered with the page rather than assembled beside it.
 
 use std::sync::LazyLock;
 

--- a/apps/web/src/ui/about.rs
+++ b/apps/web/src/ui/about.rs
@@ -7,6 +7,7 @@ use crate::sections::{section_id, section_label};
 use crate::ui::reveal::Reveal;
 use crate::ui::section_header::SectionHeader;
 
+/// Renders the about section from the translation context.
 #[component]
 pub fn About() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/chapter_rail.rs
+++ b/apps/web/src/ui/chapter_rail.rs
@@ -1,6 +1,7 @@
-//! Fixed left-hand chapter rail: roman-numeral dots that reveal the section
-//! name. The active-chapter scroll tracking is a client enhancement (Phase 4);
-//! for SSR/no-JS the first chapter renders active.
+//! Fixed left-hand chapter rail: roman-numeral dots that reveal the section name.
+//!
+//! Which chapter is active is scroll position, so the server has no answer for it and renders
+//! the first one active. The client takes over after hydration.
 
 use dioxus::prelude::*;
 
@@ -83,6 +84,7 @@ fn active_chapter() -> usize {
     current
 }
 
+/// Renders the rail. Each dot is a plain `#id` anchor, so the rail navigates without JavaScript.
 #[component]
 pub fn ChapterRail() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/contact.rs
+++ b/apps/web/src/ui/contact.rs
@@ -14,6 +14,7 @@ use crate::sections::{section_id, section_label};
 use crate::ui::reveal::Reveal;
 use crate::ui::section_header::SectionHeader;
 
+/// Renders the contact section, linking the resume for the language currently selected.
 #[component]
 pub fn Contact() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/experience.rs
+++ b/apps/web/src/ui/experience.rs
@@ -23,6 +23,8 @@ fn years_badge(start: u16, end: Option<u16>) -> String {
     }
 }
 
+/// Renders the accordion with the most recent role open. One row is open at a time, and clicking
+/// the open one collapses it.
 #[component]
 pub fn Experience() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/footer.rs
+++ b/apps/web/src/ui/footer.rs
@@ -7,6 +7,7 @@ use crate::i18n::use_i18n;
 use crate::routes::Route;
 use crate::util::current_year;
 
+/// Renders the footer. The copyright year is read from the clock at render time.
 #[component]
 pub fn Footer() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/hero.rs
+++ b/apps/web/src/ui/hero.rs
@@ -50,6 +50,8 @@ fn hero_name_lines() -> Element {
     }
 }
 
+/// Renders the hero. The years-of-experience figure comes from [`EXPERIENCE`] against the current
+/// date, so it advances without an edit here.
 #[component]
 pub fn Hero() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/masthead.rs
+++ b/apps/web/src/ui/masthead.rs
@@ -29,6 +29,10 @@ pub fn goto_section(on_home: bool, id: String) {
     }
 }
 
+/// Renders the fixed top bar and raises `on_open_palette` when the palette trigger is clicked.
+///
+/// The ⌘K shortcut is a window listener in [`crate::routes`], which owns the palette's open
+/// state, so this component never learns whether the palette is showing.
 #[component]
 pub fn Masthead(on_open_palette: EventHandler<()>) -> Element {
     let ctx = use_i18n();

--- a/apps/web/src/ui/mod.rs
+++ b/apps/web/src/ui/mod.rs
@@ -1,4 +1,11 @@
-//! UI components (ported from the v4 Yew design to Dioxus rsx).
+//! The components the pages are assembled from.
+//!
+//! Every one of them renders the same markup on the server and on the client, and reaches for
+//! the browser only inside a `#[cfg(feature = "web")]` effect that runs after hydration. A
+//! component whose server render differs from its first client render tears the hydration, so
+//! the animated ones start at their finished state and step backwards once the client is live.
+//!
+//! Routing and the document head are not here; those are `crate::routes` and `crate::app`.
 
 pub mod about;
 pub mod canonical;

--- a/apps/web/src/ui/palette.rs
+++ b/apps/web/src/ui/palette.rs
@@ -31,6 +31,11 @@ struct Entry {
     action: Action,
 }
 
+/// The ⌘K overlay: one search field over sections, repositories, pages and languages.
+///
+/// Mounted only while open, so it holds no visibility state of its own and starts each time
+/// with an empty query. `on_close` fires on Escape, on a click outside, and after any action
+/// that navigates.
 #[component]
 pub fn CommandPalette(repos: ReposState, on_close: EventHandler<()>) -> Element {
     let ctx = use_i18n();

--- a/apps/web/src/ui/projects.rs
+++ b/apps/web/src/ui/projects.rs
@@ -66,6 +66,12 @@ fn base_lists(state: &ReposState) -> (Vec<Repo>, Vec<String>) {
     (repos, langs)
 }
 
+/// Renders the section from `state` and keeps the chosen chip and page in its own signals.
+///
+/// Opens on [`Filter::Favorites`], and falls back to the full list when nothing featured
+/// survived the build's fetch, so the section is never empty on its own first view. A
+/// [`ReposState::Failed`] `state` says so in the status line and renders no cards: the embedded
+/// listing did not parse, so there is nothing to fall back to.
 #[component]
 pub fn Projects(state: ReposState) -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/radar.rs
+++ b/apps/web/src/ui/radar.rs
@@ -127,6 +127,11 @@ fn build_dots() -> (Vec<NamedDot>, Vec<FillerDot>) {
     (named, filler)
 }
 
+/// The radar itself: named dots for real skills, seeded filler dots for texture.
+///
+/// `active` dims every quadrant but one; `None` shows all four at full strength. `on_hover`
+/// fires with the skill under the cursor and with `None` when it leaves, so the caller owns the
+/// tooltip and this component owns only the geometry.
 #[component]
 pub fn Radar(active: Option<Quadrant>, on_hover: EventHandler<Option<Skill>>) -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/ui/reveal.rs
+++ b/apps/web/src/ui/reveal.rs
@@ -8,6 +8,11 @@
 
 use dioxus::prelude::*;
 
+/// Wraps `children` so they fade in when scrolled to, `delay` milliseconds after the block
+/// above them.
+///
+/// Stagger a row by giving each item a larger `delay`. Nothing is delayed on the server or under
+/// reduced motion, where the children stay visible.
 #[component]
 pub fn Reveal(#[props(default = 0)] delay: u32, children: Element) -> Element {
     // Empty on the server and on the first client render (identical to the SSR

--- a/apps/web/src/ui/section_header.rs
+++ b/apps/web/src/ui/section_header.rs
@@ -1,8 +1,13 @@
-//! The v4 section header: a `grid-12` row with the section number + title in
-//! the label column and the intro sentence in the body column.
+//! The heading every home-page section opens with.
 
 use dioxus::prelude::*;
 
+/// A `grid-12` row: the mono section label and the title in the label column, the intro
+/// sentence in the body column.
+///
+/// `num` is a whole rendered label such as `"§ 02 — about"`, from
+/// [`crate::sections::section_label`], rather than a number this component formats. Section
+/// numbering is one derivation and it lives there.
 #[component]
 pub fn SectionHeader(num: String, title: String, intro: String) -> Element {
     rsx! {

--- a/apps/web/src/ui/skills.rs
+++ b/apps/web/src/ui/skills.rs
@@ -12,6 +12,7 @@ use crate::ui::radar::Radar;
 use crate::ui::reveal::Reveal;
 use crate::ui::section_header::SectionHeader;
 
+/// Renders the stack section, with the quadrant chips and the radar sharing one selection.
 #[component]
 pub fn Skills() -> Element {
     let i18n = use_i18n().i18n;

--- a/apps/web/src/util.rs
+++ b/apps/web/src/util.rs
@@ -1,4 +1,4 @@
-//! Small cross-target helpers.
+//! Reading the wall clock, which the two build targets do differently.
 //!
 //! The "current date" is read from the JS `Date` on the wasm client and from the
 //! system clock (`time`) on the server. The two use different zones — the client

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# `clippy::doc_markdown` reads a CamelCase word in prose as an identifier someone forgot to
+# backtick, and it carries a default list of the ones that are really product names. `..` keeps
+# that list and adds the names this repository writes that are not on it. Backticking them
+# instead would render a company as code.
+doc-valid-idents = ["LinkedIn", "OpenGraph", ".."]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -74,3 +74,6 @@ terrace-config = { workspace = true, features = ["testing"] }
 # dependency, so it stays where `terrace-config/schema` already puts it — in
 # the generator — and out of every binary this workspace ships.
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -20,7 +20,7 @@
 //! - the `update-repos` builder, [`BuilderConfig`] ([`GithubConfig`]).
 //!
 //! The aggregates live here rather than in the binaries so the generated configuration reference
-//! can describe the types those binaries actually load; see [`aggregates`].
+//! can describe the types those binaries actually load.
 //!
 //! # Why the loader half only
 //!

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -15,3 +15,6 @@ schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/data/src/lib.rs
+++ b/crates/data/src/lib.rs
@@ -4,6 +4,9 @@
 //! [`I18N_DE`]); this crate only holds facts (names, dates, URLs, confidence
 //! values) and the schemas for the build-time generated documents — `repos.json`
 //! and the third-party licence inventory in [`licenses`].
+//!
+//! Nothing here is read at run time. Every item is a compile-time constant or a schema for a
+//! document produced during the image build, so changing any of it is a redeploy.
 
 use std::collections::BTreeMap;
 
@@ -42,6 +45,12 @@ pub const OG_IMAGE_FILE: &str = "og-image.png";
 pub const OG_IMAGE_SIZE: (u32, u32) = (1200, 630);
 
 /// The resume file name for a language code, falling back to English.
+///
+/// ```
+/// # use portfolio_data::resume_file;
+/// assert_eq!(resume_file("de"), "Tim-Schönle-Lebenslauf.pdf");
+/// assert_eq!(resume_file("fr"), resume_file("en"));
+/// ```
 pub fn resume_file(lang: &str) -> &'static str {
     RESUME_FILES
         .iter()
@@ -80,23 +89,40 @@ impl ResumeFingerprints {
 
 // ---------- Site configuration ----------
 
+/// A processor the privacy policy has to name.
+///
+/// Nothing renders one. The GDPR wants these facts in the reader's own language, so the prose
+/// that states them is in the translation files; this is the copy that prose is checked against.
 pub struct ExternalService {
+    /// The legal entity, spelled as it appears in its own imprint.
     pub name: &'static str,
+    /// Registered seat, in the format that country writes addresses in.
     pub address: &'static str,
+    /// The processor's own privacy policy, which the prose links to.
     pub policy_url: &'static str,
 }
 
+/// What the imprint and privacy pages are obliged to state.
+///
+/// Five of these reach a rendered page. The rest is duplicated inside the translated prose for
+/// the reason [`ExternalService`] gives, and is kept here so there is one place to correct when
+/// a provider moves or a retention period changes.
 pub struct Legal {
     /// Postal address used in the imprint and as GDPR controller address.
     pub address_lines: &'static [&'static str],
+    /// VAT identification number. German law obliges the imprint to show it.
     pub vat_id: &'static str,
     /// Second contact channel required by the imprint service.
     pub second_contact_url: &'static str,
+    /// Who runs the machine the site is served from.
     pub hosting: ExternalService,
+    /// Who runs the edge the site is delivered through.
     pub cloudflare: ExternalService,
+    /// How long access logs are kept before deletion.
     pub log_retention_days: u32,
-    /// ISO dates shown as "last updated" on the legal pages.
+    /// ISO date shown as "last updated" on the imprint page.
     pub imprint_last_change: &'static str,
+    /// ISO date shown as "last updated" on the privacy page.
     pub privacy_last_change: &'static str,
     /// Supervisory authority for data-protection complaints.
     pub authority_url: &'static str,
@@ -104,31 +130,53 @@ pub struct Legal {
     pub odr_url: &'static str,
 }
 
+/// Who the site is about, and every address that identifies them.
+///
+/// One value exists, [`CONFIG`]. Everything that names the person behind the site reads it: the
+/// document head, the resume PDF, the social card and the profile API.
 pub struct Config {
+    /// Name as it is set in print: the resume header, the social card, `og:site_name`.
     pub full_name: &'static str,
+    /// Given name alone, which is what the profile API's `name` carries.
     pub name: &'static str,
+    /// Full document title, `"{full_name} — {job_title}"`, used verbatim for `og:title`.
     pub title: &'static str,
     /// Role on its own, e.g. for schema.org `jobTitle` (the full document
     /// `title` is `"{full_name} — {job_title}"`).
     pub job_title: &'static str,
     /// Contact country exposed by the profile API and structured metadata.
     pub location: &'static str,
+    /// Published contact address, on the contact card and in the profile API.
     pub email: &'static str,
+    /// Canonical origin, with a scheme and no trailing slash. Every absolute URL the site emits
+    /// is built by appending a path to it.
     pub url: &'static str,
+    /// GitHub profile page. Contains [`github_username`](Self::github_username), which a test
+    /// asserts, because the two are rendered as one link.
     pub github: &'static str,
+    /// The account `update-repos` lists repositories for unless `github.username` names another.
     pub github_username: &'static str,
+    /// LinkedIn profile page, linked from the imprint and from the resume sidebar.
     pub linkedin: &'static str,
+    /// This repository, which the footer colophon links to.
     pub repository: &'static str,
+    /// The sentence that becomes `meta description`, `og:description` and the social card's last
+    /// line. Written to survive being cut at about 155 characters, which is where search results
+    /// truncate it.
     pub description: &'static str,
+    /// `meta keywords`, joined with `, `.
     pub keywords: &'static [&'static str],
+    /// Repositories pinned to the front of the projects section, matched case-insensitively.
     pub featured_repos: &'static [&'static str],
     /// Repositories that must never appear in `repos.json`, regardless of their
     /// activity. Matched case-insensitively by name when listing all of the
     /// user's repositories in `update-repos`.
     pub blacklisted_repos: &'static [&'static str],
+    /// The imprint and privacy facts.
     pub legal: Legal,
 }
 
+/// The site's own identity. No configuration key reaches any of it: changing one is a redeploy.
 pub const CONFIG: Config = Config {
     full_name: "Tim Schönle",
     name: "Tim",
@@ -193,11 +241,19 @@ pub const CONFIG: Config = Config {
 /// Skills below this confidence are hidden from the matrix and the resume.
 pub const MIN_CONFIDENCE: f32 = 0.6;
 
+/// A region of the tech radar, which is also a group of the skill matrix.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Quadrant {
+    /// Programming languages, and the markup and configuration formats filed with them
+    /// (`Markdown`, `TOML`, `Dockerfile`).
     Languages,
+    /// Libraries and frameworks. A datastore's client library is filed here and the datastore
+    /// itself under [`Infra`](Self::Infra): `sqlx` and `Prisma` against `PostgreSQL`.
     Frameworks,
+    /// Build, test and repository tooling. The one quadrant the profile API withholds; see
+    /// [`profile::ProfileSkills`].
     Build,
+    /// Runtimes, datastores and the deployment machinery around them.
     Infra,
 }
 
@@ -222,6 +278,7 @@ impl Quadrant {
         }
     }
 
+    /// Every quadrant, in the order the radar draws them.
     pub fn all() -> [Quadrant; 4] {
         [
             Quadrant::Languages,
@@ -232,9 +289,12 @@ impl Quadrant {
     }
 }
 
+/// One entry of the skill inventory.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Skill {
+    /// Shown as written, in both languages. A tool's name is not translated.
     pub name: &'static str,
+    /// Which radar region it is plotted in, and which matrix group it is listed under.
     pub quadrant: Quadrant,
     /// 0.0..=1.0, mirrored from the original portfolio's skills data.
     pub confidence: f32,
@@ -243,7 +303,20 @@ pub struct Skill {
 }
 
 impl Skill {
-    /// Proficiency level 1..=5 derived from confidence.
+    /// Confidence scaled by five and rounded to the nearest integer.
+    ///
+    /// Clamped at both ends, so a skill nobody would list still comes back as a 1 rather than a
+    /// 0 the star row would render as nothing.
+    ///
+    /// ```
+    /// # use portfolio_data::{Quadrant, Skill};
+    /// # fn skill(confidence: f32) -> Skill {
+    /// #     Skill { name: "x", quadrant: Quadrant::Languages, confidence, radar_only: false }
+    /// # }
+    /// assert_eq!(skill(0.95).level(), 5);
+    /// assert_eq!(skill(0.70).level(), 4);
+    /// assert_eq!(skill(0.05).level(), 1);
+    /// ```
     pub fn level(&self) -> u8 {
         ((self.confidence * 5.0).round() as u8).clamp(1, 5)
     }
@@ -419,9 +492,15 @@ pub fn matrix_skills() -> Vec<Skill> {
 
 // ---------- Experience & education ----------
 
+/// A month on the experience and education timelines.
+///
+/// Deliberately no day. Every date this site renders is `Mon YYYY` or `YYYY`, so a start day
+/// would be a fact nobody publishes and nothing corrects.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct YearMonth {
+    /// Four-digit calendar year.
     pub year: u16,
+    /// `1..=12`. [`format_period`] indexes the localized month names with it.
     pub month: u8,
 }
 
@@ -429,13 +508,18 @@ const fn ym(year: u16, month: u8) -> YearMonth {
     YearMonth { year, month }
 }
 
+/// One role in the work history.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Experience {
     /// Stable id used as translation key segment (`experience.entries.<id>`).
     /// The localized role, organisation and bullets live in the i18n files.
     pub id: &'static str,
+    /// Where the role is worked from, e.g. `Remote`. Not localized.
     pub location: &'static str,
+    /// First month of the role.
     pub start: YearMonth,
+    /// Last month, or `None` while the role is ongoing. Ongoing roles sort ahead of every ended
+    /// one in [`experiences_sorted`], however recently the ended one started.
     pub end: Option<YearMonth>,
     /// Number of localized bullets (`…bullets.b1` ..= `…bullets.b<n>`).
     pub bullet_count: u8,
@@ -444,13 +528,15 @@ pub struct Experience {
     /// bullet via [`bullet_count`](Self::bullet_count). Used to drop a redundant
     /// third bullet from the two oldest roles on the resume.
     pub resume_bullet_cap: Option<u8>,
+    /// The chip run under the entry, in the order given.
     pub tech: &'static [&'static str],
 }
 
-/// Raw work-history entries. The declaration order here is *not* significant:
-/// the site and resume never read this slice directly but go through
-/// [`experiences_sorted`], which derives the canonical order. Localized
-/// roles/bullets live in the i18n files.
+/// Raw work-history entries, in no meaningful order.
+///
+/// The site and the resume never read this slice directly. Both go through
+/// [`experiences_sorted`], which derives the rendering order from the dates, so an entry appended
+/// here lands wherever its dates put it. Localized roles and bullets live in the i18n files.
 pub const EXPERIENCE: &[Experience] = &[
     Experience {
         id: "sixtwenty",
@@ -506,11 +592,11 @@ pub const EXPERIENCE: &[Experience] = &[
     },
 ];
 
-/// Work history in the canonical order the site and resume render: ongoing
-/// roles first (no end date), then the rest in reverse-chronological order by
-/// start date, with the most recent end date breaking equal-start ties. The
-/// order is derived entirely from the dates, so an ongoing role can outrank an
-/// ended one that started later.
+/// Work history in the order the site and the resume render it.
+///
+/// Ongoing roles first, then the rest by descending start date, with the most recent end date
+/// breaking equal starts. All of that comes from the dates, so an ongoing role outranks an ended
+/// one that started later.
 pub fn experiences_sorted() -> Vec<&'static Experience> {
     let mut out: Vec<&'static Experience> = EXPERIENCE.iter().collect();
     out.sort_by(|a, b| {
@@ -529,11 +615,14 @@ pub fn experiences_sorted() -> Vec<&'static Experience> {
     out
 }
 
+/// One entry of the education history. Degree and institution are localized.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Education {
     /// Stable id used as translation key segment (`resume.education.<id>`).
     pub id: &'static str,
+    /// First month of the programme.
     pub start: YearMonth,
+    /// Last month, or `None` while it is ongoing.
     pub end: Option<YearMonth>,
 }
 
@@ -551,10 +640,28 @@ pub const EDUCATION: &[Education] = &[
     },
 ];
 
-/// Formats a date range like "Nov 2018 – Jan 2023" from localized month names.
+/// A date range in the caller's language, e.g. `Nov 2018 – Jan 2023`.
 ///
-/// `months` must contain the twelve localized month abbreviations (Jan..Dec);
-/// `present` is the localized label for open-ended ranges.
+/// `months` are the twelve month abbreviations in order, and `present` is the label an
+/// open-ended range gets in place of an end date. A month above twelve, or a `months` shorter
+/// than twelve, renders the month blank; month `0` renders the first entry of `months`.
+///
+/// ```
+/// # use portfolio_data::{YearMonth, format_period};
+/// let months: Vec<String> = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+///                            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+///     .iter().map(|m| (*m).to_owned()).collect();
+/// let ym = |year, month| YearMonth { year, month };
+///
+/// assert_eq!(
+///     format_period(ym(2018, 11), Some(ym(2023, 1)), &months, "Present"),
+///     "Nov 2018 – Jan 2023",
+/// );
+/// assert_eq!(
+///     format_period(ym(2026, 3), None, &months, "Present"),
+///     "Mar 2026 – Present",
+/// );
+/// ```
 pub fn format_period(
     start: YearMonth,
     end: Option<YearMonth>,
@@ -586,32 +693,57 @@ pub fn format_period_years(start: YearMonth, end: Option<YearMonth>, now: &str) 
 
 // ---------- repos.json schema ----------
 
+/// One repository, as `update-repos` read it out of the GitHub REST API.
+///
+/// This deserializes GitHub's own response, which is why the field names are GitHub's and why
+/// all but three default rather than failing the listing. The same type is then written to
+/// `repos.json` and read back by the web binary, so the projects section and the API response
+/// cannot describe different documents.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Repo {
+    /// Repository name without the owner, e.g. `Portfolio`.
     pub name: String,
+    /// `owner/name`.
     #[serde(default)]
     pub full_name: String,
+    /// GitHub's own description. `None` for a repository that declares none, and the card then
+    /// renders without a summary line.
     pub description: Option<String>,
+    /// The repository page the card links to.
     pub html_url: String,
+    /// GitHub's primary-language guess, coloured by [`lang_color`]. `None` for an empty
+    /// repository.
     #[serde(default)]
     pub language: Option<String>,
+    /// Stars when the listing was taken, not live.
     #[serde(default)]
     pub stargazers_count: u32,
+    /// Forks at that same moment.
     #[serde(default)]
     pub forks_count: u32,
+    /// RFC 3339 timestamp of the last push. `update-repos` drops anything older than a year.
     #[serde(default)]
     pub updated_at: String,
+    /// GitHub topics, rendered as chips.
     #[serde(default)]
     pub topics: Vec<String>,
+    /// Whether the repository is a fork. Carried but never filtered on, so a fork in a generated
+    /// listing is one that was meant to be there.
     #[serde(default)]
     pub fork: bool,
+    /// Whether GitHub has archived it. `false` for every repository an account listing produced,
+    /// since that is what the filtering removes; a repository named in `github.repos` is written
+    /// through unfiltered.
     #[serde(default)]
     pub archived: bool,
+    /// The site the repository declares, linked beside the source link.
     #[serde(default)]
     pub homepage: Option<String>,
 }
 
 impl Repo {
+    /// Whether [`CONFIG`] pins this repository to the front of the projects section. Matched
+    /// case-insensitively by name.
     pub fn is_featured(&self) -> bool {
         CONFIG
             .featured_repos
@@ -620,14 +752,23 @@ impl Repo {
     }
 }
 
+/// The generated `repos.json`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ReposFile {
+    /// RFC 3339 timestamp the listing was taken at. `update-repos` reads it back on the next
+    /// build to decide whether the file is fresh enough to skip the API call.
     pub generated_at: String,
+    /// The account the repositories were listed for.
     pub user: String,
+    /// The repositories. Most recently updated first when the account was listed, and in the
+    /// configured order when `github.repos` named them.
     pub repos: Vec<Repo>,
 }
 
-/// GitHub-style language color for a repo card.
+/// The colour GitHub paints a language in, for the dot on a repository card.
+///
+/// The values are linguist's, copied rather than fetched, so a card matches what a visitor sees
+/// on github.com. An unrecognised language gets a neutral grey rather than no dot.
 pub fn lang_color(lang: &str) -> &'static str {
     match lang {
         "Rust" => "#dea584",

--- a/crates/data/src/licenses.rs
+++ b/crates/data/src/licenses.rs
@@ -113,6 +113,7 @@ impl LicensesFile {
 /// One dependency and the licence texts it ships under: a row of the page.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DependencyLicenses<'a> {
+    /// The crate being attributed.
     pub dependency: &'a CrateLicense,
     /// Empty only if the generator found no licence file for it at all, which is
     /// worth showing as such rather than hiding the dependency.
@@ -147,16 +148,23 @@ pub struct LicenseText {
 }
 
 /// A crate named from a licence text's coverage list.
+///
+/// Name and version together, because a dependency graph can hold two versions of the same crate
+/// under two different copyright lines.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CrateRef {
+    /// Crate name as published.
     pub name: String,
+    /// The exact version cargo resolved.
     pub version: String,
 }
 
 /// One crate in the resolved dependency graph.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CrateLicense {
+    /// Crate name as published.
     pub name: String,
+    /// The exact version cargo resolved, which is what the page prints beside the name.
     pub version: String,
     /// The SPDX *expression* the crate declares, e.g. `MIT OR Apache-2.0` —
     /// what it offers, which is not always the single licence it was resolved

--- a/crates/data/src/profile.rs
+++ b/crates/data/src/profile.rs
@@ -1,12 +1,17 @@
-//! Public profile API model, mirroring the original `models/api.ts`.
+//! The document `/api/v1/profile` serves, and the schema that describes it.
 //!
-//! The document is assembled from [`crate::CONFIG`] and [`crate::SKILLS`] and
-//! serialized by the server's `/api/v1/profile` route. It is language-neutral
-//! and stable, so the server builds it once and caches it.
+//! Assembled from [`crate::CONFIG`] and [`crate::SKILLS`], language-neutral, and the same bytes
+//! on every request, which is why the server builds it once and caches it.
 //!
-//! The JSON Schema served at `/api/v1/profile/schema` is derived from these
-//! types via `schemars`; that derive is behind the `schema` feature so the
-//! WebAssembly frontend, which only reads the data, does not pull it in.
+//! The field names and the JSON shape are older than this crate. They were fixed by the Next.js
+//! site this one replaced, and the endpoint kept its contract across that rewrite, so a change
+//! to any `#[serde(rename)]`, to a field name, or to the `Build` omission in [`ProfileSkills`]
+//! is a breaking API change rather than a refactor. The published schema is what a consumer
+//! would notice it with.
+//!
+//! That schema, served at [`SCHEMA_PATH`], is derived from these types by `schemars` under the
+//! `schema` feature. The feature is off for the WebAssembly frontend, which only reads the data
+//! and would otherwise carry a schema generator into the bundle.
 
 use serde::Serialize;
 
@@ -15,14 +20,16 @@ use crate::{CONFIG, Quadrant, SKILLS, Skill};
 /// Path of the profile JSON Schema, relative to [`CONFIG`]`.url`.
 pub const SCHEMA_PATH: &str = "/api/v1/profile/schema";
 
-/// Where a skill is surfaced across the site. Mirrors `SKILL_RENDER_AREAS`
-/// from the original `types/skill.ts`.
+/// One of the places a skill is shown.
 #[derive(Serialize, Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum RenderArea {
+    /// The generated resume PDF, which lists the strongest matrix skills.
     Resume,
+    /// The skills section of the home page.
     Section,
+    /// The radar, which is the only area a `radar_only` skill reaches.
     TechRadar,
 }
 
@@ -48,62 +55,95 @@ impl Skill {
     }
 }
 
-/// A skill as exposed by the API. Mirrors `SkillWithConfidence`.
+/// A skill as the API publishes it.
+///
+/// [`crate::Skill`] minus the quadrant, which the grouping in [`ProfileSkills`] already carries,
+/// and minus `radar_only`, which [`Self::render_area`] states positively instead.
 #[derive(Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileSkill {
+    /// `0.0..=1.0`. Published unrounded and unfiltered, so a consumer can set its own floor
+    /// rather than inheriting [`crate::MIN_CONFIDENCE`].
     pub confidence: f32,
+    /// The tool's name, untranslated.
     pub name: &'static str,
+    /// Every area this skill appears in.
     pub render_area: Vec<RenderArea>,
 }
 
-/// Skills grouped by category. The `Build` quadrant is intentionally omitted:
-/// the API exposes only languages, frameworks and infrastructure.
+/// Skills grouped by quadrant, three of the four.
+///
+/// [`Quadrant::Build`] has no field here, and the omission is part of the published contract.
 #[derive(Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ProfileSkills {
+    /// Every [`Quadrant::Frameworks`] skill, in inventory order.
     pub frameworks: Vec<ProfileSkill>,
+    /// Every [`Quadrant::Infra`] skill, in inventory order.
     pub infrastructure: Vec<ProfileSkill>,
+    /// Every [`Quadrant::Languages`] skill, in inventory order.
     pub languages: Vec<ProfileSkill>,
 }
 
+/// Where else to find the person the profile describes.
 #[derive(Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileSocials {
+    /// GitHub profile URL.
     #[cfg_attr(feature = "schema", schemars(extend("format" = "uri")))]
     pub github: &'static str,
+    /// The account name on its own, so a consumer can build an API call without parsing
+    /// [`Self::github`].
     pub github_username: &'static str,
+    /// LinkedIn profile URL. Omitted from the JSON entirely when absent, rather than serialized
+    /// as `null`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schema", schemars(extend("format" = "uri")))]
     pub linkedin: Option<&'static str>,
 }
 
-/// The public profile document. Mirrors `profileApiSchema` (the `$schema`
-/// pointer is added separately, see [`ProfileWithSchema`]).
+/// The profile document itself, without the `$schema` pointer.
+///
+/// Declared alphabetically, which is the order `serde` emits them in, so reordering the fields
+/// reorders the response.
 #[derive(Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct Profile {
+    /// Public contact address.
     #[cfg_attr(feature = "schema", schemars(extend("format" = "email")))]
     pub email: &'static str,
+    /// Name in full.
     pub full_name: &'static str,
+    /// Country, not a city or an address.
     pub location: &'static str,
+    /// Given name alone.
     pub name: &'static str,
+    /// The published skill set.
     pub skills: ProfileSkills,
+    /// Profile links.
     pub socials: ProfileSocials,
+    /// The role on its own: [`crate::Config::job_title`], not [`crate::Config::title`].
     pub title: &'static str,
+    /// The site's canonical origin.
     #[cfg_attr(feature = "schema", schemars(extend("format" = "uri")))]
     pub website: &'static str,
 }
 
-/// A [`Profile`] with the `$schema` pointer appended last, as served by the
-/// profile route. Mirrors `ProfileApiWithSchemaResponse`.
+/// What the route actually sends: a [`Profile`] with its `$schema` pointer.
+///
+/// The pointer is appended rather than declared first, so it is the last key in the object. That
+/// is cosmetic for a parser and deliberate for a human reading the raw response, who wants the
+/// profile before the metadata about it.
 #[derive(Serialize)]
 pub struct ProfileWithSchema {
+    /// Flattened into the top-level object, so the wire format has no nesting here.
     #[serde(flatten)]
     pub profile: Profile,
+    /// Absolute URL of the schema this document validates against, built from
+    /// [`crate::Config::url`] and [`SCHEMA_PATH`].
     #[serde(rename = "$schema")]
     pub schema: String,
 }

--- a/justfile
+++ b/justfile
@@ -111,7 +111,7 @@ licenses:
 
 [doc('Format, lint and test — what a pull request is going to run anyway')]
 [group('check')]
-verify: fmt lint test
+verify: fmt lint docs test
 
 [group('check')]
 fmt:
@@ -120,6 +120,17 @@ fmt:
 [group('check')]
 lint:
     cargo clippy --all-features --all-targets -- -D warnings
+
+# `--workspace` because the workspace root is a package, so without it cargo builds the
+# release-please placeholder in `src/lib.rs` and nothing else. `RUSTDOCFLAGS` is where the
+# `[workspace.lints.rustdoc]` table is actually enforced: `cargo check` never runs those lints.
+
+[doc('Build the API documentation with the rustdoc lints denied')]
+[group('check')]
+docs:
+    RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps
+    RUSTDOCFLAGS='-D warnings' cargo doc -p web --no-default-features --features web --no-deps
+    cargo test --workspace --doc --all-features
 
 [group('check')]
 test:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
-// This is a place holder file to make the release please workaround work
+//! Nothing. The workspace root carries a `[package]` because release-please needs one manifest
+//! to own the version it bumps, and a package needs a target to be a package.
+//!
+//! Every line of this repository that does anything is in `crates/` or `apps/`.


### PR DESCRIPTION
The doc comment contract from TimSchoenle/actions, applied to this workspace, with the lint gate that keeps it true.

## What carries a comment now

Every crate root, every exported item, and the private items whose reason is not visible at the definition. That is 10 `//!` blocks and 31 `///` comments.

The roots are the design record, and each one says what `README.md` and `docs/METRICS.md` do not. `senec-core` gives the `/lala.cgi` request and response shape, and names the two things that deliberately live elsewhere. `senec-discovery` gives the single thing a caller has to know about the result: a key the web UI never mentions cannot be found, so the profile is one device's answer and not a specification. `senec-export` gives the accumulated kWh totals as the only state that outlives the process. Both binaries carry a failure posture, meaning what is fatal at startup, what a failed poll costs, and why `docker stop` waits out its grace period.

Two facts that were nowhere in the repository are now next to the code that depends on them. The digit in a value token's type prefix is the leading digit of its bit width, so `i8` is 8-bit, `i1` 16-bit, `i3` 32-bit and `u6` 64-bit. The persisted economics snapshot holds no timestamp on purpose, because carrying one across a restart would bill the whole outage at the last observed power.

## What was left alone, and why

Private helpers whose body says everything the name does not: `typed_tokens`, `normalize_path`, the six `extract_*` functions in discovery, `set_derived_economics_metrics`. `clippy::missing_docs_in_private_items` stays off for the reason the standard gives, which is that a lint cannot tell a six-line obvious helper from a constant that came out of a rate limit.

No paragraph of `README.md` or `docs/METRICS.md` is copied into a comment. Where a root would have restated one it points at it instead, so the collector root sends a reader to `docs/METRICS.md` for what a scrape can tell about a failed cycle rather than repeating it.

`#![doc = include_str!("../README.md")]` is not used. This README is rendered from a Handlebars template, so including it would put a badge row, an interpolated version string and a provenance banner on the front page of the API documentation.

No `#![cfg_attr(docsrs, ...)]` block was added. The workspace is `publish = false` and docs.rs never builds it, so the feature badges have no reader, and `doc_auto_cfg` was removed in Rust 1.92, which makes that attribute a build failure waiting for the first job that passes `--cfg docsrs`.

## The gate, in this pull request

`[workspace.lints.rust]`, `[workspace.lints.clippy]` and `[workspace.lints.rustdoc]` declare `missing_docs`, `clippy::pedantic` with the four documentation lints named again so the next reader can see they are deliberate, and `broken_intra_doc_links` denied rather than warned. Every member inherits them through `[lints] workspace = true`.

A `doc` job in `build.yaml` runs `cargo doc` and the doctests under `RUSTDOCFLAGS: -D warnings`. It has to be a job of its own, because the rustdoc lints run under rustdoc and nowhere else, so neither `cargo check` nor clippy can fail a broken intra-doc link. One pass covers every page, since no crate here declares a feature. It installs the same pinned `actions-rust-lang/setup-rust-toolchain` the shared `cargo-check`, `test` and `clippy` actions install, so the documentation is built by the rustc the rest of the workflow already agreed on rather than whatever `ubuntu-latest` ships that week.

`docker-build-test` now needs `check` and `doc`. A job in no `needs:` list is advisory, and an advisory documentation job goes red on `main` and stays there.

`decode_numeric_values` gains the one doctest in the workspace. Without it the doctest half of that job passes by finding nothing.

Turning `pedantic` on surfaced nine findings in code rather than comments. Seven are fixed in place, including `f64::from` over an as-cast, `map_or_else` over `map().unwrap_or_else()`, and a `BTreeSet` where a `BTreeMap` with unit values was standing in for one. Two are `#[expect]` with a reason on the line: the 2^53 ceiling on a 64-bit token, and the field names of the persisted snapshot, which are the JSON keys of the state file.

## Blocker

Which checks block a merge is set in branch protection on `main`, which this repository does not carry as code and this branch cannot change. `doc` now reaches the merge through `docker-build-test`, so it gates as long as `Docker Build and Test` is required. `clippy` and `test` are still standalone jobs with nothing downstream of them.

**Confirm that `Docker Build and Test` is a required status check on `main` when this merges,** or add `Doc` to the list directly. Neither is doable from a branch.

## Verification

Run against the branch head. All five passed:

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-features --all-targets -- -D warnings
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps
cargo test --doc --workspace --all-features
cargo test --workspace
```

12 unit tests and 1 doctest, no failures. Clippy was confirmed to be firing rather than reading a stale cache: removing the `#[expect(clippy::struct_field_names)]` on `GridEconomicsSnapshot` turns the run red on 1.97.1, so all four expectations in the diff are fulfilled and none of them trips `unfulfilled_lint_expectations`.

The `--workspace` flag is load-bearing on the doctest command. Without it cargo resolves the default package and exits with `no library targets found in package senec-v3-collector`, since the collector is a binary.

## The two checks from the standard

Opener check, budget zero:

```bash
rg -n --pcre2 '^\s*(///|\*|//!)\s*(This (function|method|struct|class|enum|trait|module|field)|Used to |Helper (for|that)|Responsible for|A utility|Note that|In other words|Under the hood|Simply |Basically )' \
  --glob '!target' --glob '!dist' --glob '!node_modules'
```

No matches.

Length distribution over the 31 `///` comments:

```
n=31 mean=4.7 median=3 stdev=4.5 max=15 one-line=39%
```

The house reference in the standard is median 2, mean 3.5, stdev 3.7, 41% one line. This lands above both floors the standard sets, which are a standard deviation of two and a one-line share of fifteen percent. Twelve of the 31 are a single line. The four longest are `query_strings`, `discover`, `PrometheusMetricsExporter::new` and `decode_numeric_values`, which are the four public functions with a chunking rule, a request count, a price model and an example to state.

## First review pass

A review of the first draft found six claims that were wrong or unreachable. Each is corrected here:

- `site_id` does not label `senec_scrape_up`, `senec_poll_ok` or `senec_poll_timestamp_seconds`. Those three are built with a bare `Opts::new` and carry no labels, which `docs/METRICS.md` already said and the comment contradicted.
- The economics state file is written at the end of every **successful** cycle. A cycle that fails returns at the `?` on `query_strings`, before `update_grid_economics` and its write.
- A `None` economics state path turns persistence off, so the totals start at zero on every start. Nothing said so, and both modes are exercised by the tests.
- `discover` cannot fail on a regex. Every regex in that module is a string literal, so the clause was the `?` operator showing through rather than a condition a test could trigger.
- `discover` makes two more requests than the count claimed: `/js/senec.min.js` itself, and `/`, which is added to the path set whether or not the JavaScript names it.
- `reqwest::Response::text()` sniffs the charset and replaces malformed sequences, so a non-text body decodes to garbage instead of an error. The only failure there is a read that does not finish.

Four crate roots also carried paragraphs the README or `docs/METRICS.md` already published, in one case a third copy of the same per-device rationale. Those are cut, and the pointers stay.

## Second review pass

Nine comment findings and one workflow finding, all minor or low. Every one is applied:

- `PrometheusMetricsExporter::new` no longer says an unreadable state file stops the process. It returns a `Result`; what the caller does with it is the caller's decision, and `# Errors` already names the condition.
- `render`'s `# Errors` named a failure nobody could act on and missed one. It now names both: an encoder that cannot write a gathered family, and output that is not UTF-8.
- The `senec-core` root dropped its module roll call, which rustdoc renders as the Modules table three lines below. In its place it says what does not belong there, which is the half the standard asks for and the draft omitted.
- The collector root dropped `Past that the process is meant to outlive the device it polls.` It stated intent, and the mechanism is in the sentence after it.
- The collector's failure posture gained the case it was missing. The metrics server is a spawned task, so a serve failure after a successful bind logs, ends that task, and leaves the poll loop running against a dead scrape endpoint.
- `senec_scrape_up` is set to 1 in `new` and again in `render`, and never cleared. `render` said it was set to 1 while rendering, which implied a scope the series does not have.
- The two sentences on `GridEconomicsSnapshot` explaining why the timestamp is not persisted moved from `///` to `//`. It is a private struct, so rustdoc never rendered them and no caller could act on them.
- `PrometheusMetricsExporter` stops after `A clone shares the registry and the accumulated totals.` What the collector binary does with a clone is not part of a library contract.
- `normalize_profile` deduplicates keys through a `BTreeSet`, so a profile listing the same key twice polls it once. The summary claimed only that blanks were dropped.
- The `doc` job ran on whatever rustc the runner image shipped and gated nothing. Both are fixed above.
