### PR TITLE
test(web): pin Sentry layer transparency to a time-invariant route

### DIFF
--- a/apps/web/src/server/mod.rs
+++ b/apps/web/src/server/mod.rs
@@ -913,9 +913,12 @@ mod tests {
             .unwrap()
     }
 
+    async fn bytes(response: axum::response::Response) -> axum::body::Bytes {
+        to_bytes(response.into_body(), usize::MAX).await.unwrap()
+    }
+
     async fn json(response: axum::response::Response) -> Value {
-        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        serde_json::from_slice(&bytes).unwrap()
+        serde_json::from_slice(&bytes(response).await).unwrap()
     }
 
     /// The middleware state, with the policy the deployment's defaults produce.
@@ -1047,6 +1050,12 @@ mod tests {
     /// the request-metadata layer sit outside every handler, and a response that goes through them
     /// has to be the response the handler produced, header for header and byte for byte.
     ///
+    /// That comparison only means something over a route whose answer depends on nothing but the
+    /// request, hence `/api/v1/profile`: a `&'static str` rendered once at startup. The probes
+    /// cannot stand in — each stamps the current time to the millisecond, so two of their
+    /// responses differ whenever the clock ticks between the calls, which says nothing about the
+    /// layers.
+    ///
     /// Also the only place the layer *types* are composed the way `router` composes them, so a
     /// version of `sentry-tower` that stops fitting an axum `Router` fails here rather than in the
     /// image build.
@@ -1062,7 +1071,7 @@ mod tests {
 
         let request = || {
             Request::builder()
-                .uri("/api/health")
+                .uri("/api/v1/profile")
                 .body(Body::empty())
                 .unwrap()
         };
@@ -1079,7 +1088,7 @@ mod tests {
 
         assert_eq!(bare.status(), layered.status());
         assert_eq!(bare.headers(), layered.headers());
-        assert_eq!(json(bare).await, json(layered).await);
+        assert_eq!(bytes(bare).await, bytes(layered).await);
     }
 
     /// The other half of the switch: with the block at its default nothing is mounted at all, so a


### PR DESCRIPTION
## The failure

`web::server::tests::the_sentry_layers_leave_a_response_untouched` fails at random. It took down the `Build` workflow on `main` at 8faa4ba and again on release PR #1138, which contains nothing but version bumps:

```
thread '...the_sentry_layers_leave_a_response_untouched' panicked at apps/web/src/server/mod.rs:1082:9:
assertion `left == right` failed
  left: Object {"status": String("healthy"), "timestamp": String("2026-08-26T13:22:07.007Z")}
 right: Object {"status": String("healthy"), "timestamp": String("2026-08-26T13:22:07.008Z")}
```

## The cause

The test drives one request through the bare `api_router` and an identical one through the router wrapped in the two Sentry layers, then asserts the two responses match byte for byte. It sent both to `/api/health`, and that handler stamps `OffsetDateTime::now_utc()` into every answer at millisecond precision. The two requests are served a moment apart, so the bodies differ whenever a millisecond boundary falls between them — nothing to do with the layers under test.

## The fix

Send both requests to `/api/v1/profile` instead. That handler answers with `PROFILE_JSON`, a `&'static str` rendered once at startup, behind a fixed content-type and cache-control pair, so its response is a function of the request alone. Any difference between the two responses is now attributable to the layers, which is the claim the test exists to make.

Two smaller things while here:

- Compare the raw response bytes rather than parsed JSON. The doc comment promises "header for header and byte for byte"; parsing to `serde_json::Value` would have let key reordering through.
- Pull the body read into a `bytes` helper that the existing `json` helper now calls, rather than duplicating the `to_bytes` line.

No production code changes.

## Verification

```bash
cargo test -p web --no-default-features --features server
```

70 server tests pass. The repaired test was then run 40 times in a row with no failure; before the change it fails on roughly any run where the clock ticks between the two calls.

`cargo fmt --check` is clean and `cargo clippy -p web --no-default-features --features server --all-targets` reports nothing new in the touched module.
