### PR TITLE
feat(observability): add optional Sentry error reporting and request tracing

### DIFF
--- a/.github/templates/README.md.hbs
+++ b/.github/templates/README.md.hbs
@@ -190,10 +190,14 @@ keys, so a deployment needs no GitHub token. That is why there are two tables an
 
 {{{ builderConfigTable }}}
 
-`{{ keys.githubToken.path }}` is the only secret in the workspace, and it should arrive as a file
-rather than as an environment variable. `/proc/<pid>/environ`, a crash dump and `docker inspect` all
-carry the environment, and child processes inherit it. The Docker build mounts it as a BuildKit
-secret and hands `update-repos` the path.
+There are two secrets in the workspace, and each should arrive as a file rather than as an
+environment variable: `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry the
+environment, and child processes inherit it.
+
+`{{ keys.githubToken.path }}` is the builder's, and the Docker build already mounts it as a
+BuildKit secret and hands `update-repos` the path. `{{ keys.sentryDsn.path }}` is the server's, read
+only when error reporting is switched on — supply it as `{{ keys.sentryDsn.envFile }}=/path`, or as
+`{{ keys.sentryDsn.secretsFile }}` in a mounted `Secret` volume.
 
 `IP`, `PORT` and `RUST_LOG` sit outside this namespace deliberately. They are the Dioxus toolchain's
 contract with the binary, and it keeps reading them itself.
@@ -223,6 +227,22 @@ Standard with a read-only root filesystem, no privilege escalation, every capabi
 Incremental static regeneration is the one thing that wants a writable path. The image points the
 cache at `/tmp/isr` and bakes an empty one owned by the runtime user; where that path is not
 writable, every request is rendered fresh instead.
+
+### Error reporting
+
+Optional, off, and the only thing that would give the process an outbound connection. Set
+`{{ keys.sentryEnabled.path }}` with a DSN and the server installs a Sentry client, a panic hook, a
+`tracing` layer feeding it, and one transaction per request named by the matched route. Enabled
+without a usable DSN it refuses to boot, rather than reporting into a dashboard whose emptiness
+looks like a healthy site.
+
+Two keys decide how much goes with it. `sentry.traces_sample_rate` is `0`, so switching reporting on
+does not also switch performance data on. `sentry.send_default_pii` is `false` and should stay
+there: on, every event carries the client IP and the full request header set, `Cookie` included.
+
+While Sentry is off, `RUST_LOG` and the log format are the Dioxus toolchain's as before; while it is
+on, the server installs the subscriber itself — same variable, same default verbosity, plus the
+layer that reports.
 
 ## Compatibility
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,7 +77,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
 dependencies = [
- "object",
+ "object 0.39.1",
 ]
 
 [[package]]
@@ -172,6 +181,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +299,21 @@ name = "az"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "base16"
@@ -432,6 +479,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -552,6 +601,15 @@ dependencies = [
  "quick-xml 0.38.4",
  "serde",
  "serde_path_to_error",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -782,6 +840,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1038,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,7 +1139,7 @@ dependencies = [
  "dioxus-cli-config",
  "http",
  "infer",
- "jni",
+ "jni 0.21.1",
  "js-sys",
  "ndk",
  "ndk-context",
@@ -1229,7 +1307,7 @@ dependencies = [
  "js-sys",
  "mime",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.28",
  "rustversion",
  "send_wrapper",
  "serde",
@@ -1791,6 +1869,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1952,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2019,6 +2115,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glidesort"
@@ -2332,6 +2434,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -2821,6 +2929,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2984,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
 ]
 
 [[package]]
@@ -3084,7 +3232,7 @@ checksum = "1ed2af894a724a0b6e521f9efe84f98cfdc74a4de6828efef77ffd3b1679fd52"
 dependencies = [
  "const-serialize 0.7.2",
  "const-serialize 0.8.0-alpha.0",
- "jni",
+ "jni 0.21.1",
  "manganis-core",
  "manganis-macro",
  "ndk-context",
@@ -3260,6 +3408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3489,15 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
@@ -3344,6 +3510,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "palette"
@@ -3554,6 +3726,12 @@ checksum = "47945e80a49d08350e4a007ac4294c6498d23956c18ea5e6ff480dc93d31643c"
 dependencies = [
  "ttf-parser",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -3781,6 +3959,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -4051,6 +4230,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resume-generator"
 version = "2.9.0"
 dependencies = [
@@ -4137,6 +4355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4176,6 +4400,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4183,6 +4408,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4196,11 +4433,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4246,6 +4511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4287,6 +4561,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4299,6 +4596,114 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "sentry"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63207365db50cb817402f0ec8097d6dad3d644ef3fffd6ba30c75b3077e514da"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.4",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tower",
+ "sentry-tracing",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bcc2497c2327998146207b7600599ef7592233920f4d4e1d41ddeeba0e4210"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48759bc392fb5e3b36b4efcb485f51074c0ba8479711cd5c8cf79e86f9f75d41"
+dependencies = [
+ "rand 0.9.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5bd325059b70b21ca6e42b0f2409821272dddc1cf37923de37269af55389b5"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a685d22f672b1562ebeff3f2affceb5960595648cc936dae73da3e1d6a55fbd1"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tower"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a7519104172a9cdf1b6cdb3b77e91b7fce672ae90c0cf9947415882e3d07a9"
+dependencies = [
+ "axum",
+ "http",
+ "pin-project",
+ "sentry-core",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa7d8e0db4cccddbac01ddabd5344ad03b7c2f954b3ff850cecb1d9cf5d4758"
+dependencies = [
+ "bitflags",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fab146d15a30ab4897a95fd15d6a038b8d7fbf2661c5f8b13738ce8df7a095b7"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4496,6 +4901,22 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simplecss"
@@ -4764,7 +5185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -5224,6 +5645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -5237,18 +5659,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5947,8 +6383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vello_common"
@@ -6188,6 +6631,8 @@ dependencies = [
  "portfolio-config",
  "portfolio-data",
  "schemars",
+ "secrecy",
+ "sentry",
  "serde",
  "serde_json",
  "time",
@@ -6195,6 +6640,7 @@ dependencies = [
  "tower",
  "tower-http 0.7.0",
  "tracing",
+ "tracing-subscriber",
  "wasm-bindgen-futures",
  "web-sys",
 ]
@@ -6220,6 +6666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6235,6 +6690,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,6 +6713,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,64 @@ tower-http = { version = "0.7", features = [
     "compression-gzip",
 ] }
 tracing = "0.1"
+# Only reached when `sentry.enabled` is set: the Sentry layer has to be a layer *of* a
+# subscriber, and `dioxus_logger::initialize_default` builds one that cannot be extended after
+# the fact. So the server builds its own — same `RUST_LOG` contract, same formatter — and does it
+# before `dioxus::serve`, which then sees `tracing::dispatcher::has_been_set` and leaves it
+# alone. With Sentry off nothing here is constructed and the framework's subscriber stands.
+#
+# `env-filter` on top of the defaults, which are the `fmt` layer and its ANSI support. Already in
+# the lockfile through `dioxus-logger`, so this pulls nothing new into the graph or into
+# `THIRD-PARTY-NOTICES`.
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Error reporting and performance tracing for the SSR server, off unless an operator configures a
+# DSN (`apps/web/src/server/telemetry.rs`). One crate rather than three: `sentry` re-exports
+# `sentry-tracing` and `sentry-tower` under `sentry::integrations::*`, so the three versions
+# cannot drift.
+#
+# `default-features = false`, then back exactly what is used — and the transport is the part
+# worth reading twice.
+#
+# The default is `transport`, which is `reqwest + native-tls`: `native-tls` links OpenSSL, which
+# the `scratch` runtime image ships none of, so the failure would be at exec time in production
+# rather than at build time in CI. The obvious replacement is `reqwest` + `rustls`, and it is the
+# wrong one here: `sentry` pins reqwest 0.13 while the Dioxus fullstack stack builds 0.12, so it
+# would be a *second* async HTTP client — and reqwest 0.13's `rustls` feature means `aws-lc-rs`
+# (a cmake/C build, in an image cross-compiled to musl and built for bit-reproducibility) plus
+# `rustls-platform-verifier`, which looks for an OS trust store that `scratch` does not have.
+#
+# `ureq` is the transport that costs nothing. The crate is already in `Cargo.lock` — the
+# `update-repos` builder calls the GitHub API with it — and ureq's own `rustls` feature is `ring`
+# plus bundled `webpki-roots`, which is exactly the stack the runtime image is built for. It is a
+# blocking client, which is not a compromise: the SDK owns a background transport thread and
+# never sends on a request path.
+#
+# The defaults also include `logs`, `metrics` and `release-health` — three separate Sentry
+# products this site does not use, and each one an egress channel with no key in the
+# configuration reference describing it.
+#
+# What is on: `backtrace`/`debug-images` (stack traces and the module list that symbolicates
+# them), `panic` (the hook that turns a panic into an issue — a panic in a handler unwinds that
+# request's task and leaves the process serving, so without this it is invisible), and the two
+# integrations: `tracing` for the subscriber layer and `tower-axum-matched-path` for one
+# transaction per request named by the matched route rather than by the URI, which is what stops
+# `/api/repos/{name}` becoming one transaction name per repository.
+#
+# `contexts` is deliberately **off**, and it is a default. It adds an OS/host/runtime tag block by
+# pulling `os_info`, which carries a fifteen-crate `objc2` tree for its macOS support — into
+# `Cargo.lock`, and so into the `/licenses` page, for platforms no image here targets. What it
+# would report (kernel version, arch, rustc version) is a constant of the image, which the release
+# tag already names.
+sentry = { version = "0.49", default-features = false, features = [
+    "backtrace",
+    "debug-images",
+    "panic",
+    "ureq",
+    "rustls",
+    "tracing",
+    "tower-axum-matched-path",
+] }
 
 # The Content-Security-Policy the SSR server sends, built from the document it is
 # about to serve rather than from a hand-maintained list of hashes that drifts the

--- a/Dockerfile
+++ b/Dockerfile
@@ -315,6 +315,24 @@ WORKDIR /app
 #   PORTFOLIO_CSP__CLOUDFLARE__SCRIPT_NONCE=true  # false drops the edge nonce
 #   PORTFOLIO_CSP__CLOUDFLARE__TURNSTILE=false    # admit the Turnstile widget
 #   PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS=false
+#
+# Sentry error reporting is OFF, and nothing here turns it on: a DSN is an egress
+# destination for whatever a log line carries, so it is a per-deployment decision
+# rather than an image default. Nothing below is baked in for the same reason a
+# working default DSN would be a credential in a published Dockerfile. Switched
+# on without a usable DSN the server refuses to start, rather than reporting into
+# a dashboard whose emptiness reads as a healthy site.
+#
+# Mount the DSN rather than setting it: PORTFOLIO_SENTRY__DSN_FILE names a file
+# holding it, and `sentry__dsn` inside $PORTFOLIO_SECRETS_DIR is the same value
+# as a key in a mounted Secret. TRACES_SAMPLE_RATE stays 0 until performance data
+# is wanted; 0.1 is an ordinary production figure. SEND_DEFAULT_PII stays false —
+# on, every event carries the client IP and the full request header set, Cookie
+# included. See README.md § Error reporting.
+#   PORTFOLIO_SENTRY__ENABLED=false
+#   PORTFOLIO_SENTRY__DSN_FILE=/run/secrets/sentry_dsn
+#   PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE=0
+#   PORTFOLIO_SENTRY__SEND_DEFAULT_PII=false
 ENV PORT=8080 \
     IP=0.0.0.0 \
     RUST_LOG=info \

--- a/README.md
+++ b/README.md
@@ -195,6 +195,21 @@ environment spelling also accepts a `_FILE` suffix naming a file that holds the 
 | `csp.cloudflare.web_analytics` | `bool` | `PORTFOLIO_CSP__CLOUDFLARE__WEB_ANALYTICS` | `false` | — | Admit the Cloudflare Web Analytics beacon and the endpoint it reports to. |
 | `isr.cache_dir` | `PathBuf` | `PORTFOLIO_ISR__CACHE_DIR` | unset (ISR off; the image sets `/tmp/isr`) | — | Writable directory rendered HTML is cached into. Unset or empty disables ISR. |
 | `isr.ttl_secs` | `u64` | `PORTFOLIO_ISR__TTL_SECS` | `0` (permanent) | — | Revalidation interval in seconds. Zero means a permanent cache. |
+| `sentry.enabled` | `bool` | `PORTFOLIO_SENTRY__ENABLED` | `false` | — | Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing` layer and no HTTP middleware, so every other key here is inert and nothing leaves the process. |
+| `sentry.dsn` | `SecretString` | `PORTFOLIO_SENTRY__DSN` | unset | secret | Ingest URL, `https://<key>@<host>/<project>`. |
+| `sentry.environment` | `String` | `PORTFOLIO_SENTRY__ENVIRONMENT` | unset (`production` in a release build, `development` otherwise) | — | Environment tag on every event. |
+| `sentry.release` | `String` | `PORTFOLIO_SENTRY__RELEASE` | unset (`portfolio@` and the built version) | — | Release tag on every event. |
+| `sentry.server_name` | `String` | `PORTFOLIO_SENTRY__SERVER_NAME` | unset | — | Host tag on every event. |
+| `sentry.sample_rate` | `f32` | `PORTFOLIO_SENTRY__SAMPLE_RATE` | `1` | — | Fraction of captured events actually sent, `0.0`–`1.0`. |
+| `sentry.traces_sample_rate` | `f32` | `PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE` | `0` | — | Fraction of request traces recorded, `0.0`–`1.0`. |
+| `sentry.capture_level` | `SentryLevel`: `off` \| `error` \| `warn` \| `info` \| `debug` \| `trace` | `PORTFOLIO_SENTRY__CAPTURE_LEVEL` | `error` | — | Least severe `tracing` level reported as a Sentry **issue**. |
+| `sentry.breadcrumb_level` | `SentryLevel`: `off` \| `error` \| `warn` \| `info` \| `debug` \| `trace` | `PORTFOLIO_SENTRY__BREADCRUMB_LEVEL` | `info` | — | Least severe `tracing` level kept as a **breadcrumb**, the trail attached to the next issue. |
+| `sentry.max_breadcrumbs` | `usize` | `PORTFOLIO_SENTRY__MAX_BREADCRUMBS` | `100` | — | How many breadcrumbs one event carries. |
+| `sentry.attach_stacktraces` | `bool` | `PORTFOLIO_SENTRY__ATTACH_STACKTRACES` | `true` | — | Attach a stack trace to events that carry none of their own. |
+| `sentry.send_default_pii` | `bool` | `PORTFOLIO_SENTRY__SEND_DEFAULT_PII` | `false` | — | Send personally identifying data with every event: the client IP, the full request header set (`Cookie` included) and the resolved user. |
+| `sentry.http_transactions` | `bool` | `PORTFOLIO_SENTRY__HTTP_TRANSACTIONS` | `true` | — | Record one Sentry transaction per request, named by the *matched route* rather than by the URI — so `/api/repos/{name}` does not become one transaction name per repository. |
+| `sentry.span_attributes` | `bool` | `PORTFOLIO_SENTRY__SPAN_ATTRIBUTES` | `false` | — | Copy `tracing` span fields onto the Sentry span as attributes. |
+| `sentry.debug` | `bool` | `PORTFOLIO_SENTRY__DEBUG` | `false` | — | Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running. |
 
 ### Builder
 
@@ -207,10 +222,14 @@ keys, so a deployment needs no GitHub token. That is why there are two tables an
 | `github.token` | `SecretString` | `PORTFOLIO_GITHUB__TOKEN` | unset | secret | Bearer token lifting the GitHub API rate limit. |
 | `github.repos` | `Vec<String>` | `PORTFOLIO_GITHUB__REPOS` | `[]` (every active repository the user owns) | — | Explicit repository set, bypassing the "every active repository" listing and its filtering. |
 
-`github.token` is the only secret in the workspace, and it should arrive as a file
-rather than as an environment variable. `/proc/<pid>/environ`, a crash dump and `docker inspect` all
-carry the environment, and child processes inherit it. The Docker build mounts it as a BuildKit
-secret and hands `update-repos` the path.
+There are two secrets in the workspace, and each should arrive as a file rather than as an
+environment variable: `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry the
+environment, and child processes inherit it.
+
+`github.token` is the builder's, and the Docker build already mounts it as a
+BuildKit secret and hands `update-repos` the path. `sentry.dsn` is the server's, read
+only when error reporting is switched on — supply it as `PORTFOLIO_SENTRY__DSN_FILE=/path`, or as
+`sentry__dsn` in a mounted `Secret` volume.
 
 `IP`, `PORT` and `RUST_LOG` sit outside this namespace deliberately. They are the Dioxus toolchain's
 contract with the binary, and it keeps reading them itself.
@@ -240,6 +259,22 @@ Standard with a read-only root filesystem, no privilege escalation, every capabi
 Incremental static regeneration is the one thing that wants a writable path. The image points the
 cache at `/tmp/isr` and bakes an empty one owned by the runtime user; where that path is not
 writable, every request is rendered fresh instead.
+
+### Error reporting
+
+Optional, off, and the only thing that would give the process an outbound connection. Set
+`sentry.enabled` with a DSN and the server installs a Sentry client, a panic hook, a
+`tracing` layer feeding it, and one transaction per request named by the matched route. Enabled
+without a usable DSN it refuses to boot, rather than reporting into a dashboard whose emptiness
+looks like a healthy site.
+
+Two keys decide how much goes with it. `sentry.traces_sample_rate` is `0`, so switching reporting on
+does not also switch performance data on. `sentry.send_default_pii` is `false` and should stay
+there: on, every event carries the client IP and the full request header set, `Cookie` included.
+
+While Sentry is off, `RUST_LOG` and the log format are the Dioxus toolchain's as before; while it is
+on, the server installs the subscriber itself — same variable, same default verbosity, plus the
+layer that reports.
 
 ## Compatibility
 

--- a/apps/web/Cargo.toml
+++ b/apps/web/Cargo.toml
@@ -29,6 +29,12 @@ tower-http = { workspace = true, optional = true }
 # only: it hashes the response body, and its nonce feature needs an OS CSPRNG.
 csp-shell = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
+# The two halves of the optional error reporting in `src/server/telemetry.rs`: the SDK, and the
+# subscriber it needs a layer on. Native SSR only — the client that would report a wasm panic is
+# a *browser* SDK loaded by the page, which is a different product, a `connect-src` in the
+# Content-Security-Policy and a line in the privacy page, so none of it is this.
+sentry = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 time = { workspace = true, features = ["macros"], optional = true }
 # Synchronous access to the current request during SSR (for locale negotiation).
@@ -50,6 +56,10 @@ portfolio-data.workspace = true
 # tests compiled under `--features server`.
 tower.workspace = true
 tokio.workspace = true
+# `src/server/telemetry.rs` builds a `SentryConfig` with a deliberately malformed DSN, and the
+# field is a `SecretString` that only this crate can construct. A development dependency: the
+# server itself never wraps a secret, it only reads one `portfolio-config` already wrapped.
+secrecy.workspace = true
 
 [features]
 # No platform by default so a bare `cargo check`/`clippy`/`test` over the
@@ -78,6 +88,13 @@ server = [
     "dep:tower-http",
     "dep:csp-shell",
     "dep:tracing",
+    # Compiled into every server build and switched on by `sentry.enabled`, rather than gated
+    # behind a Cargo feature of its own. A feature would mean an image where
+    # `PORTFOLIO_SENTRY__ENABLED=true` is accepted by the loader and does nothing — a knob that
+    # silently no-ops, which is the failure this workspace already refuses elsewhere. Off, the
+    # cost is one `if` at boot: no client, no hook, no layer, no middleware.
+    "dep:sentry",
+    "dep:tracing-subscriber",
     "dep:schemars",
     "dep:time",
     "dep:dioxus-fullstack-core",

--- a/apps/web/src/server/mod.rs
+++ b/apps/web/src/server/mod.rs
@@ -10,6 +10,7 @@ mod assets;
 mod cache;
 mod csp;
 mod seo;
+mod telemetry;
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -52,10 +53,37 @@ const EX_CONFIG: i32 = 78;
 pub fn serve() {
     let config = Arc::new(load_config());
 
+    // Before `dioxus::serve`, and that ordering is the whole of the handover: the framework
+    // installs its own subscriber unless one is already set, and a Sentry layer has to be a
+    // layer *of* the subscriber rather than something added to a finished one. With
+    // `sentry.enabled` off this installs nothing and the framework's subscriber stands.
+    //
+    // The binding is held for the rest of `serve`, which is the rest of the process —
+    // `dioxus::serve` diverges. See `telemetry::TelemetryGuard` for why that means the
+    // drop-time flush is unreachable, and why no key claims otherwise.
+    let _telemetry = match telemetry::init(&config.sentry) {
+        Ok(guard) => guard,
+        Err(err) => refuse(&err),
+    };
+
     dioxus::serve(move || {
         let config = Arc::clone(&config);
         async move { Ok(router(&config)) }
     });
+}
+
+/// Ends the process with [`EX_CONFIG`], naming what could not be started with.
+///
+/// Runs before `dioxus::serve` installs a logger — and, when Sentry is on, before this server
+/// installs one — so `tracing` would discard this; it goes to stderr directly.
+///
+/// The error names the key; the report under it names the layer that supplied it, which is the
+/// half an operator cannot get at from inside a distroless image with no shell. Neither holds a
+/// configuration value, so both are safe in a log that is shipped and retained.
+fn refuse(err: &dyn std::fmt::Display) -> ! {
+    eprintln!("portfolio: cannot start, the configuration is not usable: {err}");
+    eprintln!("{}", portfolio_config::provenance());
+    std::process::exit(EX_CONFIG)
 }
 
 /// Reads the configuration, or ends the process with [`EX_CONFIG`].
@@ -63,25 +91,19 @@ pub fn serve() {
 /// Two ways to be unusable, and both are start-up failures: a value that cannot be *loaded* (a
 /// missing file, an unparseable number, one key supplied by two layers), and a set of values that
 /// load individually but cannot be *served* together — see
-/// [`CspConfig::validate`](portfolio_config::CspConfig::validate). Failing here means the
-/// container never reports ready, rather than serving every visitor a blank page.
+/// [`CspConfig::validate`](portfolio_config::CspConfig::validate) and
+/// [`SentryConfig::validate`](portfolio_config::SentryConfig::validate). Failing here means the
+/// container never reports ready, rather than serving every visitor a blank page or reporting its
+/// errors into a void.
 fn load_config() -> ServerConfig {
-    // Runs before `dioxus::serve` installs the logger, so `tracing` would discard this.
-    //
-    // The error names the key; the report under it names the layer that supplied it, which is
-    // the half an operator cannot get at from inside a distroless image with no shell. It holds
-    // no configuration value, so it is safe in a log that is shipped and retained.
-    let refuse = |err: &dyn std::fmt::Display| -> ! {
-        eprintln!("portfolio: cannot start, the configuration is not usable: {err}");
-        eprintln!("{}", portfolio_config::provenance());
-        std::process::exit(EX_CONFIG)
-    };
-
     let config = match portfolio_config::load::<ServerConfig>() {
         Ok(config) => config,
         Err(err) => refuse(&err),
     };
     if let Err(err) = config.csp.validate() {
+        refuse(&err);
+    }
+    if let Err(err) = config.sentry.validate() {
         refuse(&err);
     }
     config
@@ -118,28 +140,43 @@ fn router(config: &ServerConfig) -> Router {
     // The policy for everything that is not a document, and only where the layer
     // above has not already set a stricter, document-specific one — hence
     // `if_not_present` rather than the `overriding` every other header uses.
-    app.layer(SetResponseHeaderLayer::if_not_present(
-        header::CONTENT_SECURITY_POLICY,
-        policy.subresource(),
-    ))
-    .layer(static_header(header::X_CONTENT_TYPE_OPTIONS, "nosniff"))
-    .layer(static_header(header::X_FRAME_OPTIONS, "DENY"))
-    .layer(static_header(header::REFERRER_POLICY, "no-referrer"))
-    .layer(static_header(
-        header::STRICT_TRANSPORT_SECURITY,
-        "max-age=31536000; includeSubDomains; preload",
-    ))
-    .layer(static_header(
-        HeaderName::from_static("permissions-policy"),
-        "camera=(), microphone=(), geolocation=(), interest-cohort=()",
-    ))
-    // Compress text assets per Accept-Encoding; already-encoded payloads are
-    // skipped, so this never double-compresses the SSR HTML.
-    .layer(CompressionLayer::new().compress_when(compression_predicate()))
-    // Assign a `Cache-Control` TTL per asset class, but only when a handler
-    // did not already set one (so the API's own headers win). Runs last.
-    .layer(middleware::from_fn(cache::set_cache_control))
-    .layer(TraceLayer::new_for_http())
+    let app = app
+        .layer(SetResponseHeaderLayer::if_not_present(
+            header::CONTENT_SECURITY_POLICY,
+            policy.subresource(),
+        ))
+        .layer(static_header(header::X_CONTENT_TYPE_OPTIONS, "nosniff"))
+        .layer(static_header(header::X_FRAME_OPTIONS, "DENY"))
+        .layer(static_header(header::REFERRER_POLICY, "no-referrer"))
+        .layer(static_header(
+            header::STRICT_TRANSPORT_SECURITY,
+            "max-age=31536000; includeSubDomains; preload",
+        ))
+        .layer(static_header(
+            HeaderName::from_static("permissions-policy"),
+            "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+        ))
+        // Compress text assets per Accept-Encoding; already-encoded payloads are
+        // skipped, so this never double-compresses the SSR HTML.
+        .layer(CompressionLayer::new().compress_when(compression_predicate()))
+        // Assign a `Cache-Control` TTL per asset class, but only when a handler
+        // did not already set one (so the API's own headers win). Runs last.
+        .layer(middleware::from_fn(cache::set_cache_control));
+
+    // Outside everything that can fail, so a panic or a 500 from any layer above is still
+    // reported with its request attached. Absent entirely when Sentry is off, rather than
+    // present as a no-op: a request must not pay for a feature nobody switched on.
+    //
+    // Two layers, and the order between them matters — the last `.layer` call is the outermost,
+    // so the hub is bound first and the metadata layer below writes onto the hub it bound.
+    // Mounted through `Router::layer`, which runs after routing, which is what puts the
+    // `MatchedPath` extension in place for the route-named transaction.
+    let app = match telemetry::http_layers(&config.sentry) {
+        Some((hub, http)) => app.layer(http).layer(hub),
+        None => app,
+    };
+
+    app.layer(TraceLayer::new_for_http())
 }
 
 /// What [`localize_page`] carries per request.
@@ -1002,6 +1039,54 @@ mod tests {
             get_("/api/does-not-exist").await.status(),
             StatusCode::NOT_FOUND
         );
+    }
+
+    /// The two Sentry middlewares are mounted on the live stack in [`router`], where nothing else
+    /// in this suite reaches — that function builds the Dioxus app router, which wants a bundle on
+    /// disk. What is worth pinning without one is that the pair is transparent: the hub layer and
+    /// the request-metadata layer sit outside every handler, and a response that goes through them
+    /// has to be the response the handler produced, header for header and byte for byte.
+    ///
+    /// Also the only place the layer *types* are composed the way `router` composes them, so a
+    /// version of `sentry-tower` that stops fitting an axum `Router` fails here rather than in the
+    /// image build.
+    #[tokio::test]
+    async fn the_sentry_layers_leave_a_response_untouched() {
+        let config = portfolio_config::SentryConfig {
+            enabled: true,
+            dsn: Some(secrecy::SecretString::from("https://key@sentry.example/42")),
+            ..portfolio_config::SentryConfig::default()
+        };
+        let (hub, http) =
+            telemetry::http_layers(&config).expect("a configured block mounts both layers");
+
+        let request = || {
+            Request::builder()
+                .uri("/api/health")
+                .body(Body::empty())
+                .unwrap()
+        };
+        let bare = api_router(AssetsConfig::default())
+            .oneshot(request())
+            .await
+            .unwrap();
+        let layered = api_router(AssetsConfig::default())
+            .layer(http)
+            .layer(hub)
+            .oneshot(request())
+            .await
+            .unwrap();
+
+        assert_eq!(bare.status(), layered.status());
+        assert_eq!(bare.headers(), layered.headers());
+        assert_eq!(json(bare).await, json(layered).await);
+    }
+
+    /// The other half of the switch: with the block at its default nothing is mounted at all, so a
+    /// deployment that never asked for reporting pays nothing per request.
+    #[test]
+    fn the_default_block_mounts_no_sentry_layer() {
+        assert!(telemetry::http_layers(&portfolio_config::SentryConfig::default()).is_none());
     }
 
     #[tokio::test]

--- a/apps/web/src/server/telemetry.rs
+++ b/apps/web/src/server/telemetry.rs
@@ -1,0 +1,427 @@
+//! Optional Sentry error reporting and performance tracing.
+//!
+//! Off unless `sentry.enabled` is set, and then only with a DSN — the combination without one is
+//! refused by [`SentryConfig::validate`] before this module is reached, because a client that
+//! reports nowhere produces an empty dashboard that looks exactly like a site with no errors.
+//!
+//! Three sinks, all fed from the one client [`init`] installs:
+//!
+//! - **`tracing`** — [`tracing_layer`] turns records into issues and breadcrumbs, under the two
+//!   thresholds in [`SentryConfig`].
+//! - **panics** — the SDK's own hook, added by `sentry::init`. A panic in a handler unwinds that
+//!   request's task and leaves the process serving every other request, so without the hook it is
+//!   invisible: no 500 is logged, and the reader sees a dropped connection.
+//! - **HTTP** — [`http_layers`], mounted by [`super::router`].
+//!
+//! # This module owns the log subscriber, but only while Sentry is on
+//!
+//! A Sentry layer has to be a layer *of* the subscriber, and `dioxus::serve` installs one through
+//! `dioxus_logger::initialize_default`, which cannot be extended afterwards. It can, however, be
+//! declined: it returns early when `tracing::dispatcher::has_been_set()`, so installing ours
+//! first — before `dioxus::serve` — is the whole of the handover. [`init`] therefore builds a
+//! subscriber that keeps the framework's contract (`RUST_LOG`, the same default verbosity, the
+//! same `hyper_util` mute) and adds the Sentry layer to it.
+//!
+//! With Sentry off, nothing here is constructed and the framework's subscriber stands exactly as
+//! before. That asymmetry is deliberate: the default path must not change behaviour to make an
+//! opt-in feature possible.
+//!
+//! One visible difference on the opted-in path, and only in development: `dioxus_logger` drops
+//! timestamps and targets when it detects that it is running under `dx`, and this does not,
+//! because the detection lives in `dioxus-cli-config` — a crate the `server` feature does not
+//! pull in, and not one worth pulling in for the width of a log line.
+
+use core::fmt;
+
+use portfolio_config::{SentryConfig, SentryLevel};
+use sentry::integrations::tracing::{EventFilter, SentryLayer, default_span_filter};
+use tracing::Level;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::{EnvFilter, Registry};
+
+/// What the default release tag names the project, ahead of the version.
+///
+/// The image, the contract and the GitHub repository all spell it this way, so an event's release
+/// is a string an operator can match against a tag without translating it.
+const RELEASE_PREFIX: &str = "portfolio";
+
+/// The module paths a stack trace should treat as application code.
+///
+/// The crate names as the linker spells them, so `apps/web`'s own frames and the two workspace
+/// libraries are in-app and everything under `dioxus`, `axum` and `hyper` is not. That is what
+/// makes a trace open on the handler rather than on a framework internal ten frames above it.
+const IN_APP: &[&str] = &["web", "portfolio_config", "portfolio_data"];
+
+/// Keeps the Sentry client alive.
+///
+/// Bind it (`let _telemetry = …`) for as long as the process should report; `let _ = …` drops it
+/// immediately and closes the client before the server has served anything.
+///
+/// # The drop is not a shutdown flush here
+///
+/// `sentry::ClientInitGuard::drop` normally flushes what the transport has queued. In this binary
+/// it never runs: `dioxus::serve` diverges (`-> !`), and its release path awaits `axum::serve`
+/// with no shutdown signal, so a container stopping takes the default `SIGTERM` disposition and
+/// the process is gone before any destructor. That is why `shutdown_timeout_secs` is absent from
+/// the configuration surface — it would be a key describing a code path this server does not
+/// have. What actually gets events out is the SDK's background transport, which sends
+/// continuously rather than at exit.
+#[must_use = "dropping the guard closes the Sentry client and stops reporting"]
+pub struct TelemetryGuard(Option<sentry::ClientInitGuard>);
+
+// Hand-written because `ClientInitGuard` has no `Debug`, and because the only fact worth printing
+// is the one an operator asks for: is anything reporting at all.
+impl fmt::Debug for TelemetryGuard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TelemetryGuard")
+            .field(&self.0.is_some())
+            .finish()
+    }
+}
+
+/// Install the Sentry client and the subscriber that feeds it, or leave both alone.
+///
+/// Called before `dioxus::serve`, which is the only moment the handover described in the module
+/// documentation is available. Returns a guard the caller has to hold.
+///
+/// # Errors
+///
+/// [`TelemetryError::Dsn`] when `sentry.dsn` is not a Sentry DSN — checked here rather than in
+/// `portfolio-config`, which does not link the SDK — and [`TelemetryError::Subscriber`] when a
+/// `tracing` subscriber is already installed, which means the Sentry layer would silently report
+/// nothing. Both are start-up failures the caller refuses the boot on.
+pub fn init(config: &SentryConfig) -> Result<TelemetryGuard, TelemetryError> {
+    // Off, or on with no DSN — the second already refused by `SentryConfig::validate`, and
+    // treated here as off rather than re-reported, so this function has exactly one failure mode
+    // per error variant.
+    let Some(dsn) = config.enabled.then(|| config.dsn()).flatten() else {
+        return Ok(TelemetryGuard(None));
+    };
+
+    // Parsed here rather than handed to `ClientOptions::dsn`, which panics on a malformed value.
+    let dsn = dsn
+        .parse::<sentry::types::Dsn>()
+        .map_err(TelemetryError::Dsn)?;
+
+    let mut options = sentry::ClientOptions::new()
+        .debug(config.debug)
+        .sample_rate(config.sample_rate)
+        .traces_sample_rate(config.traces_sample_rate)
+        .max_breadcrumbs(config.max_breadcrumbs)
+        .attach_stacktrace(config.attach_stacktraces)
+        .send_default_pii(config.send_default_pii)
+        .environment(environment(config))
+        .release(release(config))
+        .in_app_include(IN_APP.to_vec());
+    options.dsn = Some(dsn);
+    if let Some(server_name) = config.server_name.clone() {
+        options = options.server_name(server_name);
+    }
+
+    // Every field `apply_defaults` would otherwise fill from `SENTRY_DSN`, `SENTRY_RELEASE` or
+    // `SENTRY_ENVIRONMENT` is set above, and that is the point: those variables are a second
+    // configuration channel that bypasses the layered loader and the shadow-key rejection that
+    // makes a rotated secret trustworthy, and an already-set field is one they cannot reach.
+    //
+    // Before the subscriber: the layer below reports onto this client, and the panic hook should
+    // be in place for anything the subscriber build itself does.
+    let guard = sentry::init(options);
+
+    Registry::default()
+        .with(env_filter())
+        .with(tracing_layer(config))
+        .with(tracing_subscriber::fmt::layer().with_target(true))
+        .try_init()
+        .map_err(|err| TelemetryError::Subscriber(err.to_string()))?;
+
+    // After `try_init`, not beside `sentry::init`: a record emitted before the subscriber exists
+    // goes nowhere, and "is Sentry actually on in this container" is the first question an
+    // operator asks.
+    tracing::info!(
+        traces_sample_rate = config.traces_sample_rate,
+        send_default_pii = config.send_default_pii,
+        "Sentry reporting enabled"
+    );
+
+    Ok(TelemetryGuard(Some(guard)))
+}
+
+/// The per-request hub and the request-metadata layer, or `None` when Sentry is off.
+///
+/// The hub layer is not optional decoration. Without a hub per request, breadcrumbs from
+/// concurrently served requests all land on the main hub, and every issue arrives with a trail
+/// belonging to whoever else happened to be in flight.
+///
+/// Built after [`init`] rather than beside it, because `SentryHttpLayer::new` reads
+/// `send_default_pii` off the bound client to decide whether to redact sensitive request headers
+/// — with no client bound it would decide against a default rather than against the
+/// configuration.
+pub fn http_layers(
+    config: &SentryConfig,
+) -> Option<(
+    sentry::integrations::tower::NewSentryLayer<axum::extract::Request>,
+    sentry::integrations::tower::SentryHttpLayer,
+)> {
+    if !config.is_active() {
+        return None;
+    }
+
+    let http = sentry::integrations::tower::SentryHttpLayer::new();
+    let http = if config.http_transactions {
+        http.enable_transaction()
+    } else {
+        http
+    };
+    Some((
+        sentry::integrations::tower::NewSentryLayer::new_from_top(),
+        http,
+    ))
+}
+
+/// The `tracing` layer feeding the client.
+///
+/// Sits under the subscriber's [`EnvFilter`], which is the one surprise worth knowing: a record
+/// `RUST_LOG` drops never reaches this layer, so tightening the log filter to `warn` also removes
+/// every `info` breadcrumb.
+fn tracing_layer<S>(config: &SentryConfig) -> SentryLayer<S>
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    let capture = config.capture_level;
+    let breadcrumb = config.breadcrumb_level;
+
+    let layer = sentry::integrations::tracing::layer()
+        .event_filter(move |metadata| {
+            let level = *metadata.level();
+            if accepts(capture, level) {
+                EventFilter::Event
+            } else if accepts(breadcrumb, level) {
+                EventFilter::Breadcrumb
+            } else {
+                EventFilter::Ignore
+            }
+        })
+        // Not additionally gated on `traces_sample_rate`: whether a span is *recorded* is the
+        // sampler's decision, and gating span creation here would also remove the spans that
+        // give an issue its context, not only the ones that would have become a transaction.
+        .span_filter(default_span_filter);
+
+    if config.span_attributes {
+        layer.enable_span_attributes()
+    } else {
+        layer
+    }
+}
+
+/// The verbosity filter, matching what `dioxus_logger::initialize_default` would have installed.
+///
+/// Same contract, so switching Sentry on does not also change what is logged: `RUST_LOG` wins,
+/// the default is `debug` for a development build and `info` otherwise, and `hyper_util` is muted
+/// because it leaves `debug!` calls on the connection accept path that drown everything else.
+fn env_filter() -> EnvFilter {
+    let default = if cfg!(debug_assertions) {
+        Level::DEBUG
+    } else {
+        Level::INFO
+    };
+    let filter = EnvFilter::builder()
+        .with_default_directive(default.into())
+        .from_env_lossy();
+
+    // A literal that cannot fail to parse, matched rather than unwrapped: a panic here would
+    // take down a boot over a log directive, and the honest fallback is the filter without it.
+    match "hyper_util=warn".parse() {
+        Ok(directive) => filter.add_directive(directive),
+        Err(_) => filter,
+    }
+}
+
+/// The environment tag, from the configuration or from the build profile.
+///
+/// The profile is the only distinction this workspace has: it ships one image, and what separates
+/// a developer's `dx serve` from the deployed container is what it was compiled as.
+fn environment(config: &SentryConfig) -> String {
+    config.environment.clone().unwrap_or_else(|| {
+        if cfg!(debug_assertions) {
+            "development".to_owned()
+        } else {
+            "production".to_owned()
+        }
+    })
+}
+
+/// The release tag, from the configuration or from the version this binary was built at.
+///
+/// `CARGO_PKG_VERSION` rather than a `v`-prefixed tag: every deploy of this site is a new image
+/// cut from a new workspace version, so the bare version is what makes a regression attributable
+/// to one.
+fn release(config: &SentryConfig) -> String {
+    config
+        .release
+        .clone()
+        .unwrap_or_else(|| format!("{RELEASE_PREFIX}@{}", env!("CARGO_PKG_VERSION")))
+}
+
+/// Whether a record at `level` is at least as severe as `threshold`.
+///
+/// [`Level`] orders `ERROR` lowest, so "at least as severe" is `<=`.
+fn accepts(threshold: SentryLevel, level: Level) -> bool {
+    let threshold = match threshold {
+        SentryLevel::Off => return false,
+        SentryLevel::Error => Level::ERROR,
+        SentryLevel::Warn => Level::WARN,
+        SentryLevel::Info => Level::INFO,
+        SentryLevel::Debug => Level::DEBUG,
+        SentryLevel::Trace => Level::TRACE,
+    };
+    level <= threshold
+}
+
+/// A `[sentry]` block that loaded but cannot be installed.
+///
+/// Separate from [`portfolio_config::SentryConfigError`] on purpose: that one is everything the
+/// schema can decide on its own, and this is the two answers only the SDK and the process can
+/// give. Both end the boot through the same refusal, so an operator sees one behaviour.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum TelemetryError {
+    /// `sentry.dsn` is not a Sentry DSN.
+    Dsn(sentry::types::ParseDsnError),
+    /// A `tracing` subscriber was already installed, so the Sentry layer has nothing to sit in.
+    Subscriber(String),
+}
+
+impl fmt::Display for TelemetryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // The DSN is deliberately not quoted: it is a credential, and this message reaches a
+            // log stream that is shipped and retained.
+            Self::Dsn(err) => write!(
+                f,
+                "sentry.dsn is not a valid Sentry DSN ({err}); the project settings page spells \
+                 it https://<key>@<host>/<project>"
+            ),
+            Self::Subscriber(err) => write!(
+                f,
+                "a tracing subscriber was already installed ({err}), so the Sentry layer could \
+                 not be added and nothing would be reported. This server installs the subscriber \
+                 itself while sentry.enabled is set; something ran before it"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for TelemetryError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Dsn(err) => Some(err),
+            Self::Subscriber(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{accepts, environment, http_layers, init, release};
+    use portfolio_config::{SentryConfig, SentryLevel};
+    use secrecy::SecretString;
+    use tracing::Level;
+
+    /// [`Level`] sorts `ERROR` *below* `TRACE`, so a severity threshold reads as `<=` and not
+    /// `>=`. Inverting it turns `capture_level = "error"` into "capture everything", which is a
+    /// bill rather than a compile error.
+    #[test]
+    fn a_threshold_accepts_only_levels_at_least_as_severe() {
+        assert!(accepts(SentryLevel::Error, Level::ERROR));
+        assert!(!accepts(SentryLevel::Error, Level::WARN));
+        assert!(!accepts(SentryLevel::Error, Level::TRACE));
+
+        assert!(accepts(SentryLevel::Info, Level::ERROR));
+        assert!(accepts(SentryLevel::Info, Level::WARN));
+        assert!(accepts(SentryLevel::Info, Level::INFO));
+        assert!(!accepts(SentryLevel::Info, Level::DEBUG));
+
+        for level in [
+            Level::ERROR,
+            Level::WARN,
+            Level::INFO,
+            Level::DEBUG,
+            Level::TRACE,
+        ] {
+            assert!(!accepts(SentryLevel::Off, level));
+            assert!(accepts(SentryLevel::Trace, level));
+        }
+    }
+
+    /// The default path installs nothing at all — not a client with an empty DSN, which still
+    /// starts a transport thread and still queues events — and leaves the subscriber to the
+    /// framework, which is what keeps this feature from changing a deployment that has not asked
+    /// for it.
+    #[test]
+    fn the_default_configuration_installs_nothing() {
+        let config = SentryConfig::default();
+        let guard = init(&config).expect("an off block cannot fail to install nothing");
+        assert_eq!(format!("{guard:?}"), "TelemetryGuard(false)");
+        assert!(http_layers(&config).is_none());
+        assert!(
+            !tracing::dispatcher::has_been_set(),
+            "the off path must leave the subscriber to `dioxus::serve`; taking it here would \
+             change what a deployment that never asked for Sentry logs"
+        );
+    }
+
+    /// `enabled` without a DSN is refused by `SentryConfig::validate` at boot; reaching this
+    /// module anyway must still install nothing rather than a client pointing at nowhere.
+    #[test]
+    fn enabled_without_a_dsn_installs_nothing() {
+        let config = SentryConfig {
+            enabled: true,
+            ..SentryConfig::default()
+        };
+        let guard = init(&config).expect("no DSN is not this module's failure to report");
+        assert_eq!(format!("{guard:?}"), "TelemetryGuard(false)");
+        assert!(http_layers(&config).is_none());
+    }
+
+    /// A DSN that is not one has to fail the boot rather than panic inside `ClientOptions`, which
+    /// is what `ClientOptions::dsn` does with the same value.
+    #[test]
+    fn a_malformed_dsn_is_an_error_rather_than_a_panic() {
+        let config = SentryConfig {
+            enabled: true,
+            dsn: Some(SecretString::from("not-a-dsn")),
+            ..SentryConfig::default()
+        };
+        let err = init(&config).expect_err("a malformed DSN must not install a client");
+        let message = err.to_string();
+        assert!(message.contains("sentry.dsn"), "{message}");
+        // The credential must not reach a log line, even the malformed one — an operator who
+        // pasted the wrong secret into the right key would otherwise publish it.
+        assert!(!message.contains("not-a-dsn"), "{message}");
+    }
+
+    /// Both tags fall back to something that identifies the build, because an untagged event is
+    /// an event nobody can attribute to a deploy.
+    #[test]
+    fn the_release_and_environment_tags_have_defaults() {
+        let config = SentryConfig::default();
+        assert_eq!(
+            release(&config),
+            format!("portfolio@{}", env!("CARGO_PKG_VERSION"))
+        );
+        assert!(matches!(
+            environment(&config).as_str(),
+            "development" | "production"
+        ));
+
+        let overridden = SentryConfig {
+            environment: Some("staging".to_owned()),
+            release: Some("portfolio@custom".to_owned()),
+            ..SentryConfig::default()
+        };
+        assert_eq!(environment(&overridden), "staging");
+        assert_eq!(release(&overridden), "portfolio@custom");
+    }
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -128,6 +128,168 @@
 #   the secrets directory
 # ttl_secs = 0
 
+[sentry]
+# Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`
+# layer and no HTTP middleware, so every other key here is inert and nothing leaves the
+# process.
+#
+# It also decides who owns the log subscriber. Off — the default — the Dioxus toolchain
+# installs its own, which is the behaviour this server has always had. On, the server
+# installs one first (still reading `RUST_LOG`, still formatting the same way) because a
+# Sentry layer has to be a layer *of* the subscriber, and the framework's is not
+# extensible after the fact.
+# Type: bool
+# Also from: PORTFOLIO_SENTRY__ENABLED, PORTFOLIO_SENTRY__ENABLED_FILE=/path/to/file,
+#   sentry__enabled in the secrets directory
+# enabled = false
+
+# Ingest URL, `https://<key>@<host>/<project>`.
+#
+# The embedded key is a bearer credential for the project's ingest endpoint, so it is held
+# as a `SecretString` — this block is nested in a `ServerConfig` that is printed with `?` on
+# the refusal path. Supply it as `PORTFOLIO_SENTRY__DSN_FILE=/run/secrets/sentry_dsn`, or as
+# `sentry__dsn` inside `$PORTFOLIO_SECRETS_DIR`, so it never enters the process
+# environment — where `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry
+# it, and every child process inherits it.
+#
+# Absent while `sentry.enabled` is set is a boot failure, not a silent no-op.
+# Type: SecretString
+# Also from: PORTFOLIO_SENTRY__DSN, PORTFOLIO_SENTRY__DSN_FILE=/path/to/file, sentry__dsn in the
+#   secrets directory
+# Secret: the value below is a placeholder.
+# dsn = "<secret>"
+
+# Environment tag on every event.
+#
+# Unset resolves to `production` for a release build and `development` otherwise, which is
+# the only distinction this workspace has: it ships one image, and the thing that separates
+# a developer's `dx serve` from the deployed container is the profile it was built with.
+# Type: String
+# Also from: PORTFOLIO_SENTRY__ENVIRONMENT, PORTFOLIO_SENTRY__ENVIRONMENT_FILE=/path/to/file,
+#   sentry__environment in the secrets directory
+# Unset by default: the value below is only the shape.
+# environment = "<value>"
+
+# Release tag on every event.
+#
+# Unset resolves to `portfolio@<version>`, the workspace version the binary was built from
+# — which is what makes a regression attributable to a deploy, since every deploy of this
+# site is a new image cut from a new version.
+# Type: String
+# Also from: PORTFOLIO_SENTRY__RELEASE, PORTFOLIO_SENTRY__RELEASE_FILE=/path/to/file,
+#   sentry__release in the secrets directory
+# Unset by default: the value below is only the shape.
+# release = "<value>"
+
+# Host tag on every event.
+#
+# Left unset, Sentry reports none. The hostname of a replica is infrastructure detail that
+# `sentry.send_default_pii` would otherwise be the gate for, and this site runs one image
+# behind a tunnel, so it identifies nothing an event does not already say.
+# Type: String
+# Also from: PORTFOLIO_SENTRY__SERVER_NAME, PORTFOLIO_SENTRY__SERVER_NAME_FILE=/path/to/file,
+#   sentry__server_name in the secrets directory
+# Unset by default: the value below is only the shape.
+# server_name = "<value>"
+
+# Fraction of captured events actually sent, `0.0`–`1.0`.
+#
+# A blunt volume cap: it drops whole issues rather than repetitions of one, so a rare bug
+# is exactly as likely to be dropped as a noisy one. Leave it at `1.0` unless a quota
+# forces otherwise.
+# Type: f32
+# Also from: PORTFOLIO_SENTRY__SAMPLE_RATE, PORTFOLIO_SENTRY__SAMPLE_RATE_FILE=/path/to/file,
+#   sentry__sample_rate in the secrets directory
+# sample_rate = 1.0
+
+# Fraction of request traces recorded, `0.0`–`1.0`.
+#
+# `0.0` — the default — records none, which is what keeps switching Sentry on for crash
+# reporting from also switching performance data on. `0.05`–`0.2` is an ordinary
+# production figure.
+#
+# This server starts every trace it has: it is the edge, and nothing upstream of it hands
+# it a sampled trace to continue. That is the difference from a service tier, where the
+# rate of whoever *starts* the trace decides whether it exists at all.
+# Type: f32
+# Also from: PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE,
+#   PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE_FILE=/path/to/file, sentry__traces_sample_rate in the
+#   secrets directory
+# traces_sample_rate = 0.0
+
+# Least severe `tracing` level reported as a Sentry **issue**.
+# Type: SentryLevel — one of: off, error, warn, info, debug, trace
+# Also from: PORTFOLIO_SENTRY__CAPTURE_LEVEL, PORTFOLIO_SENTRY__CAPTURE_LEVEL_FILE=/path/to/file,
+#   sentry__capture_level in the secrets directory
+# capture_level = "error"
+
+# Least severe `tracing` level kept as a **breadcrumb**, the trail attached to the next
+# issue.
+#
+# Records at or above `sentry.capture_level` become issues instead, so the two thresholds
+# partition the stream rather than overlapping on it.
+# Type: SentryLevel — one of: off, error, warn, info, debug, trace
+# Also from: PORTFOLIO_SENTRY__BREADCRUMB_LEVEL,
+#   PORTFOLIO_SENTRY__BREADCRUMB_LEVEL_FILE=/path/to/file, sentry__breadcrumb_level in the secrets
+#   directory
+# breadcrumb_level = "info"
+
+# How many breadcrumbs one event carries.
+# Type: usize
+# Also from: PORTFOLIO_SENTRY__MAX_BREADCRUMBS,
+#   PORTFOLIO_SENTRY__MAX_BREADCRUMBS_FILE=/path/to/file, sentry__max_breadcrumbs in the secrets
+#   directory
+# max_breadcrumbs = 100
+
+# Attach a stack trace to events that carry none of their own.
+# Type: bool
+# Also from: PORTFOLIO_SENTRY__ATTACH_STACKTRACES,
+#   PORTFOLIO_SENTRY__ATTACH_STACKTRACES_FILE=/path/to/file, sentry__attach_stacktraces in the
+#   secrets directory
+# attach_stacktraces = true
+
+# Send personally identifying data with every event: the client IP, the full request header
+# set (`Cookie` included) and the resolved user.
+#
+# **Off, and worth leaving off.** A reader's IP address and cookies are exactly what a
+# crash report does not need in order to be actionable, and Sentry is a third party for the
+# purposes of the privacy page this site publishes — a page that currently says no
+# third-party service receives visitor data, which is a statement this key is the one way
+# to falsify. On, it also widens what the HTTP middleware records, because `sentry-tower`
+# reads this same flag to decide whether to redact sensitive request headers.
+# Type: bool
+# Also from: PORTFOLIO_SENTRY__SEND_DEFAULT_PII,
+#   PORTFOLIO_SENTRY__SEND_DEFAULT_PII_FILE=/path/to/file, sentry__send_default_pii in the secrets
+#   directory
+# send_default_pii = false
+
+# Record one Sentry transaction per request, named by the *matched route* rather than by
+# the URI — so `/api/repos/{name}` does not become one transaction name per repository.
+#
+# Whether a started transaction is *kept* is `sentry.traces_sample_rate`'s decision; this is
+# the switch for taking the middleware out entirely.
+# Type: bool
+# Also from: PORTFOLIO_SENTRY__HTTP_TRANSACTIONS,
+#   PORTFOLIO_SENTRY__HTTP_TRANSACTIONS_FILE=/path/to/file, sentry__http_transactions in the
+#   secrets directory
+# http_transactions = true
+
+# Copy `tracing` span fields onto the Sentry span as attributes.
+#
+# Off. Span fields here routinely carry request paths and the negotiated locale, and a
+# transaction is stored under a longer retention than a log line.
+# Type: bool
+# Also from: PORTFOLIO_SENTRY__SPAN_ATTRIBUTES,
+#   PORTFOLIO_SENTRY__SPAN_ATTRIBUTES_FILE=/path/to/file, sentry__span_attributes in the secrets
+#   directory
+# span_attributes = false
+
+# Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.
+# Type: bool
+# Also from: PORTFOLIO_SENTRY__DEBUG, PORTFOLIO_SENTRY__DEBUG_FILE=/path/to/file, sentry__debug in
+#   the secrets directory
+# debug = false
+
 [github]
 # User whose repositories to list.
 #
@@ -165,3 +327,4 @@
 # Also from: PORTFOLIO_GITHUB__REPOS, PORTFOLIO_GITHUB__REPOS_FILE=/path/to/file, github__repos in
 #   the secrets directory
 # repos = []
+

--- a/config.example.toml
+++ b/config.example.toml
@@ -327,4 +327,3 @@
 # Also from: PORTFOLIO_GITHUB__REPOS, PORTFOLIO_GITHUB__REPOS_FILE=/path/to/file, github__repos in
 #   the secrets directory
 # repos = []
-

--- a/crates/config/examples/config-schema.rs
+++ b/crates/config/examples/config-schema.rs
@@ -92,6 +92,8 @@ const KEYS: &[(&str, &str)] = &[
     ("cspScriptNonce", "csp.cloudflare.script_nonce"),
     ("githubRepos", "github.repos"),
     ("githubToken", "github.token"),
+    ("sentryEnabled", "sentry.enabled"),
+    ("sentryDsn", "sentry.dsn"),
 ];
 
 /// What this generator adds to the argument list [`USAGE`] describes.

--- a/crates/config/src/aggregates.rs
+++ b/crates/config/src/aggregates.rs
@@ -15,7 +15,7 @@
 
 use serde::Deserialize;
 
-use crate::{AssetsConfig, CspConfig, GithubConfig, IsrConfig};
+use crate::{AssetsConfig, CspConfig, GithubConfig, IsrConfig, SentryConfig};
 
 /// What the SSR server (`apps/web`) loads.
 ///
@@ -41,6 +41,10 @@ pub struct ServerConfig {
     #[cfg_attr(feature = "config-schema", config(nested))]
     #[serde(default)]
     pub isr: IsrConfig,
+    /// Where errors and request traces are reported, if anywhere. Off unless configured.
+    #[cfg_attr(feature = "config-schema", config(nested))]
+    #[serde(default)]
+    pub sentry: SentryConfig,
 }
 
 /// What the `update-repos` builder loads.

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -16,7 +16,8 @@
 //! This crate owns the *blocks*, the dialect, and one aggregate per binary naming the blocks that
 //! binary reads — so a struct field is evidence that something consumes it:
 //!
-//! - the SSR server, [`ServerConfig`] ([`AssetsConfig`], [`CspConfig`], [`IsrConfig`]),
+//! - the SSR server, [`ServerConfig`] ([`AssetsConfig`], [`CspConfig`], [`IsrConfig`],
+//!   [`SentryConfig`]),
 //! - the `update-repos` builder, [`BuilderConfig`] ([`GithubConfig`]).
 //!
 //! The aggregates live here rather than in the binaries so the generated configuration reference
@@ -36,9 +37,12 @@
 //! not take it, for two reasons that both have to hold before it would be worth the
 //! tokio/notify/`inotify` weight:
 //!
-//! 1. **The server holds no secrets.** Rotation is what the supervisor exists to survive, and
-//!    the only secret in the workspace ([`GithubConfig::token`]) belongs to a one-shot build
-//!    tool that exits in seconds. Every value the *server* reads changes only on a redeploy.
+//! 1. **Neither secret is one a reload could re-point.** Rotation is what the supervisor exists
+//!    to survive. [`GithubConfig::token`] belongs to a one-shot build tool that exits in
+//!    seconds, and [`SentryConfig::dsn`] is read once by `sentry::init`, which binds one client
+//!    to the process for its lifetime — so a rebuilt configuration would carry the new DSN to a
+//!    client that cannot be told about it. Every other value the *server* reads changes only on
+//!    a redeploy.
 //! 2. **The serve loop is not ours to cancel.** `dioxus::serve` owns the listener and the accept
 //!    loop, and offers no shutdown handle, so a rebuild could not stop the previous generation
 //!    before the replacement binds the same address. Taking the supervisor would mean
@@ -82,6 +86,7 @@ mod csp;
 mod github;
 mod isr;
 mod loader;
+mod sentry;
 
 pub use aggregates::{BuilderConfig, ServerConfig};
 pub use assets::AssetsConfig;
@@ -89,3 +94,4 @@ pub use csp::{CloudflareConfig, CspConfig, CspConfigError};
 pub use github::GithubConfig;
 pub use isr::IsrConfig;
 pub use loader::{ConfigError, load, provenance, terrace};
+pub use sentry::{SentryConfig, SentryConfigError, SentryLevel};

--- a/crates/config/src/loader.rs
+++ b/crates/config/src/loader.rs
@@ -80,7 +80,7 @@ pub fn provenance() -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CspConfig, GithubConfig, IsrConfig, terrace};
+    use crate::{CspConfig, GithubConfig, IsrConfig, SentryConfig, terrace};
     use secrecy::ExposeSecret as _;
     use serde::Deserialize;
     use terrace_config::testing::Harness;
@@ -93,6 +93,8 @@ mod tests {
         github: GithubConfig,
         #[serde(default)]
         isr: IsrConfig,
+        #[serde(default)]
+        sentry: SentryConfig,
     }
 
     /// A sandbox over the loader [`terrace`] builds, so every name a test arranges is derived
@@ -149,6 +151,30 @@ mod tests {
                 .into_token()
                 .expect("the secret supplies a token");
             assert_eq!(token.expose_secret(), "ghp_real");
+            Ok(())
+        });
+    }
+
+    /// The other secret in the workspace, through the layer it is meant to arrive on.
+    ///
+    /// `sentry.dsn` is the only key the *server* mounts as a file, so this is where the
+    /// `PORTFOLIO_<KEY>_FILE` indirection stops being a documented feature and becomes a tested
+    /// one. The trailing newline is not incidental: `printf` into a Kubernetes `Secret`, an
+    /// editor and a BuildKit secret all add one, and a DSN that keeps it does not parse.
+    #[test]
+    fn the_dsn_arrives_through_file_indirection_and_loses_its_newline() {
+        harness().run(|jail| {
+            jail.env_key("sentry.enabled", true);
+            jail.indirection("sentry.dsn", "https://key@sentry.example/42\n")?;
+
+            let config: Sample = jail.load()?;
+            assert!(config.sentry.is_active());
+            assert_eq!(config.sentry.dsn(), Some("https://key@sentry.example/42"));
+            assert_eq!(config.sentry.validate(), Ok(()));
+            // The block materialises around what was supplied rather than replacing it: nothing
+            // here turns performance tracing on, and nothing here widens what an event carries.
+            assert!((config.sentry.traces_sample_rate - 0.0).abs() < f32::EPSILON);
+            assert!(!config.sentry.send_default_pii);
             Ok(())
         });
     }

--- a/crates/config/src/sentry.rs
+++ b/crates/config/src/sentry.rs
@@ -1,0 +1,471 @@
+//! Sentry error reporting and performance tracing for the SSR server.
+//!
+//! The block is here and the client is in `apps/web/src/server/telemetry.rs`, for the same
+//! reason every other block is split that way: this crate owns the schema, so the generated
+//! configuration reference can describe the keys without linking the SDK that reads them.
+//!
+//! Off by default, and it has to stay that way. A DSN is an egress destination for whatever a
+//! log line happens to carry, and this site publishes a privacy page saying it measures nothing;
+//! switching it on is an operator's decision, made once per deployment, with
+//! [`send_default_pii`](SentryConfig::send_default_pii) still off underneath it.
+
+use core::fmt;
+
+use secrecy::{ExposeSecret as _, SecretString};
+use serde::Deserialize;
+
+/// How much of the `tracing` stream one Sentry sink takes.
+///
+/// Ordered by severity, so a threshold names the *least* severe record it accepts: `warn` means
+/// `error` and `warn`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
+#[serde(rename_all = "lowercase")]
+pub enum SentryLevel {
+    /// Take nothing.
+    Off,
+    /// `error` only.
+    #[default]
+    Error,
+    /// `error` and `warn`.
+    Warn,
+    /// Down to `info`.
+    Info,
+    /// Down to `debug`.
+    Debug,
+    /// Everything.
+    Trace,
+}
+
+/// Sentry error reporting and performance tracing.
+///
+/// Every key is inert while [`enabled`](Self::enabled) is off, which is the default and what an
+/// unmentioned `[sentry]` block produces. Switched on without a usable
+/// [`dsn`](Self::dsn), the boot is refused rather than started with a reporter that reports
+/// nowhere — see [`validate`](Self::validate).
+// No `deny_unknown_fields`, for the reason given on `AssetsConfig`: the `_FILE` indirection keys
+// share this namespace.
+#[derive(Debug, Clone, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(serde::Serialize, terrace_config::schema::Describe)
+)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent operator toggles, one per PORTFOLIO_SENTRY__* variable"
+)]
+pub struct SentryConfig {
+    /// Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`
+    /// layer and no HTTP middleware, so every other key here is inert and nothing leaves the
+    /// process.
+    ///
+    /// It also decides who owns the log subscriber. Off — the default — the Dioxus toolchain
+    /// installs its own, which is the behaviour this server has always had. On, the server
+    /// installs one first (still reading `RUST_LOG`, still formatting the same way) because a
+    /// Sentry layer has to be a layer *of* the subscriber, and the framework's is not
+    /// extensible after the fact.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Ingest URL, `https://<key>@<host>/<project>`.
+    ///
+    /// The embedded key is a bearer credential for the project's ingest endpoint, so it is held
+    /// as a `SecretString` — this block is nested in a `ServerConfig` that is printed with `?` on
+    /// the refusal path. Supply it as `PORTFOLIO_SENTRY__DSN_FILE=/run/secrets/sentry_dsn`, or as
+    /// `sentry__dsn` inside `$PORTFOLIO_SECRETS_DIR`, so it never enters the process
+    /// environment — where `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry
+    /// it, and every child process inherits it.
+    ///
+    /// Absent while `sentry.enabled` is set is a boot failure, not a silent no-op.
+    // Not rustdoc: `skip_serializing` is here for the same reason it is on `github.token` —
+    // `SecretString` has no `Serialize`, and the schema generator serialises a default config to
+    // read the `Default` column out of it. The key still appears in the table, with `unset` for
+    // a default it never had.
+    #[cfg_attr(feature = "config-schema", config(secret))]
+    #[serde(default, skip_serializing)]
+    pub dsn: Option<SecretString>,
+
+    /// Environment tag on every event.
+    ///
+    /// Unset resolves to `production` for a release build and `development` otherwise, which is
+    /// the only distinction this workspace has: it ships one image, and the thing that separates
+    /// a developer's `dx serve` from the deployed container is the profile it was built with.
+    #[cfg_attr(
+        feature = "config-schema",
+        config(note = "`production` in a release build, `development` otherwise")
+    )]
+    #[serde(default)]
+    pub environment: Option<String>,
+
+    /// Release tag on every event.
+    ///
+    /// Unset resolves to `portfolio@<version>`, the workspace version the binary was built from
+    /// — which is what makes a regression attributable to a deploy, since every deploy of this
+    /// site is a new image cut from a new version.
+    #[cfg_attr(
+        feature = "config-schema",
+        config(note = "`portfolio@` and the built version")
+    )]
+    #[serde(default)]
+    pub release: Option<String>,
+
+    /// Host tag on every event.
+    ///
+    /// Left unset, Sentry reports none. The hostname of a replica is infrastructure detail that
+    /// `sentry.send_default_pii` would otherwise be the gate for, and this site runs one image
+    /// behind a tunnel, so it identifies nothing an event does not already say.
+    #[serde(default)]
+    pub server_name: Option<String>,
+
+    /// Fraction of captured events actually sent, `0.0`–`1.0`.
+    ///
+    /// A blunt volume cap: it drops whole issues rather than repetitions of one, so a rare bug
+    /// is exactly as likely to be dropped as a noisy one. Leave it at `1.0` unless a quota
+    /// forces otherwise.
+    #[serde(default = "SentryConfig::default_sample_rate")]
+    pub sample_rate: f32,
+
+    /// Fraction of request traces recorded, `0.0`–`1.0`.
+    ///
+    /// `0.0` — the default — records none, which is what keeps switching Sentry on for crash
+    /// reporting from also switching performance data on. `0.05`–`0.2` is an ordinary
+    /// production figure.
+    ///
+    /// This server starts every trace it has: it is the edge, and nothing upstream of it hands
+    /// it a sampled trace to continue. That is the difference from a service tier, where the
+    /// rate of whoever *starts* the trace decides whether it exists at all.
+    #[serde(default)]
+    pub traces_sample_rate: f32,
+
+    /// Least severe `tracing` level reported as a Sentry **issue**.
+    #[cfg_attr(feature = "config-schema", config(values))]
+    #[serde(default)]
+    pub capture_level: SentryLevel,
+
+    /// Least severe `tracing` level kept as a **breadcrumb**, the trail attached to the next
+    /// issue.
+    ///
+    /// Records at or above `sentry.capture_level` become issues instead, so the two thresholds
+    /// partition the stream rather than overlapping on it.
+    #[cfg_attr(feature = "config-schema", config(values))]
+    #[serde(default = "SentryConfig::default_breadcrumb_level")]
+    pub breadcrumb_level: SentryLevel,
+
+    /// How many breadcrumbs one event carries.
+    #[serde(default = "SentryConfig::default_max_breadcrumbs")]
+    pub max_breadcrumbs: usize,
+
+    /// Attach a stack trace to events that carry none of their own.
+    #[serde(default = "SentryConfig::default_attach_stacktraces")]
+    pub attach_stacktraces: bool,
+
+    /// Send personally identifying data with every event: the client IP, the full request header
+    /// set (`Cookie` included) and the resolved user.
+    ///
+    /// **Off, and worth leaving off.** A reader's IP address and cookies are exactly what a
+    /// crash report does not need in order to be actionable, and Sentry is a third party for the
+    /// purposes of the privacy page this site publishes — a page that currently says no
+    /// third-party service receives visitor data, which is a statement this key is the one way
+    /// to falsify. On, it also widens what the HTTP middleware records, because `sentry-tower`
+    /// reads this same flag to decide whether to redact sensitive request headers.
+    #[serde(default)]
+    pub send_default_pii: bool,
+
+    /// Record one Sentry transaction per request, named by the *matched route* rather than by
+    /// the URI — so `/api/repos/{name}` does not become one transaction name per repository.
+    ///
+    /// Whether a started transaction is *kept* is `sentry.traces_sample_rate`'s decision; this is
+    /// the switch for taking the middleware out entirely.
+    #[serde(default = "SentryConfig::default_http_transactions")]
+    pub http_transactions: bool,
+
+    /// Copy `tracing` span fields onto the Sentry span as attributes.
+    ///
+    /// Off. Span fields here routinely carry request paths and the negotiated locale, and a
+    /// transaction is stored under a longer retention than a log line.
+    #[serde(default)]
+    pub span_attributes: bool,
+
+    /// Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.
+    #[serde(default)]
+    pub debug: bool,
+}
+
+impl SentryConfig {
+    /// Send everything that is captured; see the field.
+    const fn default_sample_rate() -> f32 {
+        1.0
+    }
+
+    /// Breadcrumbs down to `info`; see the field.
+    const fn default_breadcrumb_level() -> SentryLevel {
+        SentryLevel::Info
+    }
+
+    /// The SDK's own default, restated so the generated table can print it.
+    const fn default_max_breadcrumbs() -> usize {
+        100
+    }
+
+    /// Stack traces are the point; see the field.
+    const fn default_attach_stacktraces() -> bool {
+        true
+    }
+
+    /// Route-named transactions are the point; see the field.
+    const fn default_http_transactions() -> bool {
+        true
+    }
+
+    /// The ingest URL, or `None` when unset or blank.
+    ///
+    /// Blank has to read as unset rather than as a DSN that fails to parse: `PORTFOLIO_SENTRY__DSN=`
+    /// is how a container platform spells a declared-but-unset variable, and how an unfilled chart
+    /// value arrives. The two produce very different messages and only one sends the operator to
+    /// the right place.
+    ///
+    /// This is the single point where the DSN is exposed, and the only caller is the line in
+    /// `apps/web/src/server/telemetry.rs` that hands it to `sentry::init`.
+    #[must_use]
+    pub fn dsn(&self) -> Option<&str> {
+        self.dsn
+            .as_ref()
+            .map(|dsn| dsn.expose_secret().trim())
+            .filter(|dsn| !dsn.is_empty())
+    }
+
+    /// Whether a client should be installed at all.
+    ///
+    /// One accessor rather than reading the field, because "on" means "on *and* pointing
+    /// somewhere": [`validate`](Self::validate) has already refused the boot for the other
+    /// combination, so these two are the same question by the time anything asks it.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.enabled && self.dsn().is_some()
+    }
+
+    /// Reject a `[sentry]` block that would install a client reporting nowhere, or one the SDK
+    /// would panic on.
+    ///
+    /// Called at boot beside [`CspConfig::validate`](crate::CspConfig::validate), before the
+    /// listener exists, so the container fails to start rather than serving a site whose errors
+    /// go into a void the dashboard makes look empty.
+    ///
+    /// What is *not* checked here is whether the DSN parses: that is
+    /// `sentry::types::Dsn`'s answer, and this crate does not link the SDK. The server asks it
+    /// immediately afterwards and refuses the same way.
+    ///
+    /// # Errors
+    ///
+    /// [`SentryConfigError::MissingDsn`] when [`enabled`](Self::enabled) is set with no usable
+    /// [`dsn`](Self::dsn), and [`SentryConfigError::RateOutOfRange`] when a sample rate falls
+    /// outside `0.0..=1.0` — which `ClientOptions` would otherwise accept and then never sample
+    /// as asked.
+    pub fn validate(&self) -> Result<(), SentryConfigError> {
+        if !self.enabled {
+            return Ok(());
+        }
+        if self.dsn().is_none() {
+            return Err(SentryConfigError::MissingDsn);
+        }
+        check_rate("sentry.sample_rate", self.sample_rate)?;
+        check_rate("sentry.traces_sample_rate", self.traces_sample_rate)?;
+        Ok(())
+    }
+}
+
+/// Whether `rate` is a fraction the SDK can sample by.
+fn check_rate(key: &'static str, rate: f32) -> Result<(), SentryConfigError> {
+    if (0.0..=1.0).contains(&rate) {
+        Ok(())
+    } else {
+        Err(SentryConfigError::RateOutOfRange { key, rate })
+    }
+}
+
+impl Default for SentryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dsn: None,
+            environment: None,
+            release: None,
+            server_name: None,
+            sample_rate: Self::default_sample_rate(),
+            traces_sample_rate: 0.0,
+            capture_level: SentryLevel::Error,
+            breadcrumb_level: Self::default_breadcrumb_level(),
+            max_breadcrumbs: Self::default_max_breadcrumbs(),
+            attach_stacktraces: Self::default_attach_stacktraces(),
+            send_default_pii: false,
+            http_transactions: Self::default_http_transactions(),
+            span_attributes: false,
+            debug: false,
+        }
+    }
+}
+
+/// A `[sentry]` block that cannot be started with.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub enum SentryConfigError {
+    /// `sentry.enabled` is set while `sentry.dsn` is unset or blank.
+    MissingDsn,
+    /// A sample rate is outside `0.0..=1.0`.
+    RateOutOfRange {
+        /// The key that carries it, as an operator spells it.
+        key: &'static str,
+        /// What it was set to. Not a secret, and naming it is what makes a stray `%` or a
+        /// percentage typed as `25` obvious from the log line alone.
+        rate: f32,
+    },
+}
+
+impl fmt::Display for SentryConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingDsn => f.write_str(
+                "sentry.enabled is set but sentry.dsn is unset or empty, so a client would be \
+                 installed that reports nowhere — and a dashboard with no events in it looks \
+                 exactly like a site with no errors. Supply the DSN (sentry.dsn, \
+                 PORTFOLIO_SENTRY__DSN_FILE, or sentry__dsn in the secrets directory), or set \
+                 sentry.enabled = false",
+            ),
+            // Deliberately not naming the DSN anywhere in this enum: the message reaches a log
+            // stream that is shipped and retained.
+            Self::RateOutOfRange { key, rate } => write!(
+                f,
+                "{key} is a fraction between 0.0 and 1.0, and was set to {rate}. A percentage \
+                 belongs here as a decimal — 10% is 0.1",
+            ),
+        }
+    }
+}
+
+impl core::error::Error for SentryConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{SentryConfig, SentryConfigError, SentryLevel};
+    use secrecy::SecretString;
+
+    /// A deployment that says nothing about Sentry gets no client and no egress. Every key is
+    /// `#[serde(default)]`, twice over — once on `sentry` in the aggregate, once per field here
+    /// — so an absent block has to materialise rather than fail the boot of a deployment that
+    /// has never heard of this feature.
+    #[test]
+    fn an_unmentioned_block_is_off() {
+        let config = SentryConfig::default();
+        assert!(!config.enabled);
+        assert!(!config.is_active());
+        assert_eq!(config.dsn(), None);
+        assert!(!config.send_default_pii);
+        assert!((config.traces_sample_rate - 0.0).abs() < f32::EPSILON);
+        assert_eq!(config.capture_level, SentryLevel::Error);
+        assert_eq!(config.breadcrumb_level, SentryLevel::Info);
+        assert_eq!(config.validate(), Ok(()));
+    }
+
+    /// The failure this refuses to repeat: a client installed against nothing, whose empty
+    /// dashboard is indistinguishable from a healthy site.
+    #[test]
+    fn enabling_without_a_dsn_is_refused() {
+        let config = SentryConfig {
+            enabled: true,
+            ..SentryConfig::default()
+        };
+        assert_eq!(config.validate(), Err(SentryConfigError::MissingDsn));
+    }
+
+    /// `PORTFOLIO_SENTRY__DSN=` is how a container platform spells "declared but unset", and how
+    /// a compose pass-through or an unfilled chart value arrives. It has to land on the missing
+    /// message rather than on a parse error about a URL the operator never typed.
+    #[test]
+    fn a_blank_dsn_reads_as_absent_rather_than_malformed() {
+        let config = SentryConfig {
+            enabled: true,
+            dsn: Some(SecretString::from("   ")),
+            ..SentryConfig::default()
+        };
+        assert_eq!(config.dsn(), None);
+        assert_eq!(config.validate(), Err(SentryConfigError::MissingDsn));
+    }
+
+    #[test]
+    fn a_dsn_is_trimmed_of_the_newline_a_mounted_file_carries() {
+        let config = SentryConfig {
+            enabled: true,
+            dsn: Some(SecretString::from("https://key@sentry.example/42\n")),
+            ..SentryConfig::default()
+        };
+        assert_eq!(config.dsn(), Some("https://key@sentry.example/42"));
+        assert!(config.is_active());
+        assert_eq!(config.validate(), Ok(()));
+    }
+
+    /// A percentage typed as `25` is the mistake this catches, and it is silent otherwise:
+    /// `ClientOptions` takes the value and then samples everything.
+    #[test]
+    fn a_rate_outside_the_unit_interval_is_refused() {
+        let enabled = SentryConfig {
+            enabled: true,
+            dsn: Some(SecretString::from("https://key@sentry.example/42")),
+            ..SentryConfig::default()
+        };
+
+        for rate in [-0.1_f32, 1.1, 25.0] {
+            let config = SentryConfig {
+                traces_sample_rate: rate,
+                ..enabled.clone()
+            };
+            assert_eq!(
+                config.validate(),
+                Err(SentryConfigError::RateOutOfRange {
+                    key: "sentry.traces_sample_rate",
+                    rate,
+                })
+            );
+        }
+
+        for rate in [0.0_f32, 0.5, 1.0] {
+            let config = SentryConfig {
+                sample_rate: rate,
+                ..enabled.clone()
+            };
+            assert_eq!(config.validate(), Ok(()));
+        }
+    }
+
+    /// Nothing is validated while the block is off, so a half-filled `[sentry]` left behind by an
+    /// operator who turned it off cannot fail a boot that never installs a client.
+    #[test]
+    fn a_disabled_block_is_not_checked() {
+        let config = SentryConfig {
+            enabled: false,
+            traces_sample_rate: 42.0,
+            ..SentryConfig::default()
+        };
+        assert_eq!(config.validate(), Ok(()));
+        assert!(!config.is_active());
+    }
+
+    /// The refusal names the keys an operator has to change, and never the value of the one that
+    /// is a credential.
+    #[test]
+    fn the_refusals_name_the_keys_and_not_the_secret() {
+        let missing = SentryConfigError::MissingDsn.to_string();
+        assert!(missing.contains("sentry.enabled"));
+        assert!(missing.contains("sentry.dsn"));
+
+        let rate = SentryConfigError::RateOutOfRange {
+            key: "sentry.sample_rate",
+            rate: 25.0,
+        }
+        .to_string();
+        assert!(rate.contains("sentry.sample_rate"));
+        assert!(rate.contains("25"));
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,13 @@ Six packages in one Cargo workspace: two libraries every binary reads, three bin
 `apps/web` selects its renderer with a feature rather than splitting into two crates, because the
 route table, the page components and the `<head>` metadata are shared and would otherwise be a
 third crate that both depend on. `web` pulls `dioxus-web` and `web-sys`; `server` pulls axum,
-`tower-http` and `csp-shell`. The Dioxus CLI (`dx`) drives both halves.
+`tower-http`, `csp-shell` and the Sentry SDK. The Dioxus CLI (`dx`) drives both halves.
+
+Sentry is on the server side only, and there is deliberately no browser SDK: reporting a client
+error would mean a third-party script on every page load, a `connect-src` in the
+Content-Security-Policy and a line in the privacy page. It is compiled into every server build and
+switched on by `sentry.enabled` rather than by a Cargo feature, so an image cannot accept the key
+and silently do nothing with it — see [SECURITY_POSTURE.md](SECURITY_POSTURE.md).
 
 Server-side rendering is not a fallback here. The locale is negotiated from request headers in
 `apps/web/src/i18n.rs` and applied before the document is serialised, so nothing arrives in the

--- a/docs/SECURITY_POSTURE.md
+++ b/docs/SECURITY_POSTURE.md
@@ -4,9 +4,11 @@ The Content-Security-Policy the server builds per response, the headers around i
 
 ## Runtime
 
-The server reads its bundle directory and writes to stdout. Nothing else. It runs with a read-only
-root filesystem and no writable volume, apart from the ISR cache described in
-[DEPLOYMENT.md](DEPLOYMENT.md), which it does without when the path is not writable.
+The server reads its bundle directory and writes to stdout. Nothing else, unless error reporting is
+switched on — the one thing that gives the process an outbound connection, and it is off by
+default; see [Error reporting](#error-reporting). It runs with a read-only root filesystem and no
+writable volume, apart from the ISR cache described in [DEPLOYMENT.md](DEPLOYMENT.md), which it
+does without when the path is not writable.
 
 It is built to satisfy the restricted Pod Security Standard:
 
@@ -81,16 +83,42 @@ That is the failure mode this design has. Setting both `csp.hash_inline_scripts`
 redeploy. The two must move together: a browser ignores `'unsafe-inline'` as soon as the policy
 carries a nonce, and supplying one without the other fails the boot with a message saying so.
 
-## The one secret
+## The two secrets
 
-`github.token` is the only secret in the workspace, and the server never loads it — it belongs to
-the build-time repository lister. In the process it is a `secrecy::SecretString`, which has no
-`Debug` and no `Display`, and the single place it becomes a `&str` is the `Authorization` header.
+`github.token` belongs to the build-time repository lister, which the server never loads.
+`sentry.dsn` belongs to the server and is read only when error reporting is switched on, which no
+default does. Both are a `secrecy::SecretString` in the process — no `Debug`, no `Display` — and
+each has exactly one place it becomes a `&str`: the `Authorization` header for the token, and the
+call to `sentry::init` for the DSN.
 
-Supply it as a file. `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry the
-environment, and child processes inherit it. The Docker build already does this, mounting the
-BuildKit secret and handing `update-repos` the path.
+Supply both as files. `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry the
+environment, and child processes inherit it. The Docker build already does this for the token,
+mounting the BuildKit secret and handing `update-repos` the path; a deployment does it for the DSN
+with `PORTFOLIO_SENTRY__DSN_FILE`, or with `sentry__dsn` in a mounted `Secret` volume.
 
 Only the loader half of `terrace-config` is used; its hot-reload supervisor is not. The reasoning —
-the server holds no secrets, and `dioxus::serve` owns an accept loop with no shutdown handle — is
-recorded in `crates/config/src/lib.rs`.
+neither secret is one a reload could re-point, and `dioxus::serve` owns an accept loop with no
+shutdown handle — is recorded in `crates/config/src/lib.rs`.
+
+## Error reporting
+
+The server sends nothing anywhere until `sentry.enabled` is set with a DSN. Off, no client is
+constructed, no panic hook is installed, no `tracing` layer is added and the two `sentry-tower`
+middlewares are absent from the stack — the default deployment has no egress at all beyond the
+responses it serves.
+
+Switched on, the egress is one destination: the DSN's host, over TLS, from the SDK's own
+background thread. What travels is `tracing` records at or above `sentry.capture_level` (errors
+only, by default), panics, and — at `sentry.traces_sample_rate`, `0.0` by default — request
+transactions named by the matched route rather than by the URI.
+
+`sentry.send_default_pii` is off and is the key to leave alone. On, it attaches the client IP, the
+full request header set including `Cookie`, and the resolved user to every event, and it also
+widens what the HTTP middleware records, because `sentry-tower` reads the same flag to decide
+whether to redact sensitive headers. The privacy page this site publishes says no third-party
+service receives visitor data; that statement survives error reporting being on, and does not
+survive this key being on.
+
+There is no browser SDK. Nothing is loaded by the page, the Content-Security-Policy admits no new
+origin, and a client-side error is still invisible to the operator — which is the trade made
+deliberately, since the alternative is a third-party script on every page load.

--- a/docs/config.contract.json
+++ b/docs/config.contract.json
@@ -208,6 +208,418 @@
         "required": false,
         "secret": false,
         "reserved": false
+      },
+      {
+        "path": "sentry.enabled",
+        "env": "PORTFOLIO_SENTRY__ENABLED",
+        "env_file": "PORTFOLIO_SENTRY__ENABLED_FILE",
+        "secrets_file": "sentry__enabled",
+        "docs": "Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`\nlayer and no HTTP middleware, so every other key here is inert and nothing leaves the\nprocess.\n\nIt also decides who owns the log subscriber. Off — the default — the Dioxus toolchain\ninstalls its own, which is the behaviour this server has always had. On, the server\ninstalls one first (still reading `RUST_LOG`, still formatting the same way) because a\nSentry layer has to be a layer *of* the subscriber, and the framework's is not\nextensible after the fact.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.dsn",
+        "env": "PORTFOLIO_SENTRY__DSN",
+        "env_file": "PORTFOLIO_SENTRY__DSN_FILE",
+        "secrets_file": "sentry__dsn",
+        "docs": "Ingest URL, `https://<key>@<host>/<project>`.\n\nThe embedded key is a bearer credential for the project's ingest endpoint, so it is held\nas a `SecretString` — this block is nested in a `ServerConfig` that is printed with `?` on\nthe refusal path. Supply it as `PORTFOLIO_SENTRY__DSN_FILE=/run/secrets/sentry_dsn`, or as\n`sentry__dsn` inside `$PORTFOLIO_SECRETS_DIR`, so it never enters the process\nenvironment — where `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry\nit, and every child process inherits it.\n\nAbsent while `sentry.enabled` is set is a boot failure, not a silent no-op.",
+        "ty": "SecretString",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": false,
+        "secret": true,
+        "reserved": false
+      },
+      {
+        "path": "sentry.environment",
+        "env": "PORTFOLIO_SENTRY__ENVIRONMENT",
+        "env_file": "PORTFOLIO_SENTRY__ENVIRONMENT_FILE",
+        "secrets_file": "sentry__environment",
+        "docs": "Environment tag on every event.\n\nUnset resolves to `production` for a release build and `development` otherwise, which is\nthe only distinction this workspace has: it ships one image, and the thing that separates\na developer's `dx serve` from the deployed container is the profile it was built with.",
+        "ty": "String",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": "`production` in a release build, `development` otherwise",
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.release",
+        "env": "PORTFOLIO_SENTRY__RELEASE",
+        "env_file": "PORTFOLIO_SENTRY__RELEASE_FILE",
+        "secrets_file": "sentry__release",
+        "docs": "Release tag on every event.\n\nUnset resolves to `portfolio@<version>`, the workspace version the binary was built from\n— which is what makes a regression attributable to a deploy, since every deploy of this\nsite is a new image cut from a new version.",
+        "ty": "String",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": "`portfolio@` and the built version",
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.server_name",
+        "env": "PORTFOLIO_SENTRY__SERVER_NAME",
+        "env_file": "PORTFOLIO_SENTRY__SERVER_NAME_FILE",
+        "secrets_file": "sentry__server_name",
+        "docs": "Host tag on every event.\n\nLeft unset, Sentry reports none. The hostname of a replica is infrastructure detail that\n`sentry.send_default_pii` would otherwise be the gate for, and this site runs one image\nbehind a tunnel, so it identifies nothing an event does not already say.",
+        "ty": "String",
+        "values": [],
+        "constraint": {
+          "type": "string"
+        },
+        "text_form": "text",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": null,
+        "default_value": null,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.sample_rate",
+        "env": "PORTFOLIO_SENTRY__SAMPLE_RATE",
+        "env_file": "PORTFOLIO_SENTRY__SAMPLE_RATE_FILE",
+        "secrets_file": "sentry__sample_rate",
+        "docs": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so a rare bug\nis exactly as likely to be dropped as a noisy one. Leave it at `1.0` unless a quota\nforces otherwise.",
+        "ty": "f32",
+        "values": [],
+        "constraint": {
+          "type": "number"
+        },
+        "text_form": "unknown",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "1",
+        "default_value": 1.0,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.traces_sample_rate",
+        "env": "PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE",
+        "env_file": "PORTFOLIO_SENTRY__TRACES_SAMPLE_RATE_FILE",
+        "secrets_file": "sentry__traces_sample_rate",
+        "docs": "Fraction of request traces recorded, `0.0`–`1.0`.\n\n`0.0` — the default — records none, which is what keeps switching Sentry on for crash\nreporting from also switching performance data on. `0.05`–`0.2` is an ordinary\nproduction figure.\n\nThis server starts every trace it has: it is the edge, and nothing upstream of it hands\nit a sampled trace to continue. That is the difference from a service tier, where the\nrate of whoever *starts* the trace decides whether it exists at all.",
+        "ty": "f32",
+        "values": [],
+        "constraint": {
+          "type": "number"
+        },
+        "text_form": "unknown",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "0",
+        "default_value": 0.0,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.capture_level",
+        "env": "PORTFOLIO_SENTRY__CAPTURE_LEVEL",
+        "env_file": "PORTFOLIO_SENTRY__CAPTURE_LEVEL_FILE",
+        "secrets_file": "sentry__capture_level",
+        "docs": "Least severe `tracing` level reported as a Sentry **issue**.",
+        "ty": "SentryLevel",
+        "values": [
+          "off",
+          "error",
+          "warn",
+          "info",
+          "debug",
+          "trace"
+        ],
+        "constraint": {
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+          "type": "string"
+        },
+        "text_form": "choice",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "error",
+        "default_value": "error",
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.breadcrumb_level",
+        "env": "PORTFOLIO_SENTRY__BREADCRUMB_LEVEL",
+        "env_file": "PORTFOLIO_SENTRY__BREADCRUMB_LEVEL_FILE",
+        "secrets_file": "sentry__breadcrumb_level",
+        "docs": "Least severe `tracing` level kept as a **breadcrumb**, the trail attached to the next\nissue.\n\nRecords at or above `sentry.capture_level` become issues instead, so the two thresholds\npartition the stream rather than overlapping on it.",
+        "ty": "SentryLevel",
+        "values": [
+          "off",
+          "error",
+          "warn",
+          "info",
+          "debug",
+          "trace"
+        ],
+        "constraint": {
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "type": "string"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(off|error|warn|info|debug|trace)\\s*$",
+          "type": "string"
+        },
+        "text_form": "choice",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "info",
+        "default_value": "info",
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.max_breadcrumbs",
+        "env": "PORTFOLIO_SENTRY__MAX_BREADCRUMBS",
+        "env_file": "PORTFOLIO_SENTRY__MAX_BREADCRUMBS_FILE",
+        "secrets_file": "sentry__max_breadcrumbs",
+        "docs": "How many breadcrumbs one event carries.",
+        "ty": "usize",
+        "values": [],
+        "constraint": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*\\+?[0-9]+\\s*$",
+          "type": "string"
+        },
+        "text_form": "integer",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "100",
+        "default_value": 100,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.attach_stacktraces",
+        "env": "PORTFOLIO_SENTRY__ATTACH_STACKTRACES",
+        "env_file": "PORTFOLIO_SENTRY__ATTACH_STACKTRACES_FILE",
+        "secrets_file": "sentry__attach_stacktraces",
+        "docs": "Attach a stack trace to events that carry none of their own.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "true",
+        "default_value": true,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.send_default_pii",
+        "env": "PORTFOLIO_SENTRY__SEND_DEFAULT_PII",
+        "env_file": "PORTFOLIO_SENTRY__SEND_DEFAULT_PII_FILE",
+        "secrets_file": "sentry__send_default_pii",
+        "docs": "Send personally identifying data with every event: the client IP, the full request header\nset (`Cookie` included) and the resolved user.\n\n**Off, and worth leaving off.** A reader's IP address and cookies are exactly what a\ncrash report does not need in order to be actionable, and Sentry is a third party for the\npurposes of the privacy page this site publishes — a page that currently says no\nthird-party service receives visitor data, which is a statement this key is the one way\nto falsify. On, it also widens what the HTTP middleware records, because `sentry-tower`\nreads this same flag to decide whether to redact sensitive request headers.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.http_transactions",
+        "env": "PORTFOLIO_SENTRY__HTTP_TRANSACTIONS",
+        "env_file": "PORTFOLIO_SENTRY__HTTP_TRANSACTIONS_FILE",
+        "secrets_file": "sentry__http_transactions",
+        "docs": "Record one Sentry transaction per request, named by the *matched route* rather than by\nthe URI — so `/api/repos/{name}` does not become one transaction name per repository.\n\nWhether a started transaction is *kept* is `sentry.traces_sample_rate`'s decision; this is\nthe switch for taking the middleware out entirely.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "true",
+        "default_value": true,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.span_attributes",
+        "env": "PORTFOLIO_SENTRY__SPAN_ATTRIBUTES",
+        "env_file": "PORTFOLIO_SENTRY__SPAN_ATTRIBUTES_FILE",
+        "secrets_file": "sentry__span_attributes",
+        "docs": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff. Span fields here routinely carry request paths and the negotiated locale, and a\ntransaction is stored under a longer retention than a log line.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
+      },
+      {
+        "path": "sentry.debug",
+        "env": "PORTFOLIO_SENTRY__DEBUG",
+        "env_file": "PORTFOLIO_SENTRY__DEBUG_FILE",
+        "secrets_file": "sentry__debug",
+        "docs": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+        "ty": "bool",
+        "values": [],
+        "constraint": {
+          "type": "boolean"
+        },
+        "text_constraint": {
+          "pattern": "^\\s*(true|false)\\s*$",
+          "type": "string"
+        },
+        "text_form": "boolean",
+        "aliases": [],
+        "env_aliases": [],
+        "env_file_aliases": [],
+        "secrets_file_aliases": [],
+        "default": "false",
+        "default_value": false,
+        "note": null,
+        "required": false,
+        "secret": false,
+        "reserved": false
       }
     ]
   },
@@ -270,6 +682,101 @@
             "description": "Revalidation interval in seconds. Zero means a permanent cache.\n\nEvery page renders from compile-time data, so the only thing that changes the output is a\nnew build, which starts from an empty cache anyway. A positive value opts into a finite,\ntime-based TTL, which is useful only when a *persistent* cache volume is shared across\ndeploys.\n\nDefault: permanent.",
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "sentry": {
+        "additionalProperties": false,
+        "properties": {
+          "attach_stacktraces": {
+            "default": true,
+            "description": "Attach a stack trace to events that carry none of their own.",
+            "type": "boolean"
+          },
+          "breadcrumb_level": {
+            "default": "info",
+            "description": "Least severe `tracing` level kept as a **breadcrumb**, the trail attached to the next\nissue.\n\nRecords at or above `sentry.capture_level` become issues instead, so the two thresholds\npartition the stream rather than overlapping on it.",
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "capture_level": {
+            "default": "error",
+            "description": "Least severe `tracing` level reported as a Sentry **issue**.",
+            "enum": [
+              "off",
+              "error",
+              "warn",
+              "info",
+              "debug",
+              "trace"
+            ],
+            "type": "string"
+          },
+          "debug": {
+            "default": false,
+            "description": "Print the SDK's own diagnostics to stderr. For proving a DSN works, not for running.",
+            "type": "boolean"
+          },
+          "dsn": {
+            "description": "Ingest URL, `https://<key>@<host>/<project>`.\n\nThe embedded key is a bearer credential for the project's ingest endpoint, so it is held\nas a `SecretString` — this block is nested in a `ServerConfig` that is printed with `?` on\nthe refusal path. Supply it as `PORTFOLIO_SENTRY__DSN_FILE=/run/secrets/sentry_dsn`, or as\n`sentry__dsn` inside `$PORTFOLIO_SECRETS_DIR`, so it never enters the process\nenvironment — where `/proc/<pid>/environ`, a crash dump and `docker inspect` all carry\nit, and every child process inherits it.\n\nAbsent while `sentry.enabled` is set is a boot failure, not a silent no-op.",
+            "type": "string",
+            "writeOnly": true
+          },
+          "enabled": {
+            "default": false,
+            "description": "Initialise the Sentry client. `false` installs no client, no panic hook, no `tracing`\nlayer and no HTTP middleware, so every other key here is inert and nothing leaves the\nprocess.\n\nIt also decides who owns the log subscriber. Off — the default — the Dioxus toolchain\ninstalls its own, which is the behaviour this server has always had. On, the server\ninstalls one first (still reading `RUST_LOG`, still formatting the same way) because a\nSentry layer has to be a layer *of* the subscriber, and the framework's is not\nextensible after the fact.",
+            "type": "boolean"
+          },
+          "environment": {
+            "description": "Environment tag on every event.\n\nUnset resolves to `production` for a release build and `development` otherwise, which is\nthe only distinction this workspace has: it ships one image, and the thing that separates\na developer's `dx serve` from the deployed container is the profile it was built with.\n\nDefault: `production` in a release build, `development` otherwise.",
+            "type": "string"
+          },
+          "http_transactions": {
+            "default": true,
+            "description": "Record one Sentry transaction per request, named by the *matched route* rather than by\nthe URI — so `/api/repos/{name}` does not become one transaction name per repository.\n\nWhether a started transaction is *kept* is `sentry.traces_sample_rate`'s decision; this is\nthe switch for taking the middleware out entirely.",
+            "type": "boolean"
+          },
+          "max_breadcrumbs": {
+            "default": 100,
+            "description": "How many breadcrumbs one event carries.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "release": {
+            "description": "Release tag on every event.\n\nUnset resolves to `portfolio@<version>`, the workspace version the binary was built from\n— which is what makes a regression attributable to a deploy, since every deploy of this\nsite is a new image cut from a new version.\n\nDefault: `portfolio@` and the built version.",
+            "type": "string"
+          },
+          "sample_rate": {
+            "default": 1.0,
+            "description": "Fraction of captured events actually sent, `0.0`–`1.0`.\n\nA blunt volume cap: it drops whole issues rather than repetitions of one, so a rare bug\nis exactly as likely to be dropped as a noisy one. Leave it at `1.0` unless a quota\nforces otherwise.",
+            "type": "number"
+          },
+          "send_default_pii": {
+            "default": false,
+            "description": "Send personally identifying data with every event: the client IP, the full request header\nset (`Cookie` included) and the resolved user.\n\n**Off, and worth leaving off.** A reader's IP address and cookies are exactly what a\ncrash report does not need in order to be actionable, and Sentry is a third party for the\npurposes of the privacy page this site publishes — a page that currently says no\nthird-party service receives visitor data, which is a statement this key is the one way\nto falsify. On, it also widens what the HTTP middleware records, because `sentry-tower`\nreads this same flag to decide whether to redact sensitive request headers.",
+            "type": "boolean"
+          },
+          "server_name": {
+            "description": "Host tag on every event.\n\nLeft unset, Sentry reports none. The hostname of a replica is infrastructure detail that\n`sentry.send_default_pii` would otherwise be the gate for, and this site runs one image\nbehind a tunnel, so it identifies nothing an event does not already say.",
+            "type": "string"
+          },
+          "span_attributes": {
+            "default": false,
+            "description": "Copy `tracing` span fields onto the Sentry span as attributes.\n\nOff. Span fields here routinely carry request paths and the negotiated locale, and a\ntransaction is stored under a longer retention than a log line.",
+            "type": "boolean"
+          },
+          "traces_sample_rate": {
+            "default": 0.0,
+            "description": "Fraction of request traces recorded, `0.0`–`1.0`.\n\n`0.0` — the default — records none, which is what keeps switching Sentry on for crash\nreporting from also switching performance data on. `0.05`–`0.2` is an ordinary\nproduction figure.\n\nThis server starts every trace it has: it is the edge, and nothing upstream of it hands\nit a sampled trace to continue. That is the difference from a service tier, where the\nrate of whoever *starts* the trace decides whether it exists at all.",
+            "type": "number"
           }
         },
         "type": "object"


### PR DESCRIPTION
## What

Adds a `sentry.*` configuration block to `crates/config` and the client behind it in
`apps/web/src/server/telemetry.rs`. Modelled on the arrangement in
[TankoVault](https://github.com/TimSchoenle/TankoVault) — the same block, the same two severity
thresholds, the same refusal at boot — adapted where this workspace differs.

Off by default, off in the image, and off in every rendered document. Switched on, one client feeds
three sinks:

| Sink | What it carries |
| --- | --- |
| `tracing` | issues at or above `sentry.capture_level` (`error`), breadcrumbs above `sentry.breadcrumb_level` (`info`) |
| panics | the SDK's hook — a handler panic unwinds that request's task and leaves the process serving, so today it reaches nothing at all |
| HTTP | one transaction per request, named by the **matched route**, so `/api/repos/{name}` is not one transaction name per repository |

`sentry.enabled` set without a usable DSN refuses the boot beside the existing `[csp]` refusal. An
empty Sentry dashboard is indistinguishable from a site with no errors, and that is not a state
worth being able to reach by accident.

## Three choices worth reviewing

**The transport is `ureq`, not `reqwest`.** The obvious pick fails on this image. `sentry` pins
reqwest 0.13 while the Dioxus fullstack stack builds 0.12, so it would be a *second* async HTTP
client — and reqwest 0.13's `rustls` feature means `aws-lc-rs` (a cmake/C build, inside an image
cross-compiled to musl and built for bit-reproducibility) plus `rustls-platform-verifier`, which
looks for an OS trust store `scratch` does not have. `ureq` is already in `Cargo.lock` for
`update-repos`, and its `rustls` feature is ring plus bundled `webpki-roots` — the stack the runtime
image already links. Verified against the real target:

```bash
cargo tree -p web --no-default-features --features server --target x86_64-unknown-linux-musl -i aws-lc-rs
```

returns nothing, as do `rustls-platform-verifier`, `rustls-native-certs`, `openssl-probe` and
`reqwest@0.13.4`. They appear in `Cargo.lock` — cargo records optional dependencies it never
activates — but nothing compiles them.

**No Cargo feature gates it.** It is an optional *dependency* (`dep:sentry` under `server`, so it
never reaches the wasm client) switched at runtime by `sentry.enabled`, rather than a feature of its
own. A feature would produce an image where `PORTFOLIO_SENTRY__ENABLED=true` is accepted by the
loader and does nothing — the silently-no-op knob this workspace already refuses elsewhere. Off, the
cost is one `if` at boot: no client, no hook, no layer, and the two middlewares absent from the
stack rather than present as no-ops.

**`shutdown_timeout_secs` is deliberately absent** from the block that TankoVault carries it in.
`dioxus::serve` diverges and, on the release path, awaits `axum::serve` with no shutdown signal — so
the guard's drop-time flush is unreachable and a key describing it would describe a code path this
server does not have. What gets events out is the SDK's background transport. Reasoning is on
`TelemetryGuard`.

## The subscriber handover

A Sentry layer has to be a layer *of* the subscriber, and `dioxus_logger::initialize_default` builds
one that cannot be extended afterwards. It can be declined: it returns early when
`tracing::dispatcher::has_been_set()`. So while Sentry is on, the server installs the subscriber
itself before `dioxus::serve` — same `RUST_LOG` contract, same default verbosity, same `hyper_util`
mute, plus the reporting layer. While Sentry is off, nothing is constructed and the framework's
subscriber stands exactly as before; a test asserts that, because the default path must not change
to make an opt-in feature possible.

One visible difference, development only: `dioxus_logger` drops timestamps and targets when it
detects `dx`, and this does not — the detection lives in `dioxus-cli-config`, which the `server`
feature does not pull in.

## Privacy

`sentry.send_default_pii` is off and documented as the one key that would falsify the privacy page
this site publishes: on, every event carries the client IP and the full request header set, `Cookie`
included, and `sentry-tower` reads the same flag to decide whether to redact sensitive headers.
`traces_sample_rate` is `0`, so switching reporting on does not also switch performance data on.

There is **no browser SDK**. Nothing new is loaded by the page, the Content-Security-Policy admits
no new origin, and the served document is byte-identical. A client-side error stays invisible to the
operator — the deliberate trade, since the alternative is a third-party script on every page load.

## Generated artefacts

`docs/config.contract.json`, `config.example.toml` and the `README.md` tables are regenerated from
the types; the Dockerfile `LABEL` region is unchanged (the version and prefix did not move).
`.github/templates/README.md.hbs` gains the `Error reporting` section, and `sentry.enabled` /
`sentry.dsn` join `KEYS` in the generator so the prose spellings are derived rather than typed.

## Checks

```bash
cargo fmt --all -- --check
cargo clippy --all-features --all-targets -- -D warnings
cargo test --workspace --all-features
cargo test -p web --no-default-features --features server      # 74 passed
cargo check -p web --no-default-features --features web --target wasm32-unknown-unknown
RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps
just regenerate
just licenses                                                   # licence gate passes on the new crates
```

## Not in this PR

No CI step uploading a Sentry release or debug symbols on tag. That needs `SENTRY_AUTH_TOKEN`,
`SENTRY_ORG` and `SENTRY_PROJECT` in the repository, which I cannot set. The release tag the client
sends already matches what such a step would publish (`portfolio@<version>`, from
`CARGO_PKG_VERSION`), so it can be added later without touching this code.
