### PR TITLE
feat(web): group the licences page by notice, not by dependency

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -89,9 +89,10 @@ runs as `1001:1001` and needs nothing writable.
 - **The Content-Security-Policy is built per response.** The server hashes the inline scripts that
   document actually carries and reserves a nonce for the script Cloudflare injects at the edge, so
   `script-src` needs no `'unsafe-inline'`.
-- `/licenses` lists every crate the client and the server link, the licence it ships under, and the
-  verbatim text of every licence file found. cargo-about produces it during the image build, and an
-  unlisted licence fails that build.
+- `/licenses` reproduces the licence of every crate the client and the server link. The notices are
+  grouped by licence and each distinct text is reproduced once, naming the dependencies that ship
+  it, with a flat inventory beneath listing every dependency and the terms it offers. cargo-about
+  produces the data during the image build, and an unlisted licence fails that build.
 - The project list is fetched from the GitHub API at build time, with archived, blacklisted and
   year-stale repositories dropped, then embedded into the binary by `build.rs`.
 - Cmd+K opens a command palette with fuzzy search and keyboard navigation. The stack section is a

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ runs as `1001:1001` and needs nothing writable.
 - **The Content-Security-Policy is built per response.** The server hashes the inline scripts that
   document actually carries and reserves a nonce for the script Cloudflare injects at the edge, so
   `script-src` needs no `'unsafe-inline'`.
-- `/licenses` lists every crate the client and the server link, the licence it ships under, and the
-  verbatim text of every licence file found. cargo-about produces it during the image build, and an
-  unlisted licence fails that build.
+- `/licenses` reproduces the licence of every crate the client and the server link. The notices are
+  grouped by licence and each distinct text is reproduced once, naming the dependencies that ship
+  it, with a flat inventory beneath listing every dependency and the terms it offers. cargo-about
+  produces the data during the image build, and an unlisted licence fails that build.
 - The project list is fetched from the GitHub API at build time, with archived, blacklisted and
   year-stale repositories dropped, then embedded into the binary by `build.rs`.
 - Cmd+K opens a command palette with fuzzy search and keyboard navigation. The stack section is a

--- a/apps/web/about.hbs
+++ b/apps/web/about.hbs
@@ -12,17 +12,21 @@
 
   `--format json` carries the same data plus the entire `cargo metadata` record
   of every crate — dependency graphs, feature tables, target lists, manifest
-  paths — which is 3.8 MB of which the page reads about 8%. This template is that
+  paths — which is 3.8 MB of which the page reads about 6%. This template is that
   document with the fields the page needs and nothing else.
+
+  `overview` is deliberately not carried. It counts (licence file, crate) pairs
+  rather than crates — 19 for ISC over a graph holding four, because `ring`
+  vendors fifteen ISC notices of its own — so a summary built from it says
+  "19 dependencies" about four. `LicensesFile::notices` derives the same summary
+  from `texts` instead, where the number beside a licence and the sections
+  beneath it come out of one count.
 
   Handlebars renders `{{json x}}` as a JSON literal and cargo-about disables HTML
   escaping, so licence texts survive verbatim, quotes and angle brackets and all.
   Every newline below falls between JSON tokens, never inside a string.
 --}}
 {
-"summary":[
-{{#each overview}}{"id":{{json this.id}},"name":{{json this.name}},"crates":{{this.count}}}{{#unless @last}},{{/unless}}
-{{/each}}],
 "texts":[
 {{#each licenses}}{"id":{{json this.id}},"name":{{json this.name}},"text":{{json this.text}},"used_by":[{{#each this.used_by}}{"name":{{json this.crate.name}},"version":{{json this.crate.version}}}{{#unless @last}},{{/unless}}{{/each}}]}{{#unless @last}},{{/unless}}
 {{/each}}],

--- a/apps/web/assets/input.css
+++ b/apps/web/assets/input.css
@@ -619,6 +619,7 @@ button { font-family: inherit; background: none; border: none; color: inherit; c
    block at their original wrapping. */
 .licenses-page { max-width: 1040px; margin: 0 auto; padding: 60px var(--side-pad) 80px; }
 .licenses-intro { max-width: 68ch; margin: 20px 0 0; color: rgba(232, 236, 242, 0.85); line-height: 1.65; }
+.licenses-note { max-width: 68ch; margin: 14px 0 0; color: var(--muted); font-size: 14px; line-height: 1.65; }
 .licenses-unavailable { margin-top: 48px; color: var(--muted); }
 .licenses-block { margin-top: 56px; }
 .licenses-block > h2 { font-size: 20px; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 18px; }
@@ -636,57 +637,84 @@ button { font-family: inherit; background: none; border: none; color: inherit; c
 .license-chip-name { color: rgba(232, 236, 242, 0.85); }
 .license-chip-count { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11px; color: var(--muted); }
 
-.license-deps { border-top: 1px solid var(--line); }
+/* One block per licence, each holding the distinct notices reproduced under it.
+   The heading carries the coverage the summary chip above states, so a reader
+   who scrolled past the chips still knows how much of the graph this section
+   accounts for. */
+.license-group + .license-group { margin-top: 40px; }
+.license-group-head {
+  display: flex; align-items: baseline; justify-content: space-between; flex-wrap: wrap; gap: 8px 16px;
+  margin: 0 0 10px; padding-bottom: 8px; border-bottom: 1px solid var(--line);
+  font-size: 15px; font-weight: 600;
+}
+.license-group-count {
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11.5px;
+  font-weight: 400; color: var(--muted);
+}
 
-/* Each dependency is a disclosure row: the summary is the whole clickable
-   surface, so nothing inside it is a link — the repository anchor lives in the
-   body, where it cannot swallow the click that opens the row. */
-.license-dep { border-bottom: 1px solid var(--line); }
-.license-dep > summary {
-  display: grid; grid-template-columns: 14px minmax(0, 1fr) auto minmax(0, 1.2fr);
-  gap: 4px 16px; align-items: baseline;
+/* Each notice is a disclosure row whose summary is the list of dependencies
+   shipping it — collapsed, the section reads as an index of the graph; opened,
+   it is the licence file verbatim. */
+.license-notice { border-bottom: 1px solid var(--line); }
+.license-notice > summary {
+  display: grid; grid-template-columns: 14px minmax(0, 1fr) auto; gap: 4px 14px; align-items: baseline;
   padding: 10px 2px; cursor: pointer; list-style: none; font-size: 14px;
   transition: color 0.15s ease;
 }
-.license-dep > summary::-webkit-details-marker { display: none; }
-.license-dep > summary::before { content: "+"; color: var(--muted); }
-.license-dep[open] > summary::before { content: "−"; }
-.license-dep > summary:hover,
-.license-dep > summary:focus-visible { color: var(--accent); }
-.license-dep-name { overflow-wrap: anywhere; }
-.license-dep-version,
-.license-dep-spdx {
-  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11.5px; color: var(--muted);
+.license-notice > summary::-webkit-details-marker { display: none; }
+.license-notice > summary::before { content: "+"; color: var(--muted); }
+.license-notice[open] > summary::before { content: "−"; }
+.license-notice > summary:hover,
+.license-notice > summary:focus-visible { color: var(--accent); }
+/* The dependency names are the row's label, not a detail of it: the notice is
+   identified by what it covers, and a reader looking for one crate finds it
+   without opening 130 rows. */
+.license-notice-crates {
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 12px;
+  overflow-wrap: anywhere;
 }
-.license-dep-spdx { text-align: right; overflow-wrap: anywhere; }
-
-.license-dep-body { padding: 2px 0 22px 30px; display: flex; flex-direction: column; gap: 14px; }
-.license-dep-repo {
-  align-self: start;
+.license-notice-count {
   font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11.5px;
-  color: var(--muted); overflow-wrap: anywhere; transition: color 0.15s ease;
+  color: var(--muted); white-space: nowrap;
 }
-.license-dep-repo:hover { color: var(--accent); text-decoration: underline; }
 
-.license-text-head { display: flex; align-items: baseline; gap: 10px; margin: 0 0 8px; font-size: 13px; }
-.license-text-name { color: rgba(232, 236, 242, 0.9); }
-.license-text-id {
-  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11.5px; color: var(--muted);
-}
-.license-text-missing { margin: 0; color: var(--muted); font-size: 13px; }
-.license-text pre {
-  margin: 0; padding: 16px 18px; max-height: 60vh; overflow: auto;
+.license-notice > pre {
+  margin: 0 0 22px 28px; padding: 16px 18px; max-height: 60vh; overflow: auto;
   border: 1px solid var(--line); border-radius: 3px; background: var(--bg-card);
   font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11.5px; line-height: 1.6;
   color: rgba(232, 236, 242, 0.8); white-space: pre-wrap; overflow-wrap: anywhere;
 }
 
+/* The inventory: one flat row per dependency with the terms it offers. Not a
+   disclosure list — the text it resolved to is above, under the licence that
+   owns it, and duplicating it here is what made this page 738 KB. */
+.license-deps { border-top: 1px solid var(--line); }
+.license-dep {
+  display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1.2fr);
+  gap: 4px 16px; align-items: baseline;
+  padding: 10px 2px; border-bottom: 1px solid var(--line); font-size: 14px;
+}
+.license-dep-name { overflow-wrap: anywhere; }
+a.license-dep-name { color: inherit; transition: color 0.15s ease; }
+a.license-dep-name:hover,
+a.license-dep-name:focus-visible { color: var(--accent); text-decoration: underline; }
+.license-dep-version,
+.license-dep-spdx,
+.license-dep-note {
+  font-family: "JetBrains Mono", ui-monospace, monospace; font-size: 11.5px; color: var(--muted);
+}
+.license-dep-spdx { text-align: right; overflow-wrap: anywhere; }
+/* The rare crate cargo-about found no licence file for. A column of its own
+   would be empty on every row but that one, so it wraps under the row it
+   annotates instead. */
+.license-dep-note { grid-column: 1 / -1; font-style: italic; }
+
 @media (max-width: 720px) {
   /* The SPDX expression drops to its own full-width row rather than being
      crushed into a third column that wraps mid-identifier. */
-  .license-dep > summary { grid-template-columns: 14px minmax(0, 1fr) auto; }
-  .license-dep-spdx { grid-column: 2 / -1; text-align: left; }
-  .license-dep-body { padding-left: 0; }
+  .license-dep { grid-template-columns: minmax(0, 1fr) auto; }
+  .license-dep-spdx { grid-column: 1 / -1; text-align: left; }
+  .license-notice > pre { margin-left: 0; }
 }
 
 /* 404 */

--- a/apps/web/build.rs
+++ b/apps/web/build.rs
@@ -22,7 +22,7 @@ use portfolio_data::{OG_IMAGE_FILE, RESUME_FILES};
 
 const EMPTY_MANIFEST: &str = r#"{"algorithm":"","generated_at":"","files":{}}"#;
 const EMPTY_REPOS: &str = r#"{"generated_at":"","user":"","repos":[]}"#;
-const EMPTY_LICENSES: &str = r#"{"summary":[],"texts":[],"crates":[]}"#;
+const EMPTY_LICENSES: &str = r#"{"texts":[],"crates":[]}"#;
 
 fn embed(source: &Path, out_dir: &str, name: &str, default: &str) {
     let dest = Path::new(out_dir).join(name);

--- a/apps/web/src/pages/licenses.rs
+++ b/apps/web/src/pages/licenses.rs
@@ -5,10 +5,19 @@
 //! the same fact. Nothing here is fetched at runtime and nothing is
 //! hand-maintained: adding a dependency changes this page on the next build.
 //!
-//! Two views: which licences are involved, then every dependency — each one
-//! expanding to the licence text it ships under. The texts are not a section of
-//! their own, because that section could only have listed the same dependency
-//! names a second time to say which text belonged to which.
+//! Three views, in the order the question is usually asked: which licences are
+//! involved, then the notices themselves, then every dependency with the terms
+//! it offers.
+//!
+//! **The notices are grouped by licence, not by dependency.** The first version
+//! of this page gave each dependency a row and reproduced its licence texts
+//! inside it, which served the same MIT paragraph once per crate carrying it —
+//! 499 KB of licence text for 215 KB of distinct notices, in a 738 KB document.
+//! A notice is reproduced once here and names the dependencies it covers, which
+//! is both smaller and the shape the licences themselves ask for.
+//! [`LicensesFile::notices`] does the grouping and holds the tests for it.
+
+use std::collections::BTreeSet;
 
 use dioxus::prelude::*;
 use portfolio_data::{CONFIG, licenses::LicensesFile};
@@ -38,6 +47,7 @@ pub fn Licenses() -> Element {
             }
             h1 { class: "legal-title", "{title}" }
             p { class: "licenses-intro", {t("licenses.intro")} }
+            p { class: "licenses-note", {t("licenses.note")} }
 
             if let Some(file) = load_licenses() {
                 Inventory { file }
@@ -48,20 +58,44 @@ pub fn Licenses() -> Element {
     }
 }
 
-/// The two views over a present inventory.
+/// The three views over a present inventory.
 ///
 /// A separate component so the page above reads as one decision — there is an
 /// inventory or there is not — and so everything below can take the document as
 /// a plain `&'static` borrow rather than an `Option` each block has to unwrap.
+///
+/// Everything under it is plain markup rather than further components on
+/// purpose. A `LicenseNotices` prop would be compared for equality on every
+/// re-render — a language switch is one — and that comparison is a memcmp over
+/// the 215 KB of licence text the props would carry.
 #[component]
 fn Inventory(file: &'static LicensesFile) -> Element {
     let i18n = use_i18n().i18n;
     let t = move |k: &str| i18n.read().t(k);
 
-    // The join, done once: each dependency with the licence texts naming it.
-    let dependencies = file.dependencies();
+    // Both groupings, once per render rather than once per section.
+    let licences = file.notices();
+    let dependencies: Vec<_> = file.third_party().collect();
 
-    let unit = t("licenses.dependencyUnit");
+    // The dependencies some notice names. A crate outside it is one cargo-about
+    // found no licence file for — rare, and worth saying so on its row rather
+    // than leaving a reader to conclude the page simply forgot it.
+    let attributed: BTreeSet<(&str, &str)> = licences
+        .iter()
+        .flat_map(|l| l.notices.iter())
+        .flat_map(|n| n.crates.iter())
+        .map(|c| (c.name.as_str(), c.version.as_str()))
+        .collect();
+
+    let unit = move |count: usize, singular: &str, plural: &str| {
+        format!("{count} {}", t(if count == 1 { singular } else { plural }))
+    };
+    let dependency_unit =
+        move |count: usize| unit(count, "licenses.dependencyOne", "licenses.dependencyMany");
+    let notice_unit = move |count: usize| unit(count, "licenses.noticeOne", "licenses.noticeMany");
+
+    let notice_total: usize = licences.iter().map(|l| l.notices.len()).sum();
+    let notices_heading = format!("{} ({notice_total})", t("licenses.noticesHeading"));
     let dependencies_heading = format!(
         "{} ({})",
         t("licenses.dependenciesHeading"),
@@ -72,61 +106,89 @@ fn Inventory(file: &'static LicensesFile) -> Element {
         section { class: "licenses-block",
             h2 { {t("licenses.summaryHeading")} }
             ul { class: "license-summary",
-                {file.summary.iter().map(|l| rsx! {
-                    li { key: "{l.id}", class: "license-chip",
-                        span { class: "license-chip-id", "{l.id}" }
-                        span { class: "license-chip-name", "{l.name}" }
-                        span { class: "license-chip-count", "{l.crates} {unit}" }
+                {licences.iter().map(|licence| rsx! {
+                    li { key: "{licence.id}", class: "license-chip",
+                        span { class: "license-chip-id", "{licence.id}" }
+                        span { class: "license-chip-name", "{licence.name}" }
+                        span { class: "license-chip-count",
+                            {dependency_unit(licence.crates)}
+                            // Only when there is more than one: "1 licence text"
+                            // beside a licence invites the reader to look for a
+                            // distinction that is not there.
+                            if licence.notices.len() > 1 {
+                                " · "
+                                {notice_unit(licence.notices.len())}
+                            }
+                        }
                     }
                 })}
             }
         }
 
         section { class: "licenses-block",
-            h2 { "{dependencies_heading}" }
-            // One row per dependency, the whole row a disclosure control: the
-            // licence text belongs to the dependency that ships it, and a
-            // separate list of texts could only have repeated these names to say
-            // which text was whose.
+            h2 { "{notices_heading}" }
+            // One block per licence, each holding its distinct notices. A notice
+            // is a disclosure row whose summary names the dependencies shipping
+            // it, so the collapsed section reads as an index of the graph and
+            // only the licence file itself has to be opened.
             //
             // Collapsed, not deferred — `details` hides its contents, it does not
             // withhold them — so Ctrl+F and a crawler still reach every word of
             // every licence.
-            div { class: "license-deps",
-                {dependencies.iter().map(|row| {
-                    let dep = row.dependency;
-                    rsx! {
-                        details { key: "{dep.name} {dep.version}", class: "license-dep",
-                            summary {
-                                span { class: "license-dep-name", "{dep.name}" }
-                                span { class: "license-dep-version", "{dep.version}" }
-                                span { class: "license-dep-spdx", "{dep.license}" }
+            {licences.iter().map(|licence| rsx! {
+                section { key: "{licence.id}", class: "license-group",
+                    h3 { class: "license-group-head",
+                        span { class: "license-group-name", "{licence.name} ({licence.id})" }
+                        span { class: "license-group-count", {dependency_unit(licence.crates)} }
+                    }
+                    {licence.notices.iter().enumerate().map(|(i, notice)| {
+                        let covered = notice.crate_names().join(", ");
+                        rsx! {
+                            details { key: "{licence.id}-{i}", class: "license-notice",
+                                summary {
+                                    span { class: "license-notice-crates", "{covered}" }
+                                    span { class: "license-notice-count",
+                                        {dependency_unit(notice.crates.len())}
+                                    }
+                                }
+                                pre { "{notice.text}" }
                             }
-                            div { class: "license-dep-body",
-                                // Inside the body rather than in the summary: a
-                                // link there would swallow the click on the one
-                                // word a reader aims at to open the row.
-                                if let Some(url) = dep.repository.as_deref() {
-                                    a {
-                                        class: "license-dep-repo",
-                                        href: "{url}",
-                                        target: "_blank",
-                                        rel: "noopener noreferrer",
-                                        {url.trim_start_matches("https://").trim_start_matches("http://")}
-                                    }
+                        }
+                    })}
+                }
+            })}
+        }
+
+        section { class: "licenses-block",
+            h2 { "{dependencies_heading}" }
+            // A flat inventory, not a disclosure list: the terms a dependency
+            // *offers* are one line, and the text it was resolved under is above,
+            // under the licence that owns it. Reproducing it here again is what
+            // made this page 738 KB.
+            div { class: "license-deps",
+                {dependencies.iter().map(|dep| {
+                    let unattributed =
+                        !attributed.contains(&(dep.name.as_str(), dep.version.as_str()));
+                    rsx! {
+                        div { key: "{dep.name} {dep.version}", class: "license-dep",
+                            // The name is the repository link when the crate
+                            // declares one; a crate that declares none renders
+                            // unlinked rather than as a dead anchor.
+                            if let Some(url) = dep.repository.as_deref() {
+                                a {
+                                    class: "license-dep-name",
+                                    href: "{url}",
+                                    target: "_blank",
+                                    rel: "noopener noreferrer",
+                                    "{dep.name}"
                                 }
-                                {row.texts.iter().enumerate().map(|(i, l)| rsx! {
-                                    div { key: "{i}", class: "license-text",
-                                        p { class: "license-text-head",
-                                            span { class: "license-text-name", "{l.name}" }
-                                            span { class: "license-text-id", "{l.id}" }
-                                        }
-                                        pre { "{l.text}" }
-                                    }
-                                })}
-                                if row.texts.is_empty() {
-                                    p { class: "license-text-missing", {t("licenses.noText")} }
-                                }
+                            } else {
+                                span { class: "license-dep-name", "{dep.name}" }
+                            }
+                            span { class: "license-dep-version", "{dep.version}" }
+                            span { class: "license-dep-spdx", "{dep.license}" }
+                            if unattributed {
+                                span { class: "license-dep-note", {t("licenses.noText")} }
                             }
                         }
                     }

--- a/crates/data/i18n/de.json
+++ b/crates/data/i18n/de.json
@@ -192,10 +192,15 @@
   "licenses": {
     "title": "Lizenzen Dritter",
     "intro": "Diese Seite baut auf Open Source auf. Jede Abhängigkeit, die der Server und der WebAssembly-Client einbinden, ist unten aufgeführt — mit der Lizenz, unter der sie verteilt wird, und deren vollständigem Text.",
+    "note": "Eine Abhängigkeit, die mehrere Lizenzen zur Wahl stellt, erscheint unter einer davon – ausgewählt durch die Liste akzeptierter Lizenzen, aus der das Verzeichnis erzeugt wird. Ein Paket mit MIT OR Apache-2.0 steht also nur unter MIT und erlaubt darüber hinaus Bedingungen, die hier nicht abgedruckt sind. Gleiche Lizenztexte stehen genau einmal hier und nennen jede Abhängigkeit, die sie mitliefert; zwei Texte, die sich nur in der Copyright-Zeile unterscheiden, bleiben zwei – genau diese Zeile verlangt die Lizenz wiederzugeben.",
     "summaryHeading": "Verwendete Lizenzen",
+    "noticesHeading": "Lizenztexte",
     "dependenciesHeading": "Abhängigkeiten",
-    "dependencyUnit": "Abhängigkeiten",
-    "noText": "Für diese Abhängigkeit wurde keine Lizenzdatei gefunden; sie wird unter dem oben genannten Ausdruck verteilt.",
+    "dependencyOne": "Abhängigkeit",
+    "dependencyMany": "Abhängigkeiten",
+    "noticeOne": "Lizenztext",
+    "noticeMany": "Lizenztexte",
+    "noText": "keine Lizenzdatei gefunden",
     "unavailable": "Dieser Build enthält kein Lizenzverzeichnis."
   },
   "imprint": {

--- a/crates/data/i18n/en.json
+++ b/crates/data/i18n/en.json
@@ -180,10 +180,15 @@
   "licenses": {
     "title": "Third-Party Licenses",
     "intro": "This site is built on open source. Every dependency the server and the WebAssembly client link is listed below, together with the licence it is distributed under and the full text of that licence.",
+    "note": "A dependency offering a choice of terms is attributed under one of them, chosen once by the accepted list the inventory is generated from: a crate offered as MIT OR Apache-2.0 appears under MIT only, and permits terms not printed here. Identical notices are reproduced once and name every dependency shipping them; two that differ only in a copyright line stay two, because that line is the part the licence asks be reproduced.",
     "summaryHeading": "Licences in use",
+    "noticesHeading": "Licence texts",
     "dependenciesHeading": "Dependencies",
-    "dependencyUnit": "dependencies",
-    "noText": "No licence file was found for this dependency; it is distributed under the expression above.",
+    "dependencyOne": "dependency",
+    "dependencyMany": "dependencies",
+    "noticeOne": "licence text",
+    "noticeMany": "licence texts",
+    "noText": "no licence file found",
     "unavailable": "This build carries no licence inventory."
   },
   "imprint": {

--- a/crates/data/src/licenses.rs
+++ b/crates/data/src/licenses.rs
@@ -6,44 +6,42 @@
 //! template writes this shape, the build script copies it in unchanged, and the
 //! page deserialises it here.
 //!
+//! It also holds the two views the page renders — [`LicensesFile::notices`], the
+//! attribution proper, and [`LicensesFile::third_party`], the inventory beside
+//! it. Both are computed here rather than in the components so the shape the page
+//! renders is the shape the tests below pin.
+//!
 //! It holds no prose. Licence *texts* are reproduced verbatim as their authors
 //! wrote them — that is the point of the page — and every label around them
 //! comes from the translation files.
 //!
 //! [`cargo-about`]: https://github.com/EmbarkStudios/cargo-about
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-/// The generated licence inventory: one entry per licence in [`Self::summary`],
-/// one per distinct licence *file* in [`Self::texts`], one per dependency in
-/// [`Self::crates`].
+/// The generated licence inventory: one entry per distinct licence *file* in
+/// [`Self::texts`], one per dependency in [`Self::crates`].
 ///
 /// Stored normalised — a licence text appears once, however many dependencies
-/// ship it — and joined back into one row per dependency by
-/// [`Self::dependencies`], which is the shape the page renders. Keeping the
-/// document normalised is what holds it to 340 KB in the binary: the same data
-/// denormalised, with each shared Apache text repeated under every crate using
-/// it, is half again as large.
+/// ship it — and regrouped by licence for rendering by [`Self::notices`].
+/// Keeping the document normalised is what holds it to a third of a megabyte in
+/// the binary: the same data denormalised, with each shared Apache text repeated
+/// under every crate using it, is half again as large.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct LicensesFile {
-    /// Every licence the dependency set resolves to, with the number of crates
-    /// under it. Ordered by cargo-about, most-used first.
-    #[serde(default)]
-    pub summary: Vec<LicenseSummary>,
     /// Every distinct licence file found, each naming the crates it covers.
     ///
-    /// Distinct by text, not by identifier: two crates under MIT ship two files
-    /// that differ in their copyright line, and reproducing that line is what MIT
-    /// asks for. Hence 100-odd entries over a handful of identifiers.
-    ///
-    /// `used_by` is the join, not something the page prints — [`Self::dependencies`]
-    /// inverts it so each dependency carries its own texts.
+    /// Distinct by *file*, not by licence and not quite by text: two crates under
+    /// MIT ship two files that differ in their copyright line, and reproducing
+    /// that line is what MIT asks for. Hence 100-odd entries over a handful of
+    /// identifiers — and hence also several entries that are the same notice
+    /// wrapped differently, which [`Self::notices`] merges.
     #[serde(default)]
     pub texts: Vec<LicenseText>,
-    /// Every crate in the resolved graph, as cargo resolved it for the targets
-    /// in `about.toml` — including this repository's own, which
+    /// Every crate in the resolved dependency graph, as cargo resolved it for the
+    /// targets in `about.toml` — including this repository's own, which
     /// [`Self::third_party`] filters out.
     #[serde(default)]
     pub crates: Vec<CrateLicense>,
@@ -68,37 +66,103 @@ impl LicensesFile {
         self.crates.iter().filter(|c| c.source.is_some())
     }
 
-    /// Every third-party dependency with the licence texts that cover it, in the
-    /// document's own order.
+    /// The attribution, grouped the way it is read: one entry per licence, and
+    /// under it every *distinct* notice with the crates that ship it.
     ///
-    /// The inversion of [`LicenseText::used_by`], done once here rather than by
-    /// scanning every text for every dependency while rendering — that is 175
-    /// texts against 335 dependencies on each server render, for a join whose
-    /// answer never changes within a build.
+    /// **The merge is why this exists.** cargo-about reports one entry per licence
+    /// file it harvested, so the page's first shape — a row per dependency, each
+    /// reproducing its own texts — emitted 499 KB of licence text for 215 KB of
+    /// distinct notices, the same MIT paragraph 57 times over. Grouping by licence
+    /// and merging identical texts prints each notice once and lists the crates it
+    /// covers beneath it, which is also what the licences themselves ask for.
     ///
-    /// A dependency usually has exactly one text. It has several when it is
-    /// licensed `A AND B`, or when it vendors code under notices of its own:
-    /// `ring` carries eighteen, which are eighteen genuinely different copyright
-    /// notices rather than eighteen copies of one.
-    pub fn dependencies(&self) -> Vec<DependencyLicenses<'_>> {
-        let mut covered: BTreeMap<(&str, &str), Vec<&LicenseText>> = BTreeMap::new();
+    /// **The merge is on the text, not on the identifier.** An MIT file *is*
+    /// mostly its copyright line, and the 130 distinct MIT notices in this graph
+    /// name 130 different copyright holders; collapsing those to one would drop
+    /// exactly the part the licence requires be reproduced. Whitespace is folded
+    /// for the comparison only — two files differing by a line wrap are one
+    /// notice — and the first copy is reproduced verbatim, byte for byte.
+    ///
+    /// Ordering is total and derived from the data, so the page is stable across
+    /// builds that did not change the graph: licences by the number of crates they
+    /// cover, then by identifier; notices by the same, then by the crates they
+    /// name.
+    pub fn notices(&self) -> Vec<LicenseNotices<'_>> {
+        // A licence text naming a path dependency is one this repository wrote,
+        // and a page about third parties must not reproduce it as though someone
+        // else had — the same rule `third_party` applies to the inventory.
+        let attributable: BTreeSet<(&str, &str)> = self
+            .third_party()
+            .map(|c| (c.name.as_str(), c.version.as_str()))
+            .collect();
+
+        // (id, name) -> whitespace-folded text -> the notice. `BTreeMap` so the
+        // grouping order is a property of the data rather than of a hasher; the
+        // vectors below are sorted explicitly regardless.
+        let mut by_licence: BTreeMap<(&str, &str), BTreeMap<String, Notice<'_>>> = BTreeMap::new();
         for text in &self.texts {
-            for used in &text.used_by {
-                covered
-                    .entry((used.name.as_str(), used.version.as_str()))
-                    .or_default()
-                    .push(text);
+            let covered: Vec<&CrateRef> = text
+                .used_by
+                .iter()
+                .filter(|c| attributable.contains(&(c.name.as_str(), c.version.as_str())))
+                .collect();
+            if covered.is_empty() {
+                continue;
             }
+
+            by_licence
+                .entry((text.id.as_str(), text.name.as_str()))
+                .or_default()
+                .entry(whitespace_folded(&text.text))
+                .or_insert_with(|| Notice {
+                    text: text.text.as_str(),
+                    crates: Vec::new(),
+                })
+                .crates
+                .extend(covered);
         }
 
-        self.third_party()
-            .map(|dependency| DependencyLicenses {
-                texts: covered
-                    .remove(&(dependency.name.as_str(), dependency.version.as_str()))
-                    .unwrap_or_default(),
-                dependency,
+        let mut licences: Vec<LicenseNotices<'_>> = by_licence
+            .into_iter()
+            .map(|((id, name), merged)| {
+                let mut notices: Vec<Notice<'_>> = merged
+                    .into_values()
+                    .map(|mut notice| {
+                        // `&CrateRef` orders by name then version through the
+                        // derive, so a crate named by two files of one notice —
+                        // the same text under two paths in one crate — collapses.
+                        notice.crates.sort_unstable();
+                        notice.crates.dedup();
+                        notice
+                    })
+                    .collect();
+                notices.sort_by(|a, b| {
+                    b.crates
+                        .len()
+                        .cmp(&a.crates.len())
+                        .then_with(|| a.crate_names().cmp(&b.crate_names()))
+                });
+
+                LicenseNotices {
+                    id,
+                    name,
+                    // Distinct crates, not the sum over notices: a crate whose
+                    // notices differ per vendored file — `ring` carries eighteen —
+                    // is one crate under this licence, not eighteen. Counting the
+                    // sum is the bug the chips used to render, where "299
+                    // dependencies" was really 299 licence files.
+                    crates: notices
+                        .iter()
+                        .flat_map(|n| n.crates.iter().map(|c| (&c.name, &c.version)))
+                        .collect::<BTreeSet<_>>()
+                        .len(),
+                    notices,
+                }
             })
-            .collect()
+            .collect();
+
+        licences.sort_by(|a, b| b.crates.cmp(&a.crates).then_with(|| a.id.cmp(b.id)));
+        licences
     }
 
     /// `true` when there is nothing to attribute — a `cargo check` or a `cargo
@@ -110,26 +174,59 @@ impl LicensesFile {
     }
 }
 
-/// One dependency and the licence texts it ships under: a row of the page.
+/// One licence and every distinct notice reproduced under it: a section of the
+/// page.
 #[derive(Clone, Debug, PartialEq)]
-pub struct DependencyLicenses<'a> {
-    /// The crate being attributed.
-    pub dependency: &'a CrateLicense,
-    /// Empty only if the generator found no licence file for it at all, which is
-    /// worth showing as such rather than hiding the dependency.
-    pub texts: Vec<&'a LicenseText>,
+pub struct LicenseNotices<'a> {
+    /// SPDX short identifier, e.g. `MIT`.
+    pub id: &'a str,
+    /// Full name, e.g. `MIT License`.
+    pub name: &'a str,
+    /// Distinct crates covered by the notices below.
+    ///
+    /// Sums to more than the number of dependencies across all licences: a crate
+    /// licensed `A AND B` — `ring` is `Apache-2.0 AND ISC` — is covered by both
+    /// and counted by both.
+    pub crates: usize,
+    /// The distinct notices, most-used first. Never empty.
+    pub notices: Vec<Notice<'a>>,
 }
 
-/// One licence and how many crates resolve to it.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct LicenseSummary {
-    /// SPDX short identifier, e.g. `MIT`.
-    pub id: String,
-    /// Full name, e.g. `MIT License`.
-    pub name: String,
-    /// Crates resolving to this licence. Sums to more than the number of
-    /// dependencies: a crate licensed `A AND B` is counted by both.
-    pub crates: usize,
+/// One notice and the crates that ship it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Notice<'a> {
+    /// The licence file, verbatim — copyright line, wrapping and all. Rendered
+    /// preformatted; never reflowed, translated or summarised.
+    pub text: &'a str,
+    /// The crates this notice covers, by name then version. Never empty.
+    pub crates: Vec<&'a CrateRef>,
+}
+
+impl Notice<'_> {
+    /// The distinct crate names this notice covers, for ordering and for the
+    /// collapsed row's label.
+    ///
+    /// Names, not name-and-version, and deduplicated: a graph holding two
+    /// versions of one crate under one notice — `hashbrown` is here three times
+    /// — would otherwise label the row `hashbrown, hashbrown, hashbrown`. The
+    /// versions are not lost; they are in the inventory the page renders below,
+    /// and the count beside the label still counts every one of them.
+    pub fn crate_names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.crates.iter().map(|c| c.name.as_str()).collect();
+        // `crates` is sorted by name then version, so equal names are adjacent.
+        names.dedup();
+        names
+    }
+}
+
+/// Fold every run of whitespace to a single space, for comparison only.
+///
+/// Two licence files that differ solely in line wrapping or trailing whitespace
+/// are the same notice, and reproducing both would attribute the same copyright
+/// holder twice under two texts a reader cannot tell apart. Only the folded form
+/// is compared; the notice the page prints is the first file's bytes.
+fn whitespace_folded(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// One distinct licence text and the crates it covers.
@@ -139,10 +236,9 @@ pub struct LicenseText {
     pub id: String,
     /// Full name of that licence.
     pub name: String,
-    /// The licence file, verbatim — copyright line, wrapping and all. Rendered
-    /// preformatted; never reflowed, translated or summarised.
+    /// The licence file, verbatim.
     pub text: String,
-    /// The crates this exact text was found in.
+    /// The crates this exact file was found in.
     #[serde(default)]
     pub used_by: Vec<CrateRef>,
 }
@@ -151,7 +247,7 @@ pub struct LicenseText {
 ///
 /// Name and version together, because a dependency graph can hold two versions of the same crate
 /// under two different copyright lines.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct CrateRef {
     /// Crate name as published.
     pub name: String,
@@ -168,8 +264,8 @@ pub struct CrateLicense {
     pub version: String,
     /// The SPDX *expression* the crate declares, e.g. `MIT OR Apache-2.0` —
     /// what it offers, which is not always the single licence it was resolved
-    /// under. Both are shown: the offer here, the resolved text in
-    /// [`LicensesFile::texts`].
+    /// under. Both are shown: the offer in the inventory, the resolved text in
+    /// [`LicensesFile::notices`].
     pub license: String,
     /// Where cargo resolved the crate from: a registry index, a git remote, or
     /// nothing at all for a path dependency. What makes a crate third-party —
@@ -199,7 +295,7 @@ mod tests {
     #[test]
     fn the_empty_default_parses_and_reports_itself_empty() {
         let parsed: LicensesFile =
-            serde_json::from_str(r#"{"summary":[],"texts":[],"crates":[]}"#).expect("valid");
+            serde_json::from_str(r#"{"texts":[],"crates":[]}"#).expect("valid");
         assert!(parsed.is_empty());
         assert_eq!(parsed, LicensesFile::default());
     }
@@ -210,15 +306,13 @@ mod tests {
     #[test]
     fn optional_crate_fields_default_rather_than_fail() {
         let parsed: LicensesFile = serde_json::from_str(
-            r#"{"summary":[{"id":"MIT","name":"MIT License","crates":1}],
-                "texts":[{"id":"MIT","name":"MIT License","text":"Copyright (c) 2020 Someone"}],
+            r#"{"texts":[{"id":"MIT","name":"MIT License","text":"Copyright (c) 2020 Someone"}],
                 "crates":[{"name":"anyhow","version":"1.0.0","license":"MIT OR Apache-2.0",
                            "source":"registry+https://github.com/rust-lang/crates.io-index"}]}"#,
         )
         .expect("valid");
 
         assert!(!parsed.is_empty());
-        assert_eq!(parsed.summary[0].crates, 1);
         assert!(parsed.texts[0].used_by.is_empty());
         assert_eq!(parsed.crates[0].repository, None);
     }
@@ -229,7 +323,7 @@ mod tests {
     #[test]
     fn path_dependencies_are_not_third_party() {
         let parsed: LicensesFile = serde_json::from_str(
-            r#"{"summary":[],"texts":[],"crates":[
+            r#"{"texts":[],"crates":[
                 {"name":"web","version":"2.6.0","license":"Unknown","source":null},
                 {"name":"anyhow","version":"1.0.0","license":"MIT",
                  "source":"registry+https://github.com/rust-lang/crates.io-index"},
@@ -243,62 +337,270 @@ mod tests {
         assert!(!parsed.is_empty());
     }
 
-    /// The join the page reads: every dependency carries the texts naming it,
-    /// a shared text reaches every dependency that ships it, and a dependency
-    /// with several notices keeps all of them.
-    #[test]
-    fn dependencies_carry_the_texts_that_name_them() {
-        let parsed: LicensesFile = serde_json::from_str(
-            r#"{"summary":[],
-                "texts":[
-                  {"id":"MIT","name":"MIT License","text":"shared",
-                   "used_by":[{"name":"a","version":"1.0.0"},{"name":"b","version":"2.0.0"}]},
-                  {"id":"ISC","name":"ISC License","text":"vendored",
-                   "used_by":[{"name":"b","version":"2.0.0"}]}],
-                "crates":[
-                  {"name":"a","version":"1.0.0","license":"MIT","source":"registry+x"},
-                  {"name":"b","version":"2.0.0","license":"MIT AND ISC","source":"registry+x"},
-                  {"name":"c","version":"3.0.0","license":"MIT","source":"registry+x"},
-                  {"name":"web","version":"2.6.0","license":"Unknown"}]}"#,
-        )
-        .expect("valid");
-
-        let rows = parsed.dependencies();
-        let named: Vec<&str> = rows.iter().map(|r| r.dependency.name.as_str()).collect();
-        assert_eq!(
-            named,
-            ["a", "b", "c"],
-            "path dependencies stay off the page"
-        );
-
-        assert_eq!(rows[0].texts.len(), 1, "a shared text reaches each user");
-        assert_eq!(rows[0].texts[0].text, "shared");
-
-        let both: Vec<&str> = rows[1].texts.iter().map(|t| t.id.as_str()).collect();
-        assert_eq!(
-            both,
-            ["MIT", "ISC"],
-            "every notice is kept, in document order"
-        );
-
-        assert!(
-            rows[2].texts.is_empty(),
-            "a dependency no text names is still listed"
-        );
-    }
-
     /// An inventory holding nothing but this repository's own crates is as empty
     /// as no inventory at all — otherwise the page would render three headings
     /// over an empty list instead of saying there is nothing to show.
     #[test]
     fn an_inventory_of_only_path_dependencies_is_empty() {
         let parsed: LicensesFile = serde_json::from_str(
-            r#"{"summary":[],"texts":[],
+            r#"{"texts":[],
                 "crates":[{"name":"web","version":"2.6.0","license":"Unknown"}]}"#,
         )
         .expect("valid");
 
         assert!(parsed.is_empty());
+    }
+
+    /// Builds a document the way cargo-about reports one: one entry per licence
+    /// *file*, so the same licence recurs once per crate that carries it, and
+    /// every crate named is third-party.
+    fn document(entries: &[(&str, &str, &str, &[&str])]) -> LicensesFile {
+        let mut crates: BTreeSet<&str> = BTreeSet::new();
+        for (_, _, _, names) in entries {
+            crates.extend(names.iter().copied());
+        }
+
+        LicensesFile {
+            texts: entries
+                .iter()
+                .map(|(id, name, text, names)| LicenseText {
+                    id: (*id).to_owned(),
+                    name: (*name).to_owned(),
+                    text: (*text).to_owned(),
+                    used_by: names
+                        .iter()
+                        .map(|n| CrateRef {
+                            name: (*n).to_owned(),
+                            version: "1.0.0".to_owned(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+            crates: crates
+                .into_iter()
+                .map(|name| CrateLicense {
+                    name: name.to_owned(),
+                    version: "1.0.0".to_owned(),
+                    license: "MIT".to_owned(),
+                    source: Some("registry+x".to_owned()),
+                    repository: None,
+                })
+                .collect(),
+        }
+    }
+
+    /// The bug this view exists to fix. The page's first shape rendered a row per
+    /// dependency, each reproducing the licence texts covering it, so a notice
+    /// shared by 57 crates was served 57 times — 499 KB of licence text for
+    /// 215 KB of distinct notices, in a 738 KB document. A notice is reproduced
+    /// once, and every crate carrying it is still attributed.
+    #[test]
+    fn an_identical_notice_is_reproduced_once_however_many_crates_ship_it() {
+        const MIT: &str = "MIT License\n\nCopyright (c) 2020 A. Person\n";
+        let file = document(&[
+            ("MIT", "MIT License", MIT, &["alpha"]),
+            ("MIT", "MIT License", MIT, &["beta"]),
+            ("MIT", "MIT License", MIT, &["gamma"]),
+        ]);
+
+        let licences = file.notices();
+        assert_eq!(licences.len(), 1);
+        assert_eq!(licences[0].notices.len(), 1, "one text is not three");
+        assert_eq!(licences[0].crates, 3);
+        assert_eq!(
+            licences[0].notices[0].crate_names(),
+            ["alpha", "beta", "gamma"],
+            "merging must not cost a crate its attribution"
+        );
+    }
+
+    /// Two copies of one notice that differ only in how they were wrapped are one
+    /// notice. Without the fold they are two, and the page reproduces the same
+    /// copyright holder twice under texts a reader cannot tell apart.
+    #[test]
+    fn notices_differing_only_in_whitespace_are_merged_and_the_first_kept_verbatim() {
+        let file = document(&[
+            (
+                "MIT",
+                "MIT License",
+                "Copyright (c) 2020 A. Person\nMIT\n",
+                &["alpha"],
+            ),
+            (
+                "MIT",
+                "MIT License",
+                "Copyright (c) 2020    A. Person MIT",
+                &["beta"],
+            ),
+        ]);
+
+        let licences = file.notices();
+        assert_eq!(licences[0].notices.len(), 1);
+        assert_eq!(
+            licences[0].notices[0].text, "Copyright (c) 2020 A. Person\nMIT\n",
+            "the reproduced notice is the first file's bytes, not a folded form"
+        );
+    }
+
+    /// A copyright line is the part of an MIT notice the licence requires be
+    /// reproduced, so two notices under one identifier stay two.
+    #[test]
+    fn different_copyright_holders_under_one_identifier_stay_distinct() {
+        let file = document(&[
+            (
+                "MIT",
+                "MIT License",
+                "Copyright (c) 2020 A. Person",
+                &["alpha"],
+            ),
+            (
+                "MIT",
+                "MIT License",
+                "Copyright (c) 2021 B. Person",
+                &["beta"],
+            ),
+        ]);
+
+        let licences = file.notices();
+        assert_eq!(licences[0].notices.len(), 2);
+        assert_eq!(licences[0].crates, 2);
+    }
+
+    /// A crate shipping several notices — `ring` vendors eighteen — is one crate
+    /// under that licence, not eighteen. The chips used to render the sum, which
+    /// is why `ISC` claimed 19 dependencies over a graph holding four.
+    #[test]
+    fn a_crate_shipping_several_notices_is_counted_once() {
+        let file = document(&[
+            ("ISC", "ISC License", "notice one", &["ring"]),
+            ("ISC", "ISC License", "notice two", &["ring"]),
+            ("ISC", "ISC License", "notice three", &["untrusted"]),
+        ]);
+
+        let licences = file.notices();
+        assert_eq!(licences[0].notices.len(), 3);
+        assert_eq!(licences[0].crates, 2, "two crates, three notices");
+    }
+
+    /// The order the page renders in has to come out of the data, or two builds
+    /// of an unchanged graph produce two different pages: licences by coverage
+    /// then identifier, notices by coverage then by the crates they name.
+    #[test]
+    fn licences_and_notices_are_ordered_by_coverage() {
+        let file = document(&[
+            ("MIT", "MIT License", "mit-rare", &["solo"]),
+            (
+                "MIT",
+                "MIT License",
+                "mit-common",
+                &["alpha", "beta", "gamma"],
+            ),
+            ("ISC", "ISC License", "isc", &["delta", "epsilon"]),
+            ("Zlib", "zlib License", "zlib", &["zeta", "eta"]),
+        ]);
+
+        let licences = file.notices();
+        let ids: Vec<&str> = licences.iter().map(|l| l.id).collect();
+        assert_eq!(
+            ids,
+            ["MIT", "ISC", "Zlib"],
+            "MIT covers most; ISC and Zlib tie on four crates and break on the identifier"
+        );
+
+        let texts: Vec<&str> = licences[0].notices.iter().map(|n| n.text).collect();
+        assert_eq!(texts, ["mit-common", "mit-rare"]);
+    }
+
+    /// A licence file this repository wrote must not be reproduced as a third
+    /// party's, and a notice naming nothing else must not leave an empty section
+    /// behind — the same rule `third_party` applies to the inventory.
+    #[test]
+    fn a_notice_naming_only_path_dependencies_is_dropped() {
+        let file = LicensesFile {
+            texts: vec![
+                LicenseText {
+                    id: "LicenseRef-Proprietary".to_owned(),
+                    name: "Proprietary".to_owned(),
+                    text: "ours".to_owned(),
+                    used_by: vec![CrateRef {
+                        name: "web".to_owned(),
+                        version: "2.7.1".to_owned(),
+                    }],
+                },
+                LicenseText {
+                    id: "MIT".to_owned(),
+                    name: "MIT License".to_owned(),
+                    text: "theirs".to_owned(),
+                    used_by: vec![
+                        CrateRef {
+                            name: "web".to_owned(),
+                            version: "2.7.1".to_owned(),
+                        },
+                        CrateRef {
+                            name: "anyhow".to_owned(),
+                            version: "1.0.0".to_owned(),
+                        },
+                    ],
+                },
+            ],
+            crates: vec![
+                CrateLicense {
+                    name: "web".to_owned(),
+                    version: "2.7.1".to_owned(),
+                    license: "Unknown".to_owned(),
+                    source: None,
+                    repository: None,
+                },
+                CrateLicense {
+                    name: "anyhow".to_owned(),
+                    version: "1.0.0".to_owned(),
+                    license: "MIT".to_owned(),
+                    source: Some("registry+x".to_owned()),
+                    repository: None,
+                },
+            ],
+        };
+
+        let licences = file.notices();
+        let ids: Vec<&str> = licences.iter().map(|l| l.id).collect();
+        assert_eq!(ids, ["MIT"]);
+        assert_eq!(licences[0].notices[0].crate_names(), ["anyhow"]);
+    }
+
+    /// A graph can hold two versions of one crate under one notice, and the label
+    /// a collapsed row carries must not read `hashbrown, hashbrown, hashbrown`.
+    /// The count beside it still counts every version.
+    #[test]
+    fn a_notice_labels_a_crate_once_however_many_versions_it_covers() {
+        let file = LicensesFile {
+            texts: vec![LicenseText {
+                id: "MIT".to_owned(),
+                name: "MIT License".to_owned(),
+                text: "shared".to_owned(),
+                used_by: ["0.14.5", "0.15.5", "0.16.0"]
+                    .into_iter()
+                    .map(|version| CrateRef {
+                        name: "hashbrown".to_owned(),
+                        version: version.to_owned(),
+                    })
+                    .collect(),
+            }],
+            crates: ["0.14.5", "0.15.5", "0.16.0"]
+                .into_iter()
+                .map(|version| CrateLicense {
+                    name: "hashbrown".to_owned(),
+                    version: version.to_owned(),
+                    license: "MIT".to_owned(),
+                    source: Some("registry+x".to_owned()),
+                    repository: None,
+                })
+                .collect(),
+        };
+
+        let licences = file.notices();
+        assert_eq!(licences[0].notices[0].crate_names(), ["hashbrown"]);
+        assert_eq!(licences[0].notices[0].crates.len(), 3);
+        assert_eq!(licences[0].crates, 3);
     }
 
     /// A licence text is reproduced byte for byte; the round-trip is what proves
@@ -307,7 +609,6 @@ mod tests {
     fn licence_text_survives_a_round_trip_verbatim() {
         let text = "MIT License\n\nCopyright (c) 2020 A. Person <a@example.com>\n\n\"Software\"\n";
         let file = LicensesFile {
-            summary: Vec::new(),
             texts: vec![LicenseText {
                 id: "MIT".into(),
                 name: "MIT License".into(),


### PR DESCRIPTION
`/licenses` reproduced the licence texts inside each dependency's row, so a notice
shared by 57 crates was served 57 times. The document was 738 KB, of which 499 KB
was licence text over 215 KB of distinct notices, and the summary chips counted the
wrong thing.

## Grouped by notice

Notices are now grouped by licence, and each distinct text is reproduced once,
naming the dependencies that ship it. A flat inventory beneath lists every
dependency with the terms it offers and links its repository.

The merge is on the **text**, not the SPDX identifier, and whitespace is folded for
the comparison only:

- the 130 different MIT copyright lines stay 130 notices — that line is the part MIT
  asks be reproduced;
- two files differing only in a line wrap become one, and the notice printed is the
  first file's bytes, verbatim;
- a licence file naming only a path dependency is dropped, the same rule
  `third_party()` already applied to the inventory.

Ordering is derived from the data (licences by coverage then identifier, notices the
same), so two builds of an unchanged graph render the same page.

`cargo about` and `about.toml` are untouched — this is entirely about what is done
with the document they produce.

## The counts were wrong

The chips read `MIT — 299 dependencies`, `ISC — 19 dependencies`. Those came from
cargo-about's `overview`, which counts **(licence file, crate) pairs**, not crates.
The ISC graph holds four crates; `ring` alone vendors fifteen ISC notices of its own.

The summary is now derived from the notices, so the number beside a licence and the
sections beneath it come out of one count, and `overview` is no longer carried in
`about.hbs`. The unit is pluralised too — `1 dependency`, not `1 dependencies`.

| licence | before | after |
| --- | --- | --- |
| MIT | 299 dependencies | 295 dependencies · 130 licence texts |
| ISC | 19 dependencies | 4 dependencies · 19 licence texts |
| Apache-2.0 | 8 dependencies | 7 dependencies · 2 licence texts |
| BSL-1.0 | 1 dependencies | 1 dependency |

## Result

Same 335 dependencies, same 166 distinct notices, every crate still attributed —
738 KB → 431 KB.

## Also

- `LicensesFile::summary`/`LicenseSummary` and `dependencies()`/`DependencyLicenses`
  are gone, replaced by `notices()`; the tests move with them, including one pinning
  the duplication this fixes and one for `hashbrown, hashbrown, hashbrown` (a crate
  present at three versions under one notice is labelled once and counted three
  times).
- New i18n keys in `en.json`/`de.json` for the notices heading and the singular
  forms; `dependencyUnit` is gone.
- The README bullet is updated in `.github/templates/README.md.hbs`, not the
  rendered README.

## Verification

`cargo fmt --check`, `cargo test -p portfolio-data --all-features`,
`cargo test -p web --no-default-features --features server`, both `cargo clippy`
targets and the three `cargo doc`/doctest gates pass locally. Clippy reports one
more `must_use_candidate` than `main` does (22 vs 21) — the crate omits `#[must_use]`
throughout, and CI does not enforce that lint.

Rendered and checked in a real `dx serve` build at 1280px and 700px, in both
languages, with `cargo about` output from the current lockfile.
